### PR TITLE
feat: prototype injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.log
+opentelemetry-go-compile-instrumentation
+otel
+demo

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Run `sh -x build.sh` to show instrumentation example. In this example, we will i
 If you want to check the result of instrumentation, go to the directory location that appears as output when running build.sh, e.g., WORK=/var/folders/x9/fddsvlt5363c0plvvw8_2mr80000gn/T/go-build2020695287.
 
 ### Navigate to the WORK directory:
+```bash
 cd /var/folders/x9/fddsvlt5363c0plvvw8_2mr80000gn/T/go-build2020695287
 
 ### Locate the main package under the b001 subdirectory:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ OpenTelemetry-Go-Compile-Instrumentation provides compile time  [OpenTelemetry](
 
 ## Getting Started
 
-TBD
+Run `sh -x build.sh` to show instrumentation example. In this example, we will inject a piece of code into the `main` function of the `main` package under the `demo` module to output the "Entering hook" string. This injected code comes from the `sdk` module.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ cd /var/folders/x9/fddsvlt5363c0plvvw8_2mr80000gn/T/go-build2020695287
 ls -l b001
 
 ### Inspect files:
+```bash
 cat modified.go
 
 

--- a/README.md
+++ b/README.md
@@ -17,20 +17,22 @@ OpenTelemetry-Go-Compile-Instrumentation provides compile time  [OpenTelemetry](
 ## Getting Started
 
 Run `sh -x build.sh` to show instrumentation example. In this example, we will inject a piece of code into the `main` function of the `main` package under the `demo` module to output the "Entering hook" string. This injected code comes from the `sdk` module.
-If you want to check the result of instrumentation, go to the directory location that appears as output when running build.sh, e.g., WORK=/var/folders/x9/fddsvlt5363c0plvvw8_2mr80000gn/T/go-build2020695287.
+If you want to check the result of instrumentation, go to the directory location that appears as output when running build.sh, e.g., `WORK=/var/folders/x9/fddsvlt5363c0plvvw8_2mr80000gn/T/go-build2020695287`.
 
 ### Navigate to the WORK directory:
 ```bash
 cd /var/folders/x9/fddsvlt5363c0plvvw8_2mr80000gn/T/go-build2020695287
+```
 
 ### Locate the main package under the b001 subdirectory:
 ```bash
 ls -l b001
+```
 
 ### Inspect files:
 ```bash
 cat modified.go
-
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ OpenTelemetry-Go-Compile-Instrumentation provides compile time  [OpenTelemetry](
 ## Getting Started
 
 Run `sh -x build.sh` to show instrumentation example. In this example, we will inject a piece of code into the `main` function of the `main` package under the `demo` module to output the "Entering hook" string. This injected code comes from the `sdk` module.
+If you want to check the result of instrumentation, go to the directory location that appears as output when running build.sh, e.g., WORK=/var/folders/x9/fddsvlt5363c0plvvw8_2mr80000gn/T/go-build2020695287.
+
+### Navigate to the WORK directory:
+cd /var/folders/x9/fddsvlt5363c0plvvw8_2mr80000gn/T/go-build2020695287
+
+### Locate the main package under the b001 subdirectory:
+ls -l b001
+
+### Inspect files:
+cat modified.go
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you want to check the result of instrumentation, go to the directory location
 cd /var/folders/x9/fddsvlt5363c0plvvw8_2mr80000gn/T/go-build2020695287
 
 ### Locate the main package under the b001 subdirectory:
+```bash
 ls -l b001
 
 ### Inspect files:

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+# build instrumentation tool
+go build -a -o otel
+TOOL=$(pwd)/otel
+# compile-time instrumentation via toolexec
+cd demo
+rm -rf save.go
+go build -a -toolexec=$TOOL -o demo .
+./demo

--- a/build.sh
+++ b/build.sh
@@ -3,5 +3,5 @@ go build -a -o otel
 TOOL=$(pwd)/otel
 # compile-time instrumentation via toolexec
 cd demo
-go build -a -toolexec=$TOOL -o demo .
+go build -a -work -toolexec=$TOOL -o demo .
 ./demo

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,5 @@ go build -a -o otel
 TOOL=$(pwd)/otel
 # compile-time instrumentation via toolexec
 cd demo
-rm -rf save.go
 go build -a -toolexec=$TOOL -o demo .
 ./demo

--- a/demo/go.mod
+++ b/demo/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-go-compile-instrumentation/demo
 
-go 1.22.0
+go 1.23.0
 
 replace github.com/open-telemetry/opentelemetry-go-compile-instrumentation/sdk => ../sdk
 

--- a/demo/go.mod
+++ b/demo/go.mod
@@ -1,0 +1,7 @@
+module github.com/open-telemetry/opentelemetry-go-compile-instrumentation/demo
+
+go 1.22.0
+
+replace github.com/open-telemetry/opentelemetry-go-compile-instrumentation/sdk => ../sdk
+
+require github.com/open-telemetry/opentelemetry-go-compile-instrumentation/sdk v0.0.0-00010101000000-000000000000

--- a/demo/main.go
+++ b/demo/main.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"fmt"
+	_ "unsafe"
+
+	_ "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/sdk"
+)
+
+func main() {
+	fmt.Printf("Hello World")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/open-telemetry/opentelemetry-go-compile-instrumentation
+
+go 1.22.0
+
+require github.com/dave/dst v0.27.3
+
+require (
+	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/tools v0.1.12 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-go-compile-instrumentation
 
-go 1.22.0
+go 1.23.0
 
 require github.com/dave/dst v0.27.3
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/dave/dst v0.27.3 h1:P1HPoMza3cMEquVf9kKy8yXsFirry4zEnWOdYPOoIzY=
+github.com/dave/dst v0.27.3/go.mod h1:jHh6EOibnHgcUW3WjKHisiooEkYwqpHLBSX1iOBhEyc=
+github.com/dave/jennifer v1.5.0 h1:HmgPN93bVDpkQyYbqhCHj5QlgvUkvEOzMyEvKLgCRrg=
+github.com/dave/jennifer v1.5.0/go.mod h1:4MnyiFIlZS3l5tSDn8VnzE6ffAhYBMB2SZntBsZGUok=
+github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
+github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
+golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=

--- a/internal/instrument.go
+++ b/internal/instrument.go
@@ -129,7 +129,6 @@ func Instrument(args []string) []string {
 				storeAst(modified, ast)
 				args[i] = modified
 				break
-				// saveAstToFile("save.go", ast)
 			}
 		}
 	}

--- a/internal/instrument.go
+++ b/internal/instrument.go
@@ -1,0 +1,146 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dave/dst"
+	"github.com/dave/dst/decorator"
+)
+
+const (
+	TargetPkg      = "main"
+	TargetFunc     = "main"
+	TrampolineName = "Trampoline"
+	HookName       = "Hook"
+)
+
+func loadAst(filePath string) *dst.File {
+	name := filepath.Base(filePath)
+	fset := token.NewFileSet()
+	file, err := os.Open(filePath)
+	if err != nil {
+		panic(err)
+	}
+	astFile, err := parser.ParseFile(fset, name, file, parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+	dec := decorator.NewDecorator(fset)
+	dstFile, err := dec.DecorateFile(astFile)
+	if err != nil {
+		panic(err)
+	}
+	return dstFile
+}
+
+func storeAst(filePath string, ast *dst.File) {
+	f, err := os.Create(filePath)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	r := decorator.NewRestorer()
+	err = r.Fprint(f, ast)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func newTrampolineFunc() *dst.FuncDecl {
+	trampoline := &dst.FuncDecl{
+		Name: &dst.Ident{
+			Name: TrampolineName,
+		},
+		Type: &dst.FuncType{},
+		Body: &dst.BlockStmt{
+			List: []dst.Stmt{newFuncCall(HookName)},
+		},
+	}
+	return trampoline
+}
+
+func newFuncCall(target string) *dst.ExprStmt {
+	return &dst.ExprStmt{
+		X: &dst.CallExpr{
+			Fun: &dst.Ident{
+				Name: target,
+			},
+		},
+	}
+}
+
+func newHookFunc(name string) *dst.FuncDecl {
+	return &dst.FuncDecl{
+		Name: &dst.Ident{
+			Name: name,
+		},
+		Type: &dst.FuncType{
+			Params: &dst.FieldList{},
+		},
+	}
+}
+
+func findOutputDir(args []string) string {
+	for i, arg := range args {
+		if arg == "-o" {
+			return filepath.Dir(args[i+1])
+		}
+	}
+	return ""
+}
+
+func rewriteAst(ast *dst.File, fn *dst.FuncDecl) {
+	fmt.Printf("Instrumenting function: %s\n", fn.Name.Name)
+	// Insert a call to the trampoline function at the beginning of the function
+	callToTrampoline := newFuncCall(TrampolineName)
+	fn.Body.List = append([]dst.Stmt{callToTrampoline}, fn.Body.List...)
+	// Add the trampoline function to the AST
+	ast.Decls = append(ast.Decls, newTrampolineFunc())
+	// Add the hook function to the AST
+	hook := newHookFunc(HookName)
+	ast.Decls = append(ast.Decls, hook)
+}
+
+func Instrument(args []string) []string {
+	for i, arg := range args {
+		if strings.HasSuffix(arg, ".go") {
+			ast := loadAst(arg)
+			for _, decl := range ast.Decls {
+				// Find target function
+				fn, ok := decl.(*dst.FuncDecl)
+				if !ok {
+					continue
+				}
+				if fn.Name.Name != TargetFunc {
+					continue
+				}
+				// Instrument the function
+				rewriteAst(ast, fn)
+				// Update the compilation command
+				modified := filepath.Join(findOutputDir(args), "modified.go")
+				storeAst(modified, ast)
+				args[i] = modified
+				break
+				// saveAstToFile("save.go", ast)
+			}
+		}
+	}
+
+	// Remove the -complete flag because we added a body-less hook function
+	// and the compiler will complain about it
+	for i, arg := range args {
+		if arg == "-complete" {
+			args = append(args[:i], args[i+1:]...)
+			break
+		}
+	}
+	return args
+}

--- a/main.go
+++ b/main.go
@@ -25,13 +25,21 @@ func runCmd(args ...string) error {
 }
 
 func isCompilePackage(args []string, pkg string) bool {
-	checks := []string{"compile", "-buildid", "-p " + pkg}
-	for _, check := range checks {
-		if !strings.Contains(strings.Join(args, " "), check) {
-			return false
+	if len(args) < 2 {
+		return false
+	}
+	if !strings.HasSuffix(args[0], "compile") &&
+		!strings.HasSuffix(args[0], "compile.exe") {
+		return false
+	}
+	for i, arg := range args[1:] {
+		if arg == "-p" {
+			if i+1 < len(args) && args[i+2] == pkg {
+				return true
+			}
 		}
 	}
-	return true
+	return false
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -1,0 +1,47 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/internal"
+)
+
+func runCmd(args ...string) error {
+	path := args[0]
+	args = args[1:]
+	cmd := exec.Command(path, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func isCompilePackage(args []string, pkg string) bool {
+	checks := []string{"compile", "-buildid", "-p " + pkg}
+	for _, check := range checks {
+		if !strings.Contains(strings.Join(args, " "), check) {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	args := os.Args[1:]
+	if isCompilePackage(args, internal.TargetPkg) {
+		// It's the compile command, intercept it and inject hook code
+		args = internal.Instrument(args)
+	}
+	err := runCmd(args...)
+	if err != nil {
+		panic("failed to run command: " + err.Error())
+	}
+}

--- a/sdk/NOTICE
+++ b/sdk/NOTICE
@@ -1,0 +1,1 @@
+temporarily put the sdk in this repo, it should be moved to a separate repo when the project is more mature

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,0 +1,3 @@
+module github.com/open-telemetry/opentelemetry-go-compile-instrumentation/sdk
+
+go 1.22.0

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,3 +1,3 @@
 module github.com/open-telemetry/opentelemetry-go-compile-instrumentation/sdk
 
-go 1.22.0
+go 1.23.0

--- a/sdk/hook.go
+++ b/sdk/hook.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sdk
+
+import (
+	"fmt"
+	_ "unsafe"
+)
+
+//go:linkname MyHook main.Hook
+func MyHook() {
+	fmt.Printf("Entering hook!\n")
+}


### PR DESCRIPTION
@pdelewski @RomainMuller Please review this propotype. Related to #5 

Things are going more smoothly than I expected. Of course, it might be because I haven't encountered the hidden challenges yet.

In the package where the target function resides, we inject the following code:

```go
package p

func Target() {
    Trampoline()
    ....
}

func Trampoline() {
    Hook()
}

func Hook()
```

Since Hook does not have a function body, we must remove the -complete flag to pass compilation.

In the SDK, we use `//go:linkname` to link the actual hook code to the Hook point above:

```go
package sdk

import _ "unsafe"

//go:linkname RealHook p.Hook
func RealHook(){}
```