### PR TITLE
feat(linter): Establish pedantic linting

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -9,22 +9,30 @@ permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
   # pull-requests: read
+env:
+  # TODO: Configure dependabot or renovate to update this version.
+  GOLANGCI_LINT_VERSION: v2.1.6
 
 jobs:
   golangci:
     strategy:
       matrix:
         go: [oldstable, stable]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    name: Lint
-    runs-on: ${{ matrix.os }}
+    name: Format and Lint
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
           cache-dependency-path: "**/go.mod"
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${{ env.GOLANGCI_LINT_VERSION }}
+      - name: Check Format
+        run: |
+          golangci-lint fmt --diff
+      - name: Lint
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: ${{ env.GOLANGCI_LINT_VERSION }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ opentelemetry-go-compile-instrumentation
 otel
 demo
 .idea
+tmp

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,576 @@
+# This file is licensed under the terms of the MIT license https://opensource.org/license/mit
+# Copyright (c) 2021-2025 Marat Reymers
+
+## Golden config for golangci-lint v2.1.6
+#
+# This is the best config for golangci-lint based on my experience and opinion.
+# It is very strict, but not extremely strict.
+# Feel free to adapt it to suit your needs.
+# If this config helps you, please consider keeping a link to this file (see the next comment).
+
+# Based on https://gist.github.com/maratori/47a4d00457a92aa426dbd48a18776322
+# Added our customizations to the config.
+
+version: "2"
+
+issues:
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 50
+
+run:
+  # Build tags from candidate.yml
+  build-tags: [integration]
+  # Timeout for analysis
+  timeout: 5m
+  # Include test files
+  tests: true
+
+linters:
+  enable:
+    - asasalint # checks for pass []any as any in variadic func(...any)
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - canonicalheader # checks whether net/http.Header uses canonical header
+    - contextcheck # checks the function whether use a non-inherited context
+    - copyloopvar # detects places where loop variables are copied (Go 1.22+)
+    - cyclop # checks function and package cyclomatic complexity
+    - depguard # checks if package imports are in a list of acceptable packages
+    - dupl # tool for code clone detection
+    - durationcheck # checks for two durations multiplied together
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
+    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+    - exhaustive # checks exhaustiveness of enum switch statements
+    - exptostd # detects functions from golang.org/x/exp/ that can be replaced by std functions
+    - fatcontext # detects nested contexts in loops
+    - forbidigo # forbids identifiers
+    - funcorder # checks the order of functions, methods, and constructors
+    - funlen # tool for detection of long functions
+    - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
+    - gochecknoglobals # checks that no global variables exist
+    - gochecksumtype # checks exhaustiveness on Go "sum types"
+    - gocognit # computes and checks the cognitive complexity of functions
+    - goconst # finds repeated strings that could be replaced by a constant
+    - gocritic # provides diagnostics that check for bugs, performance and style issues
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - gosec # inspects source code for security problems
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - iface # checks the incorrect use of interfaces, helping developers avoid interface pollution
+    - inamedparam # reports interfaces with unnamed method parameters
+    - ineffassign # detects when assignments to existing variables are not used
+    - interfacebloat # checks the number of methods inside an interface
+    - intrange # finds places where for loops could make use of an integer range
+    - ireturn # accept interfaces, return concrete types
+    - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
+    - makezero # finds slice declarations with non-zero initial length
+    - mirror # reports wrong mirror patterns of bytes/strings usage
+    - misspell # finds commonly misspelled English words in comments
+    - mnd # detects magic numbers
+    - musttag # enforces field tags in (un)marshaled structs
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nestif # reports deeply nested if statements
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - nilnesserr # reports that it checks for err != nil, but it returns a different nil value error (powered by nilness and nilerr)
+    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
+    - noctx # finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - nonamedreturns # reports all named returns
+    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
+    - perfsprint # checks that fmt.Sprintf can be replaced with a faster alternative
+    - prealloc # finds slice declarations that could potentially be preallocated
+    - predeclared # finds code that shadows one of Go's predeclared identifiers
+    - promlinter # checks Prometheus metrics naming via promlint
+    - protogetter # reports direct reads from proto message fields when getters should be used
+    - reassign # checks that package variables are not reassigned
+    - recvcheck # checks for receiver type consistency
+    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - sloglint # ensure consistent code style when using log/slog
+    - spancheck # checks for mistakes with OpenTelemetry/Census spans
+    - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - tagalign # checks that struct tags are well aligned
+    - testableexamples # checks if examples are testable (have an expected output)
+    - testifylint # checks usage of github.com/stretchr/testify
+    - testpackage # makes you use a separate _test package
+    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - unused # checks for unused constants, variables, functions and types
+    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
+    - usetesting # reports uses of functions with replacement inside the testing package
+    - wastedassign # finds wasted assignment statements
+    - whitespace # detects leading and trailing whitespace
+    - wrapcheck # checks that errors returned from external packages are wrapped
+
+    ## you may want to enable
+    #- decorder # checks declaration order and count of types, constants, variables and functions
+    #- ginkgolinter # [if you use ginkgo/gomega] enforces standards of using ginkgo and gomega
+    #- godox # detects usage of FIXME, TODO and other keywords inside comments
+    #- goheader # checks is file header matches to pattern
+    #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
+    #- zerologlint # detects the wrong usage of zerolog that a user forgets to dispatch zerolog.Event
+
+    ## disabled
+    #- containedctx # detects struct contained context.Context field
+    #- dogsled # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
+    #- dupword # [useless without config] checks for duplicate words in the source code
+    #- err113 # [too strict] checks the errors handling expressions
+    #- errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted
+    #- forcetypeassert # [replaced by errcheck] finds forced type assertions
+    #- gochecknoinits # [init functions are sometimes necessary] checks that no init functions are present in Go code
+    #- godot # [too pedantic] checks if comments end in a period
+    #- gomodguard # [use more powerful depguard] allow and block lists linter for direct Go module dependencies
+    #- gosmopolitan # reports certain i18n/l10n anti-patterns in your Go codebase
+    #- grouper # analyzes expression groups
+    #- importas # enforces consistent import aliases
+    #- lll # [replaced by golines] reports long lines
+    #- maintidx # measures the maintainability index of each function
+    #- nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
+    #- paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
+    #- tagliatelle # checks the struct tags
+    #- thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    #- wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
+
+  # All settings can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
+  settings:
+    cyclop:
+      # The maximal code complexity to report.
+      # Default: 10
+      max-complexity: 30
+      # The maximal average package complexity.
+      # If it's higher than 0.0 (float) the check is enabled.
+      # Default: 0.0
+      package-average: 10.0
+
+    depguard:
+      # Rules to apply.
+      #
+      # Variables:
+      # - File Variables
+      #   Use an exclamation mark `!` to negate a variable.
+      #   Example: `!$test` matches any file that is not a go test file.
+      #
+      #   `$all` - matches all go files
+      #   `$test` - matches all go test files
+      #
+      # - Package Variables
+      #
+      #   `$gostd` - matches all of go's standard library (Pulled from `GOROOT`)
+      #
+      # Default (applies if no custom rules are defined): Only allow $gostd in all files.
+      rules:
+        "deprecated":
+          # List of file globs that will match this list of settings to compare against.
+          # By default, if a path is relative, it is relative to the directory where the golangci-lint command is executed.
+          # The placeholder '${base-path}' is substituted with a path relative to the mode defined with `run.relative-path-mode`.
+          # The placeholder '${config-path}' is substituted with a path relative to the configuration file.
+          # Default: $all
+          files:
+            - "$all"
+          # List of packages that are not allowed.
+          # Entries can be a variable (starting with $), a string prefix, or an exact match (if ending with $).
+          # Default: []
+          deny:
+            - pkg: github.com/golang/protobuf
+              desc: Use google.golang.org/protobuf instead, see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules
+            - pkg: github.com/satori/go.uuid
+              desc: Use github.com/google/uuid instead, satori's package is not maintained
+            - pkg: github.com/gofrs/uuid$
+              desc: Use github.com/gofrs/uuid/v5 or later, it was not a go module before v5
+        "non-test files":
+          files:
+            - "!$test"
+          deny:
+            - pkg: math/rand$
+              desc: Use math/rand/v2 instead, see https://go.dev/blog/randv2
+            - pkg: log$
+              desc: Use structured logging with slog instead of the standard log package
+
+
+    errcheck:
+      # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+      # Such cases aren't reported by default.
+      # Default: false
+      check-type-assertions: true
+
+    exhaustive:
+      # Program elements to check for exhaustiveness.
+      # Default: [ switch ]
+      check:
+        - switch
+        - map
+
+    forbidigo:
+      # Forbid the following identifiers (list of regexp).
+      # Default: ["^(fmt\\.Print(|f|ln)|print|println)$"]
+      forbid:
+        # Forbid fmt.Print* in non-main packages (use structured logging instead)
+        - pattern: '^(fmt\.Print(|f|ln)|print|println)$'
+          msg: use structured logging instead of fmt.Print*
+
+    funcorder:
+      # Checks if the exported methods of a structure are placed before the non-exported ones.
+      # Default: true
+      struct-method: false
+
+    funlen:
+      # Checks the number of lines in a function.
+      # If lower than 0, disable the check.
+      # Default: 60
+      lines: 100
+      # Checks the number of statements in a function.
+      # If lower than 0, disable the check.
+      # Default: 40
+      statements: 50
+
+    gochecksumtype:
+      # Presence of `default` case in switch statements satisfies exhaustiveness, if all members are not listed.
+      # Default: true
+      default-signifies-exhaustive: false
+
+    gocognit:
+      # Minimal code complexity to report.
+      # Default: 30 (but we recommend 10-20)
+      min-complexity: 20
+
+    gocritic:
+      # Settings passed to gocritic.
+      # The settings key is the name of a supported gocritic checker.
+      # The list of supported checkers can be found at https://go-critic.com/overview.
+      settings:
+        captLocal:
+          # Whether to restrict checker to params only.
+          # Default: true
+          paramsOnly: false
+        underef:
+          # Whether to skip (*x).method() calls where x is a pointer receiver.
+          # Default: true
+          skipRecvDeref: false
+
+    govet:
+      # Enable all analyzers.
+      # Default: false
+      enable-all: true
+      # Disable analyzers by name.
+      # Run `GL_DEBUG=govet golangci-lint run --enable=govet` to see default, all available analyzers, and enabled analyzers.
+      # Default: []
+      disable:
+        - fieldalignment # too strict
+      # Settings per analyzer.
+      settings:
+        shadow:
+          # Whether to be strict about shadowing; can be noisy.
+          # Default: false
+          strict: true
+
+    inamedparam:
+      # Skips check for interface methods with only a single parameter.
+      # Default: false
+      skip-single-param: true
+
+    interfacebloat:
+      # The maximum number of methods allowed for an interface.
+      # Default: 10
+      max: 10
+
+    ireturn:
+      # List of interfaces to allow to be returned from functions.
+      # Default: []
+      allow:
+        # Standard Go interfaces
+        - error
+        - context.Context
+        # OpenTelemetry metric interfaces
+        - go.opentelemetry.io/otel/metric.Float64Histogram
+        - go.opentelemetry.io/otel/metric.Int64Histogram
+        - go.opentelemetry.io/otel/metric.Float64Counter
+        - go.opentelemetry.io/otel/metric.Int64Counter
+        - go.opentelemetry.io/otel/metric.Float64UpDownCounter
+        - go.opentelemetry.io/otel/metric.Int64UpDownCounter
+        - go.opentelemetry.io/otel/metric.Float64Gauge
+        - go.opentelemetry.io/otel/metric.Int64Gauge
+
+    mnd:
+      # List of function patterns to exclude from analysis.
+      # Values always ignored: `time.Date`,
+      # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
+      # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
+      # Default: []
+      ignored-functions:
+        - args.Error
+        - flag.Arg
+        - flag.Duration.*
+        - flag.Float.*
+        - flag.Int.*
+        - flag.Uint.*
+        - os.Chmod
+        - os.Mkdir.*
+        - os.OpenFile
+        - os.WriteFile
+        - prometheus.ExponentialBuckets.*
+        - prometheus.LinearBuckets
+
+    nakedret:
+      # Make an issue if func has more lines of code than this setting, and it has naked returns.
+      # Default: 30
+      max-func-lines: 0
+
+    nolintlint:
+      # Exclude following linters from requiring an explanation.
+      # Default: []
+      allow-no-explanation: [ funlen, gocognit, golines ]
+      # Enable to require an explanation of nonzero length after each nolint directive.
+      # Default: false
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific linter being suppressed.
+      # Default: false
+      require-specific: true
+
+    perfsprint:
+      # All settings from candidate.yml
+      integer-format: true
+      int-conversion: true
+      error-format: true
+      err-error: false
+      errorf: true
+      string-format: true
+      sprintf1: true
+      strconcat: false # Changed from true to match current config
+      bool-format: true
+      hex-format: true
+
+    reassign:
+      # Patterns for global variable names that are checked for reassignment.
+      # See https://github.com/curioswitch/go-reassign#usage
+      # Default: ["EOF", "Err.*"]
+      patterns:
+        - ".*"
+
+    revive:
+      enable-all-rules: false
+      rules:
+        # All rules from candidate.yml
+        - name: blank-imports
+        - name: argument-limit
+          arguments: [5]
+        - name: atomic
+        - name: confusing-results
+        - name: context-as-argument
+        - name: datarace
+        - name: defer
+        - name: dot-imports
+        - name: duplicated-imports
+        - name: early-return
+          arguments: [preserveScope]
+        - name: empty-block
+        - name: empty-lines
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: get-return
+        - name: identical-branches
+        - name: if-return
+        - name: import-alias-naming
+        - name: imports-blocklist
+          arguments: ["gotest.tools/v3/assert"] # IDE auto-inserted instead of testify's assert
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: max-control-nesting
+        - name: modifies-value-receiver
+        - name: optimize-operands-order
+          exclude: ["TEST"]
+        - name: range
+        - name: redundant-import-alias
+        - name: struct-tag
+        - name: superfluous-else
+        - name: unchecked-type-assertion
+          exclude: ["TEST"]
+          arguments: [acceptIgnoredAssertionResult: true]
+        - name: unexported-naming
+        - name: unhandled-error
+          exclude: ["TEST"]
+        - name: unnecessary-stmt
+        - name: unreachable-code
+        - name: unused-parameter
+          exclude: ["TEST"]
+        - name: unused-receiver
+          exclude: ["TEST"]
+        - name: use-any
+        - name: useless-break
+        - name: var-declaration
+        - name: waitgroup-by-value
+
+    rowserrcheck:
+      # database/sql is always checked.
+      # Default: []
+      packages:
+        - github.com/jmoiron/sqlx
+
+    sloglint:
+      # Enforce not using global loggers.
+      # Values:
+      # - "": disabled
+      # - "all": report all global loggers
+      # - "default": report only the default slog logger
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
+      # Default: ""
+      no-global: all
+      # Enforce using methods that accept a context.
+      # Values:
+      # - "": disabled
+      # - "all": report all contextless calls
+      # - "scope": report only if a context exists in the scope of the outermost function
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only
+      # Default: ""
+      context: scope
+
+    staticcheck:
+      # SAxxxx checks in https://staticcheck.dev/docs/configuration/options/#checks
+      # Example (to disable some checks): [ "all", "-SA1000", "-SA1001"]
+      # Default: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+      checks:
+        - all
+        # Incorrect or missing package comment.
+        # https://staticcheck.dev/docs/checks/#ST1000
+        - -ST1000
+        # Use consistent method receiver names.
+        # https://staticcheck.dev/docs/checks/#ST1016
+        - -ST1016
+        # Omit embedded fields from selector expression.
+        # https://staticcheck.dev/docs/checks/#QF1008
+        - -QF1008
+
+    tagalign:
+      # Align struct tags.
+      # Default: true
+      align: true
+      # Sort struct tags.
+      # Default: false
+      sort: true
+      # Specify the order of tags, the other tags will be sorted by name.
+      # This option will be ignored if `sort` is false.
+      # Default: []
+      order:
+        - json
+        - yaml
+        - xml
+        - form
+        - validate
+        - mapstructure
+        - protobuf
+        - db
+        - bson
+
+    testifylint:
+      # Enable all checkers.
+      # Default: false
+      enable-all: true
+
+    usetesting:
+      # Enable/disable `os.TempDir()` detections.
+      # Default: false
+      os-temp-dir: true
+
+    wrapcheck:
+      # An array of strings that specify substrings of signatures to ignore.
+      # If this set, it will override the default set of ignored signatures.
+      # See https://github.com/tomarrell/wrapcheck#configuration for more information.
+      # Default: [".Errorf(", "errors.New(", "errors.Unwrap(", "errors.Join(", ".Wrap(", ".Wrapf(", ".WithMessage(", ".WithMessagef(", ".WithStack("]
+      ignore-sigs:
+        - .Errorf(
+        - errors.New(
+        - errors.Unwrap(
+        - errors.Join(
+        - .Wrap(
+        - .Wrapf(
+        - .WithMessage(
+        - .WithMessagef(
+        - .WithStack(
+      # An array of strings that specify globs of packages to ignore.
+      # Default: []
+      ignore-package-globs:
+        - encoding/*
+        - github.com/pkg/*
+
+  # Exclusions configuration
+  exclusions:
+    # Mode of the generated files analysis.
+    generated: lax
+    # Log a warning if an exclusion rule is unused.
+    warn-unused: true
+    # Predefined exclusion rules from candidate.yml
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    # Paths to exclude
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+    # Excluding configuration per-path, per-linter, per-text and per-source.
+    rules:
+      # Exclude TODO comments from godot
+      - source: 'TODO'
+        linters: [ godot ]
+      # Exclude package comments requirements for files with nolint or TODO
+      - text: 'should have a package comment'
+        linters: [ revive ]
+      - text: 'exported \S+ \S+ should have comment( \(or a comment on this block\))? or be unexported'
+        linters: [ revive ]
+      - text: 'package comment should be of the form ".+"'
+        source: '// ?(nolint|TODO)'
+        linters: [ revive ]
+      - text: 'comment on exported \S+ \S+ should be of the form ".+"'
+        source: '// ?(nolint|TODO)'
+        linters: [ revive, staticcheck ]
+      # Relax some rules for test files
+      - path: '_test\.go'
+        linters:
+          - bodyclose
+          - dupl
+          - errcheck
+          - funlen
+          - goconst
+          - gosec
+          - noctx
+          - wrapcheck
+          - forbidigo # Allow fmt.Print* in tests
+          - testpackage # Allow testing internal implementation
+      # Allow fmt.Print* in main packages
+      - path: 'main\.go'
+        linters:
+          - forbidigo
+      # Exclude generated files
+      - path: '\.pb\.go$'
+        linters:
+          - goimports
+          - golines
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports # checks if the code and import statements are formatted according to the 'goimports' command
+    - golines # checks if code is formatted, and fixes long lines
+
+  # All settings can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
+  settings:
+    goimports:
+      # A list of prefixes, which, if set, checks import paths
+      # with the given prefixes are grouped after 3rd-party packages.
+      # Default: []
+      local-prefixes:
+        - github.com/kemal.akkoyun/opentelemetry-go-compile-instrumentation
+
+    golines:
+      # Target maximum line length.
+      # Default: 100
+      max-len: 120

--- a/_docs/api-design-and-project-structure.md
+++ b/_docs/api-design-and-project-structure.md
@@ -17,10 +17,12 @@ pkg ---> Public API
             network
 sdk ---> Instrumentation code for each plugin (e.g. http, grpc, ...)
 ```
+
 For Public API, we have some key abstractions as follows:
+
 1. `Instrumenter`: Unified entrance of instrumentation (generating span, metrics, ...)
 2. `Extractor`: Extracting attributes using multiple Getters according to [OpenTelemetry Semconv](https://opentelemetry.io/docs/specs/semconv/).
-3. `Getter`: Getting attributes from the REQUEST object(For example, HttpRequest object that HTTP Server received).
+3. `Getter`: Getting attributes from the REQUEST object(For example, HTTPRequest object that HTTP Server received).
 4. `AttrsShadower`: An extension for Extractor to customize the attributes extracted by the extractor.
 5. `OperationListener`: An hook for better extension(For example, aggregate the metrics).
 
@@ -55,7 +57,7 @@ classDiagram
             + GetXxx(REQUEST) string
             + ...(...)
         }
-        class HttpCommonAttributesGetter {
+        class HTTPCommonAttributesGetter {
             + GetRequestMethod(REQUEST) string
             + ...(...)
         }
@@ -69,7 +71,7 @@ classDiagram
         }
     }
 
-    HttpCommonAttributesGetter ..|> AttributesGetter
+    HTTPCommonAttributesGetter ..|> AttributesGetter
     RcpAttributesGetter ..|> AttributesGetter
     MessagingAttributesGetter ..|> AttributesGetter
 
@@ -122,7 +124,7 @@ classDiagram
             + OnAfterStart(Context, Time)
             + OnAfterEnd(Context, []KeyValue, Time)
         }
-        class HttpServerMetric {
+        class HTTPServerMetric {
             + OnBeforeStart(Context, Time) Context
             + OnBeforeEnd(Context, []KeyValue, Time) Context
             + OnAfterStart(Context, Time)
@@ -138,7 +140,7 @@ classDiagram
 
     Instrumenter *-- "1..*" OperationListener
 
-    OperationListener <|.. HttpServerMetric
+    OperationListener <|.. HTTPServerMetric
     OperationListener <|.. XxxOperationListener
 
     PropagatingFromUpstreamInstrumenter ..|> Instrumenter

--- a/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor.go
@@ -5,66 +5,77 @@ package http
 
 import (
 	"context"
+	"sync/atomic"
+
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/inst-api-semconv/instrumenter/utils"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
-	"sync/atomic"
 )
 
-type HttpRequest interface{}
-
-type HttpResponse interface{}
+type (
+	HTTPRequest  any
+	HTTPResponse any
+)
 
 /**
-Extract attributes from HttpRequest and HttpResponse according to
+Extract attributes from HTTPRequest and HTTPResponse according to
 OpenTelemetry HTTP Spec for span and metric:
 https://opentelemetry.io/docs/specs/semconv/http/http-spans/: Semantic Conventions for HTTP client and server spans.
 https://opentelemetry.io/docs/specs/semconv/http/http-metrics/: Semantic Conventions for HTTP client and server metrics.
 */
 
-type HttpCommonAttrsExtractor[REQUEST HttpRequest, RESPONSE HttpResponse,
-	COMMONATTRGETTER HttpCommonAttrsGetter[REQUEST, RESPONSE]] struct {
-	HttpGetter       COMMONATTRGETTER
+type HTTPCommonAttrsExtractor[REQUEST HTTPRequest, RESPONSE HTTPResponse,
+	COMMONATTRGETTER HTTPCommonAttrsGetter[REQUEST, RESPONSE]] struct {
+	HTTPGetter       COMMONATTRGETTER
 	AttributesFilter func(attrs []attribute.KeyValue) []attribute.KeyValue
 }
 
-func (h *HttpCommonAttrsExtractor[REQUEST, RESPONSE, COMMONATTRGETTER]) OnStart(parentContext context.Context,
+func (h *HTTPCommonAttrsExtractor[REQUEST, RESPONSE, COMMONATTRGETTER]) OnStart(parentContext context.Context,
 	attributes []attribute.KeyValue,
-	request REQUEST) ([]attribute.KeyValue, context.Context) {
+	request REQUEST,
+) ([]attribute.KeyValue, context.Context) {
 	attributes = append(attributes, attribute.KeyValue{
 		Key:   semconv.HTTPRequestMethodKey,
-		Value: attribute.StringValue(h.HttpGetter.GetRequestMethod(request)),
+		Value: attribute.StringValue(h.HTTPGetter.GetRequestMethod(request)),
 	})
 	return attributes, parentContext
 }
 
-func (h *HttpCommonAttrsExtractor[REQUEST, RESPONSE, COMMONATTRGETTER]) OnEnd(context context.Context,
+func (h *HTTPCommonAttrsExtractor[REQUEST, RESPONSE, COMMONATTRGETTER]) OnEnd(context context.Context,
 	attributes []attribute.KeyValue,
-	request REQUEST, response RESPONSE, err error) ([]attribute.KeyValue, context.Context) {
-	statusCode := h.HttpGetter.GetHttpResponseStatusCode(request, response, err)
+	request REQUEST, response RESPONSE, err error,
+) ([]attribute.KeyValue, context.Context) {
+	statusCode := h.HTTPGetter.GetHTTPResponseStatusCode(request, response, err)
 	attributes = append(attributes, attribute.KeyValue{
 		Key:   semconv.HTTPResponseStatusCodeKey,
 		Value: attribute.IntValue(statusCode),
 	})
-	errorType := h.HttpGetter.GetErrorType(request, response, err)
+	errorType := h.HTTPGetter.GetErrorType(request, response, err)
 	if errorType != "" {
-		attributes = append(attributes, attribute.KeyValue{Key: semconv.ErrorTypeKey, Value: attribute.StringValue(errorType)})
+		attributes = append(
+			attributes,
+			attribute.KeyValue{Key: semconv.ErrorTypeKey, Value: attribute.StringValue(errorType)},
+		)
 	}
 	return attributes, context
 }
 
-type HttpClientAttrsExtractor[REQUEST HttpRequest, RESPONSE HttpResponse, GETTER1 HttpClientAttrsGetter[REQUEST, RESPONSE]] struct {
-	Base HttpCommonAttrsExtractor[REQUEST, RESPONSE, GETTER1]
+type HTTPClientAttrsExtractor[REQUEST HTTPRequest, RESPONSE HTTPResponse, GETTER1 HTTPClientAttrsGetter[REQUEST, RESPONSE]] struct {
+	Base HTTPCommonAttrsExtractor[REQUEST, RESPONSE, GETTER1]
 }
 
-func (h *HttpClientAttrsExtractor[REQUEST, RESPONSE, CLIENTATTRGETTER]) OnStart(parentContext context.Context,
+func (h *HTTPClientAttrsExtractor[REQUEST, RESPONSE, CLIENTATTRGETTER]) OnStart(parentContext context.Context,
 	attributes []attribute.KeyValue,
-	request REQUEST) ([]attribute.KeyValue, context.Context) {
+	request REQUEST,
+) ([]attribute.KeyValue, context.Context) {
 	attributes, parentContext = h.Base.OnStart(parentContext, attributes, request)
-	resendCount := parentContext.Value(utils.CLIENT_RESEND_KEY)
+	resendCount := parentContext.Value(utils.ClientResendKey)
 	newCount := int32(0)
 	if resendCount != nil {
-		newCount = atomic.AddInt32(resendCount.(*int32), 1)
+		count, ok := resendCount.(*int32)
+		if ok {
+			newCount = atomic.AddInt32(count, 1)
+		}
 		if newCount > 0 {
 			attributes = append(attributes, attribute.KeyValue{
 				Key:   semconv.HTTPRequestResendCountKey,
@@ -72,15 +83,18 @@ func (h *HttpClientAttrsExtractor[REQUEST, RESPONSE, CLIENTATTRGETTER]) OnStart(
 			})
 		}
 	}
-	parentContext = context.WithValue(parentContext, utils.CLIENT_RESEND_KEY, &newCount)
+	parentContext = context.WithValue(parentContext, utils.ClientResendKey, &newCount)
 	if h.Base.AttributesFilter != nil {
 		attributes = h.Base.AttributesFilter(attributes)
 	}
 	return attributes, parentContext
 }
 
-func (h *HttpClientAttrsExtractor[REQUEST, RESPONSE, CLIENTATTRGETTER]) OnEnd(attributes []attribute.KeyValue,
-	context context.Context, request REQUEST, response RESPONSE, err error) ([]attribute.KeyValue, context.Context) {
+func (h *HTTPClientAttrsExtractor[REQUEST, RESPONSE, CLIENTATTRGETTER]) OnEnd(
+	context context.Context,
+	attributes []attribute.KeyValue,
+	request REQUEST, response RESPONSE, err error,
+) ([]attribute.KeyValue, context.Context) {
 	attributes, context = h.Base.OnEnd(context, attributes, request, response, err)
 	if h.Base.AttributesFilter != nil {
 		attributes = h.Base.AttributesFilter(attributes)
@@ -88,19 +102,22 @@ func (h *HttpClientAttrsExtractor[REQUEST, RESPONSE, CLIENTATTRGETTER]) OnEnd(at
 	return attributes, context
 }
 
-func (h *HttpClientAttrsExtractor[REQUEST, RESPONSE, CLIENTATTRGETTER]) GetSpanKey() attribute.Key {
-	return utils.HTTP_CLIENT_KEY
+func (_ *HTTPClientAttrsExtractor[REQUEST, RESPONSE, CLIENTATTRGETTER]) GetSpanKey() attribute.Key {
+	return utils.HTTPClientKey
 }
 
-type HttpServerAttrsExtractor[REQUEST HttpRequest, RESPONSE HttpResponse,
-	SERVERATTRGETTER HttpServerAttrsGetter[REQUEST, RESPONSE]] struct {
-	Base HttpCommonAttrsExtractor[REQUEST, RESPONSE, SERVERATTRGETTER]
+type HTTPServerAttrsExtractor[REQUEST HTTPRequest, RESPONSE HTTPResponse,
+	SERVERATTRGETTER HTTPServerAttrsGetter[REQUEST, RESPONSE]] struct {
+	Base HTTPCommonAttrsExtractor[REQUEST, RESPONSE, SERVERATTRGETTER]
 }
 
-func (h *HttpServerAttrsExtractor[REQUEST, RESPONSE, SERVERATTRGETTER]) OnStart(attributes []attribute.KeyValue,
-	parentContext context.Context, request REQUEST) ([]attribute.KeyValue, context.Context) {
+func (h *HTTPServerAttrsExtractor[REQUEST, RESPONSE, SERVERATTRGETTER]) OnStart(
+	parentContext context.Context,
+	attributes []attribute.KeyValue,
+	request REQUEST,
+) ([]attribute.KeyValue, context.Context) {
 	attributes, parentContext = h.Base.OnStart(parentContext, attributes, request)
-	userAgent := h.Base.HttpGetter.GetHttpRequestHeader(request, "User-Agent")
+	userAgent := h.Base.HTTPGetter.GetHTTPRequestHeader(request, "User-Agent")
 	var firstUserAgent string
 	if len(userAgent) > 0 {
 		firstUserAgent = userAgent[0]
@@ -117,10 +134,12 @@ func (h *HttpServerAttrsExtractor[REQUEST, RESPONSE, SERVERATTRGETTER]) OnStart(
 	return attributes, parentContext
 }
 
-func (h *HttpServerAttrsExtractor[REQUEST, RESPONSE, SERVERATTRGETTER]) OnEnd(attributes []attribute.KeyValue,
-	context context.Context, request REQUEST, response RESPONSE, err error) ([]attribute.KeyValue, context.Context) {
+func (h *HTTPServerAttrsExtractor[REQUEST, RESPONSE, SERVERATTRGETTER]) OnEnd(
+	context context.Context, attributes []attribute.KeyValue,
+	request REQUEST, response RESPONSE, err error,
+) ([]attribute.KeyValue, context.Context) {
 	attributes, context = h.Base.OnEnd(context, attributes, request, response, err)
-	route := h.Base.HttpGetter.GetHttpRoute(request)
+	route := h.Base.HTTPGetter.GetHTTPRoute(request)
 	attributes = append(attributes, attribute.KeyValue{
 		Key:   semconv.HTTPRouteKey,
 		Value: attribute.StringValue(route),
@@ -131,6 +150,6 @@ func (h *HttpServerAttrsExtractor[REQUEST, RESPONSE, SERVERATTRGETTER]) OnEnd(at
 	return attributes, context
 }
 
-func (h *HttpServerAttrsExtractor[REQUEST, RESPONSE, SERVERATTRGETTER]) GetSpanKey() attribute.Key {
-	return utils.HTTP_SERVER_KEY
+func (_ *HTTPServerAttrsExtractor[REQUEST, RESPONSE, SERVERATTRGETTER]) GetSpanKey() attribute.Key {
+	return utils.HTTPServerKey
 }

--- a/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor_test.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_attrs_extractor_test.go
@@ -5,66 +5,65 @@ package http
 
 import (
 	"context"
+	"testing"
+
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/inst-api-semconv/instrumenter/utils"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
-	"testing"
 )
 
-type httpServerAttrsGetter struct {
-}
+type httpServerAttrsGetter struct{}
 
-type httpClientAttrsGetter struct {
-}
+type httpClientAttrsGetter struct{}
 
-func (h httpClientAttrsGetter) GetRequestMethod(request testRequest) string {
+func (httpClientAttrsGetter) GetRequestMethod(_ testRequest) string {
 	return "GET"
 }
 
-func (h httpClientAttrsGetter) GetHttpRequestHeader(request testRequest, name string) []string {
+func (httpClientAttrsGetter) GetHTTPRequestHeader(_ testRequest, name string) []string {
 	return []string{"request-header"}
 }
 
-func (h httpClientAttrsGetter) GetHttpResponseStatusCode(request testRequest, response testResponse, err error) int {
+func (httpClientAttrsGetter) GetHTTPResponseStatusCode(_ testRequest, response testResponse, err error) int {
 	return 200
 }
 
-func (h httpClientAttrsGetter) GetHttpResponseHeader(request testRequest, response testResponse, name string) []string {
+func (httpClientAttrsGetter) GetHTTPResponseHeader(_ testRequest, _ testResponse, name string) []string {
 	return []string{"response-header"}
 }
 
-func (h httpClientAttrsGetter) GetErrorType(request testRequest, response testResponse, err error) string {
+func (httpClientAttrsGetter) GetErrorType(_ testRequest, _ testResponse, err error) string {
 	return ""
 }
 
-func (h httpServerAttrsGetter) GetRequestMethod(request testRequest) string {
+func (httpServerAttrsGetter) GetRequestMethod(_ testRequest) string {
 	return "GET"
 }
 
-func (h httpServerAttrsGetter) GetHttpRequestHeader(request testRequest, name string) []string {
+func (httpServerAttrsGetter) GetHTTPRequestHeader(_ testRequest, name string) []string {
 	return []string{"request-header"}
 }
 
-func (h httpServerAttrsGetter) GetHttpResponseStatusCode(request testRequest, response testResponse, err error) int {
+func (httpServerAttrsGetter) GetHTTPResponseStatusCode(_ testRequest, response testResponse, err error) int {
 	return 200
 }
 
-func (h httpServerAttrsGetter) GetHttpResponseHeader(request testRequest, response testResponse, name string) []string {
+func (httpServerAttrsGetter) GetHTTPResponseHeader(_ testRequest, _ testResponse, name string) []string {
 	return []string{"response-header"}
 }
 
-func (h httpServerAttrsGetter) GetErrorType(request testRequest, response testResponse, err error) string {
+func (httpServerAttrsGetter) GetErrorType(_ testRequest, _ testResponse, err error) string {
 	return "error-type"
 }
 
-func (h httpServerAttrsGetter) GetHttpRoute(request testRequest) string {
+func (httpServerAttrsGetter) GetHTTPRoute(_ testRequest) string {
 	return "http-route"
 }
 
-func TestHttpClientExtractorStart(t *testing.T) {
-	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{
-		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{},
+func TestHTTPClientExtractorStart(t *testing.T) {
+	httpClientExtractor := HTTPClientAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{
+		Base: HTTPCommonAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{},
 	}
 	var attrs []attribute.KeyValue
 	parentContext := context.Background()
@@ -72,49 +71,49 @@ func TestHttpClientExtractorStart(t *testing.T) {
 	if attrs[0].Key != semconv.HTTPRequestMethodKey || attrs[0].Value.AsString() != "GET" {
 		t.Fatalf("http method should be GET")
 	}
-	if httpClientExtractor.GetSpanKey() != utils.HTTP_CLIENT_KEY {
+	if httpClientExtractor.GetSpanKey() != utils.HTTPClientKey {
 		t.Fatalf("span key should be http-client")
 	}
 }
 
-func TestHttpClientExtractorEnd(t *testing.T) {
-	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{
-		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{},
+func TestHTTPClientExtractorEnd(t *testing.T) {
+	httpClientExtractor := HTTPClientAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{
+		Base: HTTPCommonAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{},
 	}
 	var attrs []attribute.KeyValue
 	parentContext := context.Background()
-	attrs, _ = httpClientExtractor.OnEnd(attrs, parentContext, testRequest{}, testResponse{}, nil)
+	attrs, _ = httpClientExtractor.OnEnd(parentContext, attrs, testRequest{}, testResponse{}, nil)
 	if attrs[0].Key != semconv.HTTPResponseStatusCodeKey || attrs[0].Value.AsInt64() != 200 {
 		t.Fatalf("status code should be 200")
 	}
 }
 
-func TestHttpServerExtractorStart(t *testing.T) {
-	httpServerExtractor := HttpServerAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{
-		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{},
+func TestHTTPServerExtractorStart(t *testing.T) {
+	httpServerExtractor := HTTPServerAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{
+		Base: HTTPCommonAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{},
 	}
 	var attrs []attribute.KeyValue
 	parentContext := context.Background()
-	attrs, _ = httpServerExtractor.OnStart(attrs, parentContext, testRequest{})
+	attrs, _ = httpServerExtractor.OnStart(parentContext, attrs, testRequest{})
 	if attrs[0].Key != semconv.HTTPRequestMethodKey || attrs[0].Value.AsString() != "GET" {
 		t.Fatalf("http method should be GET")
 	}
 	if attrs[1].Key != semconv.UserAgentOriginalKey || attrs[1].Value.AsString() != "request-header" {
 		t.Fatalf("user agent original should be request-header")
 	}
-	if httpServerExtractor.GetSpanKey() != utils.HTTP_SERVER_KEY {
+	if httpServerExtractor.GetSpanKey() != utils.HTTPServerKey {
 		t.Fatalf("span key should be http-server")
 	}
 }
 
-func TestHttpServerExtractorEnd(t *testing.T) {
-	httpServerExtractor := HttpServerAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{
-		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{},
+func TestHTTPServerExtractorEnd(t *testing.T) {
+	httpServerExtractor := HTTPServerAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{
+		Base: HTTPCommonAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{},
 	}
 	var attrs []attribute.KeyValue
 	ctx := context.Background()
 	ctx = trace.ContextWithSpan(ctx, &testReadOnlySpan{isRecording: true})
-	attrs, _ = httpServerExtractor.OnEnd(attrs, ctx, testRequest{}, testResponse{}, nil)
+	attrs, _ = httpServerExtractor.OnEnd(ctx, attrs, testRequest{}, testResponse{}, nil)
 	if attrs[0].Key != semconv.HTTPResponseStatusCodeKey || attrs[0].Value.AsInt64() != 200 {
 		t.Fatalf("status code should be 200")
 	}
@@ -126,36 +125,36 @@ func TestHttpServerExtractorEnd(t *testing.T) {
 	}
 }
 
-func TestHttpServerExtractorWithFilter(t *testing.T) {
-	httpServerExtractor := HttpServerAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{
-		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{},
+func TestHTTPServerExtractorWithFilter(t *testing.T) {
+	httpServerExtractor := HTTPServerAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{
+		Base: HTTPCommonAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{},
 	}
 	var attrs []attribute.KeyValue
 	parentContext := context.Background()
-	httpServerExtractor.Base.AttributesFilter = func(attrs []attribute.KeyValue) []attribute.KeyValue {
+	httpServerExtractor.Base.AttributesFilter = func(_ []attribute.KeyValue) []attribute.KeyValue {
 		return []attribute.KeyValue{{
 			Key:   "test",
 			Value: attribute.StringValue("test"),
 		}}
 	}
 	attrs = make([]attribute.KeyValue, 0)
-	attrs, _ = httpServerExtractor.OnStart(attrs, parentContext, testRequest{Method: "test"})
+	attrs, _ = httpServerExtractor.OnStart(parentContext, attrs, testRequest{Method: "test"})
 	if attrs[0].Key != "test" || attrs[0].Value.AsString() != "test" {
-		panic("attribute should be test")
+		t.Fatal("attribute should be test")
 	}
-	attrs, _ = httpServerExtractor.OnEnd(attrs, parentContext, testRequest{Method: "test"}, testResponse{}, nil)
+	attrs, _ = httpServerExtractor.OnEnd(parentContext, attrs, testRequest{Method: "test"}, testResponse{}, nil)
 	if attrs[0].Key != "test" || attrs[0].Value.AsString() != "test" {
-		panic("attribute should be test")
+		t.Fatal("attribute should be test")
 	}
 }
 
-func TestHttpClientExtractorWithFilter(t *testing.T) {
-	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{
-		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{},
+func TestHTTPClientExtractorWithFilter(t *testing.T) {
+	httpClientExtractor := HTTPClientAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{
+		Base: HTTPCommonAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{},
 	}
 	var attrs []attribute.KeyValue
 	parentContext := context.Background()
-	httpClientExtractor.Base.AttributesFilter = func(attrs []attribute.KeyValue) []attribute.KeyValue {
+	httpClientExtractor.Base.AttributesFilter = func(_ []attribute.KeyValue) []attribute.KeyValue {
 		return []attribute.KeyValue{{
 			Key:   "test",
 			Value: attribute.StringValue("test"),
@@ -164,22 +163,22 @@ func TestHttpClientExtractorWithFilter(t *testing.T) {
 	attrs = make([]attribute.KeyValue, 0)
 	attrs, _ = httpClientExtractor.OnStart(parentContext, attrs, testRequest{Method: "test"})
 	if attrs[0].Key != "test" || attrs[0].Value.AsString() != "test" {
-		panic("attribute should be test")
+		t.Fatal("attribute should be test")
 	}
-	attrs, _ = httpClientExtractor.OnEnd(attrs, parentContext, testRequest{Method: "test"}, testResponse{}, nil)
+	attrs, _ = httpClientExtractor.OnEnd(parentContext, attrs, testRequest{Method: "test"}, testResponse{}, nil)
 	if attrs[0].Key != "test" || attrs[0].Value.AsString() != "test" {
-		panic("attribute should be test")
+		t.Fatal("attribute should be test")
 	}
 }
 
 func TestNonRecordingSpan(t *testing.T) {
-	httpServerExtractor := HttpServerAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{
-		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{},
+	httpServerExtractor := HTTPServerAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{
+		Base: HTTPCommonAttrsExtractor[testRequest, testResponse, httpServerAttrsGetter]{},
 	}
 	var attrs []attribute.KeyValue
 	ctx := context.Background()
 	ctx = trace.ContextWithSpan(ctx, &testReadOnlySpan{isRecording: false})
-	attrs, _ = httpServerExtractor.OnEnd(attrs, ctx, testRequest{}, testResponse{}, nil)
+	attrs, _ = httpServerExtractor.OnEnd(ctx, attrs, testRequest{}, testResponse{}, nil)
 	if attrs[0].Key != semconv.HTTPResponseStatusCodeKey || attrs[0].Value.AsInt64() != 200 {
 		t.Fatalf("status code should be 200")
 	}
@@ -189,12 +188,12 @@ func TestNonRecordingSpan(t *testing.T) {
 }
 
 func TestResendCountHandling(t *testing.T) {
-	httpClientExtractor := HttpClientAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{
-		Base: HttpCommonAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{},
+	httpClientExtractor := HTTPClientAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{
+		Base: HTTPCommonAttrsExtractor[testRequest, testResponse, httpClientAttrsGetter]{},
 	}
 	parentContext := context.Background()
 	resendCount := int32(0)
-	parentContext = context.WithValue(parentContext, utils.CLIENT_RESEND_KEY, &resendCount)
+	parentContext = context.WithValue(parentContext, utils.ClientResendKey, &resendCount)
 	var attributes []attribute.KeyValue
 	attributes, _ = httpClientExtractor.OnStart(parentContext, attributes, testRequest{})
 	if attributes[1].Key != semconv.HTTPRequestResendCountKey || attributes[1].Value.AsInt64() != 1 {

--- a/pkg/inst-api-semconv/instrumenter/http/http_attrs_getter.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_attrs_getter.go
@@ -3,19 +3,19 @@
 
 package http
 
-type HttpCommonAttrsGetter[REQUEST any, RESPONSE any] interface {
+type HTTPCommonAttrsGetter[REQUEST any, RESPONSE any] interface {
 	GetRequestMethod(request REQUEST) string
-	GetHttpRequestHeader(request REQUEST, name string) []string
-	GetHttpResponseStatusCode(request REQUEST, response RESPONSE, err error) int
-	GetHttpResponseHeader(request REQUEST, response RESPONSE, name string) []string
+	GetHTTPRequestHeader(request REQUEST, name string) []string
+	GetHTTPResponseStatusCode(request REQUEST, response RESPONSE, err error) int
+	GetHTTPResponseHeader(request REQUEST, response RESPONSE, name string) []string
 	GetErrorType(request REQUEST, response RESPONSE, err error) string
 }
 
-type HttpServerAttrsGetter[REQUEST any, RESPONSE any] interface {
-	HttpCommonAttrsGetter[REQUEST, RESPONSE]
-	GetHttpRoute(request REQUEST) string
+type HTTPServerAttrsGetter[REQUEST any, RESPONSE any] interface {
+	HTTPCommonAttrsGetter[REQUEST, RESPONSE]
+	GetHTTPRoute(request REQUEST) string
 }
 
-type HttpClientAttrsGetter[REQUEST any, RESPONSE any] interface {
-	HttpCommonAttrsGetter[REQUEST, RESPONSE]
+type HTTPClientAttrsGetter[REQUEST any, RESPONSE any] interface {
+	HTTPCommonAttrsGetter[REQUEST, RESPONSE]
 }

--- a/pkg/inst-api-semconv/instrumenter/http/http_span_name_extractor.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_span_name_extractor.go
@@ -8,27 +8,29 @@ HTTP span names SHOULD be {method} {target} if there is a (low-cardinality) targ
 If there is no (low-cardinality) {target} available, HTTP span names SHOULD be {method}.
 */
 
-type HttpClientSpanNameExtractor[REQUEST any, RESPONSE any] struct {
-	Getter HttpClientAttrsGetter[REQUEST, RESPONSE]
+const defaultHTTPSpanName = "HTTP"
+
+type HTTPClientSpanNameExtractor[REQUEST any, RESPONSE any] struct {
+	Getter HTTPClientAttrsGetter[REQUEST, RESPONSE]
 }
 
-func (h *HttpClientSpanNameExtractor[REQUEST, RESPONSE]) Extract(request REQUEST) string {
+func (h *HTTPClientSpanNameExtractor[REQUEST, RESPONSE]) Extract(request REQUEST) string {
 	method := h.Getter.GetRequestMethod(request)
 	if method == "" {
-		return "HTTP"
+		return defaultHTTPSpanName
 	}
 	return method
 }
 
-type HttpServerSpanNameExtractor[REQUEST any, RESPONSE any] struct {
-	Getter HttpServerAttrsGetter[REQUEST, RESPONSE]
+type HTTPServerSpanNameExtractor[REQUEST any, RESPONSE any] struct {
+	Getter HTTPServerAttrsGetter[REQUEST, RESPONSE]
 }
 
-func (h *HttpServerSpanNameExtractor[REQUEST, RESPONSE]) Extract(request REQUEST) string {
+func (h *HTTPServerSpanNameExtractor[REQUEST, RESPONSE]) Extract(request REQUEST) string {
 	method := h.Getter.GetRequestMethod(request)
-	route := h.Getter.GetHttpRoute(request)
+	route := h.Getter.GetHTTPRoute(request)
 	if method == "" {
-		return "HTTP"
+		return defaultHTTPSpanName
 	}
 	if route == "" {
 		return method

--- a/pkg/inst-api-semconv/instrumenter/http/http_span_name_extractor_test.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_span_name_extractor_test.go
@@ -10,40 +10,39 @@ type testRequest struct {
 	Route  string
 }
 
-type testResponse struct {
-}
+type testResponse struct{}
 
 type testClientGetter struct {
-	HttpClientAttrsGetter[testRequest, testResponse]
+	HTTPClientAttrsGetter[testRequest, testResponse]
 }
 
 type testServerGetter struct {
-	HttpServerAttrsGetter[testRequest, testResponse]
+	HTTPServerAttrsGetter[testRequest, testResponse]
 }
 
-func (t testClientGetter) GetRequestMethod(request testRequest) string {
+func (testClientGetter) GetRequestMethod(request testRequest) string {
 	if request.Method != "" {
 		return request.Method
 	}
 	return ""
 }
 
-func (t testServerGetter) GetRequestMethod(request testRequest) string {
+func (testServerGetter) GetRequestMethod(request testRequest) string {
 	if request.Method != "" {
 		return request.Method
 	}
 	return ""
 }
 
-func (t testServerGetter) GetHttpRoute(request testRequest) string {
+func (testServerGetter) GetHTTPRoute(request testRequest) string {
 	if request.Route != "" {
 		return request.Route
 	}
 	return ""
 }
 
-func TestHttpClientExtractSpanName(t *testing.T) {
-	r := HttpClientSpanNameExtractor[testRequest, testResponse]{Getter: testClientGetter{}}
+func TestHTTPClientExtractSpanName(t *testing.T) {
+	r := HTTPClientSpanNameExtractor[testRequest, testResponse]{Getter: testClientGetter{}}
 	spanName := r.Extract(testRequest{Method: "GET"})
 	if spanName != "GET" {
 		t.Errorf("want GET, got %s", spanName)
@@ -54,8 +53,8 @@ func TestHttpClientExtractSpanName(t *testing.T) {
 	}
 }
 
-func TestHttpServerExtractSpanName(t *testing.T) {
-	r := HttpServerSpanNameExtractor[testRequest, testResponse]{Getter: testServerGetter{}}
+func TestHTTPServerExtractSpanName(t *testing.T) {
+	r := HTTPServerSpanNameExtractor[testRequest, testResponse]{Getter: testServerGetter{}}
 	spanName := r.Extract(testRequest{Method: "GET"})
 	if spanName != "GET" {
 		t.Errorf("want GET, got %s", spanName)

--- a/pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor.go
@@ -4,53 +4,68 @@
 package http
 
 import (
+	"strconv"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.opentelemetry.io/otel/trace"
-	"strconv"
 )
 
 /**
-For HttpServer, status code >= 500 or < 100 is treated as error.
-For HttpClient, status code >= 400 or < 100 is treated as error.
+For HTTPServer, status code >= 500 or < 100 is treated as error.
+For HTTPClient, status code >= 400 or < 100 is treated as error.
 */
 
-const invalidHttpStatusCode = "INVALID_HTTP_STATUS_CODE"
+const invalidHTTPStatusCode = "INVALID_HTTP_STATUS_CODE"
 
-type HttpClientSpanStatusExtractor[REQUEST any, RESPONSE any] struct {
-	Getter HttpCommonAttrsGetter[REQUEST, RESPONSE]
+type HTTPClientSpanStatusExtractor[REQUEST any, RESPONSE any] struct {
+	Getter HTTPCommonAttrsGetter[REQUEST, RESPONSE]
 }
 
-func (h HttpClientSpanStatusExtractor[REQUEST, RESPONSE]) Extract(span trace.Span, request REQUEST, response RESPONSE, err error) {
-	statusCode := h.Getter.GetHttpResponseStatusCode(request, response, err)
+func (h HTTPClientSpanStatusExtractor[REQUEST, RESPONSE]) Extract(
+	span trace.Span,
+	request REQUEST,
+	response RESPONSE,
+	err error,
+) {
+	statusCode := h.Getter.GetHTTPResponseStatusCode(request, response, err)
 	if statusCode >= 400 || statusCode < 100 {
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 		} else {
-			span.SetStatus(codes.Error, invalidHttpStatusCode)
+			span.SetStatus(codes.Error, invalidHTTPStatusCode)
 		}
-		span.SetAttributes(attribute.KeyValue{Key: semconv.ErrorTypeKey, Value: attribute.StringValue(strconv.Itoa(statusCode))})
+		span.SetAttributes(
+			attribute.KeyValue{Key: semconv.ErrorTypeKey, Value: attribute.StringValue(strconv.Itoa(statusCode))},
+		)
 	} else if statusCode >= 200 && statusCode < 300 {
 		span.SetStatus(codes.Ok, "success")
 	}
 }
 
-type HttpServerSpanStatusExtractor[REQUEST any, RESPONSE any] struct {
-	Getter HttpCommonAttrsGetter[REQUEST, RESPONSE]
+type HTTPServerSpanStatusExtractor[REQUEST any, RESPONSE any] struct {
+	Getter HTTPCommonAttrsGetter[REQUEST, RESPONSE]
 }
 
-func (h HttpServerSpanStatusExtractor[REQUEST, RESPONSE]) Extract(span trace.Span, request REQUEST, response RESPONSE, err error) {
-	statusCode := h.Getter.GetHttpResponseStatusCode(request, response, err)
+func (h HTTPServerSpanStatusExtractor[REQUEST, RESPONSE]) Extract(
+	span trace.Span,
+	request REQUEST,
+	response RESPONSE,
+	err error,
+) {
+	statusCode := h.Getter.GetHTTPResponseStatusCode(request, response, err)
 	if statusCode >= 500 || statusCode < 100 {
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 		} else {
-			span.SetStatus(codes.Error, invalidHttpStatusCode)
+			span.SetStatus(codes.Error, invalidHTTPStatusCode)
 		}
-		span.SetAttributes(attribute.KeyValue{Key: semconv.ErrorTypeKey, Value: attribute.StringValue(strconv.Itoa(statusCode))})
+		span.SetAttributes(
+			attribute.KeyValue{Key: semconv.ErrorTypeKey, Value: attribute.StringValue(strconv.Itoa(statusCode))},
+		)
 	} else if statusCode >= 200 && statusCode < 300 {
 		span.SetStatus(codes.Ok, "success")
 	}

--- a/pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor_test.go
+++ b/pkg/inst-api-semconv/instrumenter/http/http_status_code_extractor_test.go
@@ -4,11 +4,12 @@
 package http
 
 import (
+	"testing"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
-	"testing"
 )
 
 type testSpan struct {
@@ -17,7 +18,7 @@ type testSpan struct {
 	Kvs    []attribute.KeyValue
 }
 
-func (ts *testSpan) SetStatus(status codes.Code, desc string) {
+func (ts *testSpan) SetStatus(status codes.Code, _ string) {
 	*ts.status = status
 }
 
@@ -30,7 +31,7 @@ type testReadOnlySpan struct {
 	isRecording bool
 }
 
-func (t *testReadOnlySpan) Name() string {
+func (*testReadOnlySpan) Name() string {
 	return "http-route"
 }
 
@@ -38,37 +39,37 @@ func (t *testReadOnlySpan) IsRecording() bool {
 	return t.isRecording
 }
 
-type customizedNetHttpAttrsGetter struct {
+type customizedNetHTTPAttrsGetter struct {
 	code int
 }
 
-func (c customizedNetHttpAttrsGetter) GetRequestMethod(request any) string {
-	//TODO implement me
+func (customizedNetHTTPAttrsGetter) GetRequestMethod(_ any) string {
+	// TODO implement me
 	panic("implement me")
 }
 
-func (c customizedNetHttpAttrsGetter) GetHttpRequestHeader(request any, name string) []string {
-	//TODO implement me
+func (customizedNetHTTPAttrsGetter) GetHTTPRequestHeader(_ any, _ string) []string {
+	// TODO implement me
 	panic("implement me")
 }
 
-func (c customizedNetHttpAttrsGetter) GetHttpResponseStatusCode(request any, response any, err error) int {
+func (c customizedNetHTTPAttrsGetter) GetHTTPResponseStatusCode(_ any, _ any, _ error) int {
 	return c.code
 }
 
-func (c customizedNetHttpAttrsGetter) GetHttpResponseHeader(request any, response any, name string) []string {
-	//TODO implement me
+func (customizedNetHTTPAttrsGetter) GetHTTPResponseHeader(_ any, _ any, _ string) []string {
+	// TODO implement me
 	panic("implement me")
 }
 
-func (c customizedNetHttpAttrsGetter) GetErrorType(request any, response any, err error) string {
-	//TODO implement me
+func (customizedNetHTTPAttrsGetter) GetErrorType(_ any, _ any, _ error) string {
+	// TODO implement me
 	panic("implement me")
 }
 
-func TestHttpClientSpanStatusExtractor500(t *testing.T) {
-	c := HttpClientSpanStatusExtractor[any, any]{
-		Getter: customizedNetHttpAttrsGetter{
+func TestHTTPClientSpanStatusExtractor500(t *testing.T) {
+	c := HTTPClientSpanStatusExtractor[any, any]{
+		Getter: customizedNetHTTPAttrsGetter{
 			code: 500,
 		},
 	}
@@ -76,13 +77,13 @@ func TestHttpClientSpanStatusExtractor500(t *testing.T) {
 	span := &testSpan{status: &u}
 	c.Extract(span, nil, nil, nil)
 	if *span.status != codes.Error {
-		panic("span status should be error!")
+		t.Fatal("span status should be error!")
 	}
 }
 
-func TestHttpClientSpanStatusExtractor400(t *testing.T) {
-	c := HttpClientSpanStatusExtractor[any, any]{
-		Getter: customizedNetHttpAttrsGetter{
+func TestHTTPClientSpanStatusExtractor400(t *testing.T) {
+	c := HTTPClientSpanStatusExtractor[any, any]{
+		Getter: customizedNetHTTPAttrsGetter{
 			code: 400,
 		},
 	}
@@ -90,16 +91,16 @@ func TestHttpClientSpanStatusExtractor400(t *testing.T) {
 	span := &testSpan{status: &u}
 	c.Extract(span, nil, nil, nil)
 	if *span.status != codes.Error {
-		panic("span status should be error!")
+		t.Fatal("span status should be error!")
 	}
 	if span.Kvs == nil {
-		panic("kv should not be nil")
+		t.Fatal("kv should not be nil")
 	}
 }
 
-func TestHttpClientSpanStatusExtractor200(t *testing.T) {
-	c := HttpClientSpanStatusExtractor[any, any]{
-		Getter: customizedNetHttpAttrsGetter{
+func TestHTTPClientSpanStatusExtractor200(t *testing.T) {
+	c := HTTPClientSpanStatusExtractor[any, any]{
+		Getter: customizedNetHTTPAttrsGetter{
 			code: 200,
 		},
 	}
@@ -107,12 +108,13 @@ func TestHttpClientSpanStatusExtractor200(t *testing.T) {
 	span := &testSpan{status: &u}
 	c.Extract(span, nil, nil, nil)
 	if *span.status != codes.Ok {
-		panic("span status should be ok!")
+		t.Fatal("span status should be ok!")
 	}
 }
-func TestHttpClientSpanStatusExtractor201(t *testing.T) {
-	c := HttpClientSpanStatusExtractor[any, any]{
-		Getter: customizedNetHttpAttrsGetter{
+
+func TestHTTPClientSpanStatusExtractor201(t *testing.T) {
+	c := HTTPClientSpanStatusExtractor[any, any]{
+		Getter: customizedNetHTTPAttrsGetter{
 			code: 201,
 		},
 	}
@@ -120,12 +122,13 @@ func TestHttpClientSpanStatusExtractor201(t *testing.T) {
 	span := &testSpan{status: &u}
 	c.Extract(span, nil, nil, nil)
 	if *span.status != codes.Ok {
-		panic("span status should be ok!")
+		t.Fatal("span status should be ok!")
 	}
 }
-func TestHttpServerSpanStatusExtractor500(t *testing.T) {
-	c := HttpServerSpanStatusExtractor[any, any]{
-		Getter: customizedNetHttpAttrsGetter{
+
+func TestHTTPServerSpanStatusExtractor500(t *testing.T) {
+	c := HTTPServerSpanStatusExtractor[any, any]{
+		Getter: customizedNetHTTPAttrsGetter{
 			code: 500,
 		},
 	}
@@ -133,16 +136,16 @@ func TestHttpServerSpanStatusExtractor500(t *testing.T) {
 	span := &testSpan{status: &u}
 	c.Extract(span, nil, nil, nil)
 	if *span.status != codes.Error {
-		panic("span status should be error!")
+		t.Fatal("span status should be error!")
 	}
 	if span.Kvs == nil {
-		panic("kv should not be nil")
+		t.Fatal("kv should not be nil")
 	}
 }
 
-func TestHttpServerSpanStatusExtractor400(t *testing.T) {
-	c := HttpServerSpanStatusExtractor[any, any]{
-		Getter: customizedNetHttpAttrsGetter{
+func TestHTTPServerSpanStatusExtractor400(t *testing.T) {
+	c := HTTPServerSpanStatusExtractor[any, any]{
+		Getter: customizedNetHTTPAttrsGetter{
 			code: 400,
 		},
 	}
@@ -150,13 +153,13 @@ func TestHttpServerSpanStatusExtractor400(t *testing.T) {
 	span := &testSpan{status: &u}
 	c.Extract(span, nil, nil, nil)
 	if *span.status != codes.Unset {
-		panic("span status should be error!")
+		t.Fatal("span status should be unset!")
 	}
 }
 
-func TestHttpServerSpanStatusExtractor200(t *testing.T) {
-	c := HttpClientSpanStatusExtractor[any, any]{
-		Getter: customizedNetHttpAttrsGetter{
+func TestHTTPServerSpanStatusExtractor200(t *testing.T) {
+	c := HTTPServerSpanStatusExtractor[any, any]{
+		Getter: customizedNetHTTPAttrsGetter{
 			code: 200,
 		},
 	}
@@ -164,12 +167,13 @@ func TestHttpServerSpanStatusExtractor200(t *testing.T) {
 	span := &testSpan{status: &u}
 	c.Extract(span, nil, nil, nil)
 	if *span.status != codes.Ok {
-		panic("span status should be ok!")
+		t.Fatal("span status should be ok!")
 	}
 }
-func TestHttpServerSpanStatusExtractor201(t *testing.T) {
-	c := HttpClientSpanStatusExtractor[any, any]{
-		Getter: customizedNetHttpAttrsGetter{
+
+func TestHTTPServerSpanStatusExtractor201(t *testing.T) {
+	c := HTTPServerSpanStatusExtractor[any, any]{
+		Getter: customizedNetHTTPAttrsGetter{
 			code: 201,
 		},
 	}
@@ -177,6 +181,6 @@ func TestHttpServerSpanStatusExtractor201(t *testing.T) {
 	span := &testSpan{status: &u}
 	c.Extract(span, nil, nil, nil)
 	if *span.status != codes.Ok {
-		panic("span status should be ok!")
+		t.Fatal("span status should be ok!")
 	}
 }

--- a/pkg/inst-api-semconv/instrumenter/net/network_attrs_extractor.go
+++ b/pkg/inst-api-semconv/instrumenter/net/network_attrs_extractor.go
@@ -5,6 +5,7 @@ package net
 
 import (
 	"context"
+
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 )
@@ -13,17 +14,21 @@ type NetworkAttrsExtractor[REQUEST any, RESPONSE any] struct {
 	internalExtractor InternalNetworkAttributesExtractor[REQUEST, RESPONSE]
 }
 
-func (i *NetworkAttrsExtractor[REQUEST, RESPONSE]) OnStart(parentContext context.Context,
-	attributes []attribute.KeyValue, request REQUEST) ([]attribute.KeyValue, context.Context) {
+func (_ *NetworkAttrsExtractor[REQUEST, RESPONSE]) OnStart(parentContext context.Context,
+	attributes []attribute.KeyValue, _ REQUEST,
+) ([]attribute.KeyValue, context.Context) {
 	return attributes, parentContext
 }
 
 func (i *NetworkAttrsExtractor[REQUEST, RESPONSE]) OnEnd(context context.Context, attributes []attribute.KeyValue,
-	request REQUEST, response RESPONSE, err error) ([]attribute.KeyValue, context.Context) {
+	request REQUEST, response RESPONSE, _ error,
+) ([]attribute.KeyValue, context.Context) {
 	return i.internalExtractor.OnEnd(context, attributes, request, response)
 }
 
-func CreateNetworkAttributesExtractor[REQUEST any, RESPONSE any](getter NetworkAttrsGetter[REQUEST, RESPONSE]) NetworkAttrsExtractor[REQUEST, RESPONSE] {
+func CreateNetworkAttributesExtractor[REQUEST any, RESPONSE any](
+	getter NetworkAttrsGetter[REQUEST, RESPONSE],
+) NetworkAttrsExtractor[REQUEST, RESPONSE] {
 	return NetworkAttrsExtractor[REQUEST, RESPONSE]{
 		internalExtractor: InternalNetworkAttributesExtractor[REQUEST, RESPONSE]{
 			getter:                       getter,
@@ -33,28 +38,30 @@ func CreateNetworkAttributesExtractor[REQUEST any, RESPONSE any](getter NetworkA
 	}
 }
 
-type UrlAttrsExtractor[REQUEST any, RESPONSE any, GETTER UrlAttrsGetter[REQUEST]] struct {
+type URLAttrsExtractor[REQUEST any, RESPONSE any, GETTER URLAttrsGetter[REQUEST]] struct {
 	Getter GETTER
 }
 
-func (u *UrlAttrsExtractor[REQUEST, RESPONSE, GETTER]) OnStart(parentContext context.Context,
-	attributes []attribute.KeyValue, request REQUEST) ([]attribute.KeyValue, context.Context) {
+func (u *URLAttrsExtractor[REQUEST, RESPONSE, GETTER]) OnStart(parentContext context.Context,
+	attributes []attribute.KeyValue, request REQUEST,
+) ([]attribute.KeyValue, context.Context) {
 	attributes = append(attributes, attribute.KeyValue{
 		Key:   semconv.URLSchemeKey,
-		Value: attribute.StringValue(u.Getter.GetUrlScheme(request)),
+		Value: attribute.StringValue(u.Getter.GetURLScheme(request)),
 	}, attribute.KeyValue{
 		Key:   semconv.URLPathKey,
-		Value: attribute.StringValue(u.Getter.GetUrlPath(request)),
+		Value: attribute.StringValue(u.Getter.GetURLPath(request)),
 	}, attribute.KeyValue{
 		Key:   semconv.URLQueryKey,
-		Value: attribute.StringValue(u.Getter.GetUrlQuery(request)),
+		Value: attribute.StringValue(u.Getter.GetURLQuery(request)),
 	})
 	return attributes, parentContext
 }
 
-func (u *UrlAttrsExtractor[REQUEST, RESPONSE, GETTER]) OnEnd(context context.Context,
-	attributes []attribute.KeyValue, request REQUEST,
-	response RESPONSE, err error) ([]attribute.KeyValue, context.Context) {
+func (_ *URLAttrsExtractor[REQUEST, RESPONSE, GETTER]) OnEnd(context context.Context,
+	attributes []attribute.KeyValue, _ REQUEST,
+	_ RESPONSE, _ error,
+) ([]attribute.KeyValue, context.Context) {
 	return attributes, context
 }
 
@@ -63,16 +70,20 @@ type ServerAttributesExtractor[REQUEST any, RESPONSE any] struct {
 }
 
 func (s *ServerAttributesExtractor[REQUEST, RESPONSE]) OnStart(parentContext context.Context, attributes []attribute.
-	KeyValue, request REQUEST) ([]attribute.KeyValue, context.Context) {
+	KeyValue, request REQUEST,
+) ([]attribute.KeyValue, context.Context) {
 	return s.internalExtractor.OnStart(parentContext, attributes, request)
 }
 
-func (s *ServerAttributesExtractor[REQUEST, RESPONSE]) OnEnd(ctx context.Context, attributes []attribute.KeyValue,
-	request REQUEST, response RESPONSE, err error) ([]attribute.KeyValue, context.Context) {
+func (_ *ServerAttributesExtractor[REQUEST, RESPONSE]) OnEnd(ctx context.Context, attributes []attribute.KeyValue,
+	_ REQUEST, _ RESPONSE, _ error,
+) ([]attribute.KeyValue, context.Context) {
 	return attributes, ctx
 }
 
-func CreateServerAttributesExtractor[REQUEST any, RESPONSE any](getter ServerAttributesGetter[REQUEST]) ServerAttributesExtractor[REQUEST, RESPONSE] {
+func CreateServerAttributesExtractor[REQUEST any, RESPONSE any](
+	getter ServerAttributesGetter[REQUEST],
+) ServerAttributesExtractor[REQUEST, RESPONSE] {
 	return ServerAttributesExtractor[REQUEST, RESPONSE]{
 		internalExtractor: InternalServerAttributesExtractor[REQUEST]{
 			addressAndPortExtractor: &ServerAddressAndPortExtractor[REQUEST]{
@@ -88,17 +99,22 @@ type ClientAttributesExtractor[REQUEST any, RESPONSE any] struct {
 }
 
 func (s *ClientAttributesExtractor[REQUEST, RESPONSE]) OnStart(parentContext context.Context,
-	attributes []attribute.KeyValue, request REQUEST) ([]attribute.KeyValue, context.Context) {
+	attributes []attribute.KeyValue, request REQUEST,
+) ([]attribute.KeyValue, context.Context) {
 	return s.internalExtractor.OnStart(parentContext, attributes, request)
 }
 
-func (s *ClientAttributesExtractor[REQUEST, RESPONSE]) OnEnd(ctx context.Context, attributes []attribute.KeyValue,
-	request REQUEST,
-	response RESPONSE, err error) ([]attribute.KeyValue, context.Context) {
+func (_ *ClientAttributesExtractor[REQUEST, RESPONSE]) OnEnd(ctx context.Context, attributes []attribute.KeyValue,
+	_ REQUEST,
+	_ RESPONSE,
+	_ error,
+) ([]attribute.KeyValue, context.Context) {
 	return attributes, ctx
 }
 
-func CreateClientAttributesExtractor[REQUEST any, RESPONSE any](getter ClientAttributesGetter[REQUEST]) ClientAttributesExtractor[REQUEST, RESPONSE] {
+func CreateClientAttributesExtractor[REQUEST any, RESPONSE any](
+	getter ClientAttributesGetter[REQUEST],
+) ClientAttributesExtractor[REQUEST, RESPONSE] {
 	return ClientAttributesExtractor[REQUEST, RESPONSE]{
 		internalExtractor: InternalClientAttributesExtractor[REQUEST]{
 			addressAndPortExtractor: &ClientAddressAndPortExtractor[REQUEST]{

--- a/pkg/inst-api-semconv/instrumenter/net/network_attrs_extractor_test.go
+++ b/pkg/inst-api-semconv/instrumenter/net/network_attrs_extractor_test.go
@@ -5,36 +5,37 @@ package net
 
 import (
 	"context"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
-	"testing"
 )
 
-type MockUrlGetter struct{}
+type MockURLGetter struct{}
 
-func (m *MockUrlGetter) GetUrlScheme(request any) string {
+func (*MockURLGetter) GetURLScheme(_ any) string {
 	return "http"
 }
 
-func (m *MockUrlGetter) GetUrlPath(request any) string {
+func (*MockURLGetter) GetURLPath(_ any) string {
 	return "/test"
 }
 
-func (m *MockUrlGetter) GetUrlQuery(request any) string {
+func (*MockURLGetter) GetURLQuery(_ any) string {
 	return "key=value"
 }
 
 func TestOnStart(t *testing.T) {
-	mockGetter := &MockUrlGetter{}
-	urlExtractor := &UrlAttrsExtractor[any, any, *MockUrlGetter]{
+	mockGetter := &MockURLGetter{}
+	urlExtractor := &URLAttrsExtractor[any, any, *MockURLGetter]{
 		Getter: mockGetter,
 	}
 	parentContext := context.Background()
 	attributes := []attribute.KeyValue{
 		attribute.String("existingKey", "existingValue"),
 	}
-	urlExtractor.OnEnd(context.Background(), []attribute.KeyValue{}, nil, nil, nil)
+	urlExtractor.OnEnd(context.Background(), make([]attribute.KeyValue, 0), nil, nil, nil)
 	resultAttributes, resultContext := urlExtractor.OnStart(parentContext, attributes, nil)
 	expectedAttributes := []attribute.KeyValue{
 		attribute.String("existingKey", "existingValue"),

--- a/pkg/inst-api-semconv/instrumenter/net/network_attrs_getter.go
+++ b/pkg/inst-api-semconv/instrumenter/net/network_attrs_getter.go
@@ -24,8 +24,8 @@ type ServerAttributesGetter[REQUEST any] interface {
 	GetServerPort(request REQUEST) int
 }
 
-type UrlAttrsGetter[REQUEST any] interface {
-	GetUrlScheme(request REQUEST) string
-	GetUrlPath(request REQUEST) string
-	GetUrlQuery(request REQUEST) string
+type URLAttrsGetter[REQUEST any] interface {
+	GetURLScheme(request REQUEST) string
+	GetURLPath(request REQUEST) string
+	GetURLQuery(request REQUEST) string
 }

--- a/pkg/inst-api-semconv/instrumenter/utils/metric_utils.go
+++ b/pkg/inst-api-semconv/instrumenter/utils/metric_utils.go
@@ -6,16 +6,13 @@ package utils
 import (
 	"errors"
 	"fmt"
+
 	"go.opentelemetry.io/otel/metric"
-	"sync"
 )
 
-var mu sync.Mutex
-
 func NewFloat64Histogram(metricName, metricUnit, metricDescription string,
-	meter metric.Meter) (metric.Float64Histogram, error) {
-	mu.Lock()
-	defer mu.Unlock()
+	meter metric.Meter,
+) (metric.Float64Histogram, error) {
 	if meter == nil {
 		return nil, errors.New("nil meter")
 	}
@@ -24,7 +21,6 @@ func NewFloat64Histogram(metricName, metricUnit, metricDescription string,
 		metric.WithDescription(metricDescription))
 	if err == nil {
 		return d, nil
-	} else {
-		return d, fmt.Errorf("failed to create %s histogram, %v", metricName, err)
 	}
+	return d, fmt.Errorf("failed to create %s histogram, %w", metricName, err)
 }

--- a/pkg/inst-api-semconv/instrumenter/utils/metric_utils_test.go
+++ b/pkg/inst-api-semconv/instrumenter/utils/metric_utils_test.go
@@ -5,11 +5,12 @@ package utils
 
 import (
 	"context"
+	"testing"
+
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
-	"testing"
 )
 
 func TestNewFloat64Histogram(t *testing.T) {
@@ -23,13 +24,13 @@ func TestNewFloat64Histogram(t *testing.T) {
 	meter := mp.Meter("test-meter")
 	server, err := NewFloat64Histogram("test", "ms", "test metric", meter)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	ctx := context.Background()
 	server.Record(ctx, 1.0)
 	rm := &metricdata.ResourceMetrics{}
 	_ = reader.Collect(ctx, rm)
 	if rm.ScopeMetrics[0].Metrics[0].Name != "test" {
-		panic("wrong metrics name, " + rm.ScopeMetrics[0].Metrics[0].Name)
+		t.Fatal("wrong metrics name, " + rm.ScopeMetrics[0].Metrics[0].Name)
 	}
 }

--- a/pkg/inst-api-semconv/instrumenter/utils/metrics_shadower.go
+++ b/pkg/inst-api-semconv/instrumenter/utils/metrics_shadower.go
@@ -13,16 +13,11 @@ So we use this function to shadow the attributes that are not needed in the metr
 */
 
 func Shadow(attrs []attribute.KeyValue, metricsSemConv map[attribute.Key]bool) (int, []attribute.KeyValue) {
-	swap := func(attrs []attribute.KeyValue, i, j int) {
-		tmp := attrs[i]
-		attrs[i] = attrs[j]
-		attrs[j] = tmp
-	}
 	index := 0
 	for i, attr := range attrs {
 		if _, ok := metricsSemConv[attr.Key]; ok {
 			if index != i {
-				swap(attrs, i, index)
+				attrs[i], attrs[index] = attrs[index], attrs[i]
 			}
 			index++
 		}

--- a/pkg/inst-api-semconv/instrumenter/utils/metrics_shadower_test.go
+++ b/pkg/inst-api-semconv/instrumenter/utils/metrics_shadower_test.go
@@ -4,14 +4,15 @@
 package utils
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
-	"testing"
 )
 
 func TestShadowEmptyInputReturnsZeroAndEmptySlice(t *testing.T) {
-	attrs := []attribute.KeyValue{}
-	metricsSemConv := map[attribute.Key]bool{}
+	attrs := make([]attribute.KeyValue, 0)
+	metricsSemConv := make(map[attribute.Key]bool)
 	index, result := Shadow(attrs, metricsSemConv)
 	assert.Equal(t, 0, index)
 	assert.Empty(t, result)
@@ -22,7 +23,7 @@ func TestShadowNoMatchingKeysReturnsZeroAndUnchangedSlice(t *testing.T) {
 		attribute.String("key1", "value1"),
 		attribute.String("key2", "value2"),
 	}
-	metricsSemConv := map[attribute.Key]bool{}
+	metricsSemConv := make(map[attribute.Key]bool)
 	index, result := Shadow(attrs, metricsSemConv)
 	assert.Equal(t, 0, index)
 	assert.Equal(t, attrs, result)

--- a/pkg/inst-api-semconv/instrumenter/utils/span_key.go
+++ b/pkg/inst-api-semconv/instrumenter/utils/span_key.go
@@ -5,7 +5,9 @@ package utils
 
 import "go.opentelemetry.io/otel/attribute"
 
-const HTTP_CLIENT_KEY = attribute.Key("opentelemetry-traces-span-key-http-client")
-const HTTP_SERVER_KEY = attribute.Key("opentelemetry-traces-span-key-http-server")
+const (
+	HTTPClientKey = attribute.Key("opentelemetry-traces-span-key-http-client")
+	HTTPServerKey = attribute.Key("opentelemetry-traces-span-key-http-server")
 
-const CLIENT_RESEND_KEY = attribute.Key("opentelemetry-http-client-resend-key")
+	ClientResendKey = attribute.Key("opentelemetry-http-client-resend-key")
+)

--- a/pkg/inst-api/extractor.go
+++ b/pkg/inst-api/extractor.go
@@ -5,6 +5,7 @@ package instrumenter
 
 import (
 	"context"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -33,45 +34,44 @@ type SpanKeyProvider interface {
 	GetSpanKey() attribute.Key
 }
 
-type AlwaysInternalExtractor[REQUEST any] struct {
-}
+type AlwaysInternalExtractor[REQUEST any] struct{}
 
-func (a *AlwaysInternalExtractor[any]) Extract(request any) trace.SpanKind {
+func (_ *AlwaysInternalExtractor[any]) Extract(_ any) trace.SpanKind {
 	return trace.SpanKindInternal
 }
 
-type AlwaysClientExtractor[REQUEST any] struct {
-}
+type AlwaysClientExtractor[REQUEST any] struct{}
 
-func (a *AlwaysClientExtractor[any]) Extract(request any) trace.SpanKind {
+func (_ *AlwaysClientExtractor[any]) Extract(_ any) trace.SpanKind {
 	return trace.SpanKindClient
 }
 
-type AlwaysServerExtractor[REQUEST any] struct {
-}
+type AlwaysServerExtractor[REQUEST any] struct{}
 
-func (a *AlwaysServerExtractor[any]) Extract(request any) trace.SpanKind {
+func (_ *AlwaysServerExtractor[any]) Extract(_ any) trace.SpanKind {
 	return trace.SpanKindServer
 }
 
-type AlwaysProducerExtractor[REQUEST any] struct {
-}
+type AlwaysProducerExtractor[request any] struct{}
 
-func (a *AlwaysProducerExtractor[any]) Extract(request any) trace.SpanKind {
+func (_ *AlwaysProducerExtractor[any]) Extract(_ any) trace.SpanKind {
 	return trace.SpanKindProducer
 }
 
-type AlwaysConsumerExtractor[REQUEST any] struct {
-}
+type AlwaysConsumerExtractor[request any] struct{}
 
-func (a *AlwaysConsumerExtractor[any]) Extract(request any) trace.SpanKind {
+func (_ *AlwaysConsumerExtractor[any]) Extract(_ any) trace.SpanKind {
 	return trace.SpanKindConsumer
 }
 
-type defaultSpanStatusExtractor[REQUEST any, RESPONSE any] struct {
-}
+type defaultSpanStatusExtractor[request any, response any] struct{}
 
-func (d *defaultSpanStatusExtractor[REQUEST, RESPONSE]) Extract(span trace.Span, request REQUEST, response RESPONSE, err error) {
+func (*defaultSpanStatusExtractor[REQUEST, RESPONSE]) Extract(
+	span trace.Span,
+	_ REQUEST,
+	_ RESPONSE,
+	err error,
+) {
 	if err != nil {
 		span.SetStatus(codes.Error, "")
 	}

--- a/pkg/inst-api/extractor_test.go
+++ b/pkg/inst-api/extractor_test.go
@@ -17,7 +17,7 @@ type testSpan struct {
 	status *codes.Code
 }
 
-func (ts testSpan) SetStatus(status codes.Code, desc string) {
+func (ts testSpan) SetStatus(status codes.Code, _ string) {
 	*ts.status = status
 }
 

--- a/pkg/inst-api/hook.go
+++ b/pkg/inst-api/hook.go
@@ -23,7 +23,7 @@ type AttrsShadower interface {
 
 type NoopAttrsShadower struct{}
 
-func (n NoopAttrsShadower) Shadow(attrs []attribute.KeyValue) (int, []attribute.KeyValue) {
+func (NoopAttrsShadower) Shadow(attrs []attribute.KeyValue) (int, []attribute.KeyValue) {
 	return len(attrs), attrs
 }
 

--- a/pkg/inst-api/hook_test.go
+++ b/pkg/inst-api/hook_test.go
@@ -5,7 +5,6 @@ package instrumenter
 
 import (
 	"context"
-	"log"
 	"testing"
 	"time"
 
@@ -26,16 +25,20 @@ func (t *testListener) OnBeforeStart(parentContext context.Context, startTimesta
 	return context.WithValue(parentContext, testKey("test1"), "a")
 }
 
-func (t *testListener) OnBeforeEnd(ctx context.Context, startAttributes []attribute.KeyValue, startTimestamp time.Time) context.Context {
+func (t *testListener) OnBeforeEnd(
+	ctx context.Context,
+	startAttributes []attribute.KeyValue,
+	_ time.Time,
+) context.Context {
 	t.startAttributes = startAttributes
 	return context.WithValue(ctx, testKey("test2"), "a")
 }
 
-func (t *testListener) OnAfterStart(context context.Context, endTimestamp time.Time) {
+func (t *testListener) OnAfterStart(_ context.Context, endTimestamp time.Time) {
 	t.endTime = endTimestamp
 }
 
-func (t *testListener) OnAfterEnd(context context.Context, endAttributes []attribute.KeyValue, endTimestamp time.Time) {
+func (t *testListener) OnAfterEnd(_ context.Context, endAttributes []attribute.KeyValue, _ time.Time) {
 	t.endAttributes = endAttributes
 }
 
@@ -50,11 +53,11 @@ func TestShadower(t *testing.T) {
 	n := NoopAttrsShadower{}
 	num, newAttrs := n.Shadow(originAttrs)
 	if num != len(originAttrs) {
-		log.Fatal("origin attrs length is not equal to new attrs length")
+		t.Fatal("origin attrs length is not equal to new attrs length")
 	}
-	for i := 0; i < num; i++ {
+	for i := range num {
 		if newAttrs[i].Value != originAttrs[i].Value {
-			log.Fatal("origin attrs value is not equal to new attrs value")
+			t.Fatal("origin attrs value is not equal to new attrs value")
 		}
 	}
 }
@@ -63,10 +66,10 @@ func TestOnBeforeStart(t *testing.T) {
 	w := &testListener{}
 	newCtx := w.OnBeforeStart(context.Background(), time.UnixMilli(123412341234))
 	if w.startTime.UnixMilli() != 123412341234 {
-		log.Fatal("start time is not equal to new start time")
+		t.Fatal("start time is not equal to new start time")
 	}
 	if newCtx.Value(testKey("test1")) != "a" {
-		log.Fatal("key test1 is not equal to new key value")
+		t.Fatal("key test1 is not equal to new key value")
 	}
 }
 
@@ -77,10 +80,10 @@ func TestOnBeforeEnd(t *testing.T) {
 		Value: attribute.StringValue("abcde"),
 	}}, time.UnixMilli(123412341234))
 	if w.startAttributes[0].Key != "123" {
-		log.Fatal("start attribute key is not equal to new start attribute key")
+		t.Fatal("start attribute key is not equal to new start attribute key")
 	}
 	if w.startAttributes[0].Value.AsString() != "abcde" {
-		log.Fatal("start attribute value is not equal to new start attribute value")
+		t.Fatal("start attribute value is not equal to new start attribute value")
 	}
 }
 
@@ -88,7 +91,7 @@ func TestOnAfterStart(t *testing.T) {
 	w := &testListener{}
 	w.OnAfterStart(context.Background(), time.UnixMilli(123412341234))
 	if w.endTime.UnixMilli() != 123412341234 {
-		log.Fatal("start time is not equal to new start time")
+		t.Fatal("start time is not equal to new start time")
 	}
 }
 
@@ -99,9 +102,9 @@ func TestOnAfterEnd(t *testing.T) {
 		Value: attribute.StringValue("abcde"),
 	}}, time.UnixMilli(123412341234))
 	if w.endAttributes[0].Key != "123" {
-		log.Fatal("start attribute key is not equal to new start attribute key")
+		t.Fatal("start attribute key is not equal to new start attribute key")
 	}
 	if w.endAttributes[0].Value.AsString() != "abcde" {
-		log.Fatal("start attribute value is not equal to new start attribute value")
+		t.Fatal("start attribute value is not equal to new start attribute value")
 	}
 }


### PR DESCRIPTION
Greenfield projects benefit from strict standards from day one.
- Enabled several linters with proper golangci-lint v2 configuration
- Refactored all global variables using Registry pattern
- Fixed all issues
- Added formatters: gofumpt, goimports, golines

Clean codebase with high standards prevents technical debt.

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>
