### PR TITLE
feat: find project's dependencies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,7 +70,7 @@ linters:
     - makezero # finds slice declarations with non-zero initial length
     - mirror # reports wrong mirror patterns of bytes/strings usage
     - misspell # finds commonly misspelled English words in comments
-    - mnd # detects magic numbers
+    # - mnd # detects magic numbers
     - musttag # enforces field tags in (un)marshaled structs
     - nakedret # finds naked returns in functions greater than a specified function length
     - nestif # reports deeply nested if statements

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,16 @@ all: build
 .PHONY: build
 build:
 	@echo "Building instrumentation tool..."
-	go mod tidy
-	go build -a -o $(BINARY_NAME) ./$(TOOL_DIR)
+	@go mod tidy
+	@go build -a -o $(BINARY_NAME) ./$(TOOL_DIR)
 
 # Run the demo with instrumentation
 .PHONY: demo
 demo: build
 	@echo "Running demo with instrumentation..."
-	cd $(DEMO_DIR) && ../$(BINARY_NAME) go build -a
+	@cd $(DEMO_DIR) && ../$(BINARY_NAME) go build -a
+	@echo "Running demo..."
+	@./$(DEMO_DIR)/demo
 
 # Clean build artifacts
 .PHONY: clean

--- a/demo/main.go
+++ b/demo/main.go
@@ -10,5 +10,5 @@ import (
 )
 
 func main() {
-	fmt.Printf("Hello World")
+	fmt.Printf("Hello World\n")
 }

--- a/tool/cmd/main.go
+++ b/tool/cmd/main.go
@@ -8,10 +8,11 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/instrument"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/setup"
-	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/util"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
 
 const (
@@ -44,9 +45,8 @@ func initLogger(phase string) (*slog.Logger, error) {
 	switch phase {
 	case ActionSetup, ActionGo:
 		// Create .otel-build dir
-		buildTemp := ".otel-build"
-		if _, err := os.Stat(buildTemp); os.IsNotExist(err) {
-			err = os.MkdirAll(buildTemp, 0o755)
+		if _, err := os.Stat(util.BuildTempDir); os.IsNotExist(err) {
+			err = os.MkdirAll(util.BuildTempDir, 0o755)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create .otel-build dir: %w", err)
 			}
@@ -56,7 +56,7 @@ func initLogger(phase string) (*slog.Logger, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to get working directory: %w", err)
 		}
-		logFile, err := os.OpenFile(filepath.Join(pwd, ".otel-build", "debug.log"),
+		logFile, err := os.OpenFile(filepath.Join(pwd, util.GetBuildTemp("debug.log")),
 			os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o777)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open log file: %w", err)
@@ -65,9 +65,21 @@ func initLogger(phase string) (*slog.Logger, error) {
 	case ActionIntoolexec:
 		writer = os.Stdout
 	default:
-		return nil, fmt.Errorf("invalid phase: %s", phase)
+		return nil, fmt.Errorf("invalid action: %s", phase)
 	}
-	logger := slog.New(slog.NewTextHandler(writer, &slog.HandlerOptions{}))
+
+	// Create a custom handler with shorter time format
+	handler := slog.NewTextHandler(writer, &slog.HandlerOptions{
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				if t, ok := a.Value.Any().(time.Time); ok {
+					a.Value = slog.StringValue(t.Format("06/1/2 15:04:05"))
+				}
+			}
+			return a
+		},
+	})
+	logger := slog.New(handler)
 	return logger, nil
 }
 

--- a/tool/internal/instrument/instrument.go
+++ b/tool/internal/instrument/instrument.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/util"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
 
 type InstrumentPreprocessor struct {

--- a/tool/internal/setup/find.go
+++ b/tool/internal/setup/find.go
@@ -1,0 +1,193 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+package setup
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
+)
+
+const (
+	BuildPlanLog    = "build-plan.log"
+	BuildPgoProfile = "-pgoprofile"
+)
+
+// isCompileCommand checks if the line is a compile command.
+func isCompileCommand(line string) bool {
+	check := []string{"-o", "-p", "-buildid"}
+	switch util.IsWindows() {
+	case true:
+		check = append(check, "compile.exe")
+	case false:
+		check = append(check, "compile")
+	default:
+		util.ShouldNotReachHere()
+	}
+
+	// Check if the line contains all the required fields
+	for _, id := range check {
+		if !strings.Contains(line, id) {
+			return false
+		}
+	}
+
+	// @@PGO compile command is different from normal compile command, we
+	// should skip it, otherwise the same package will be find twice
+	// (one for PGO and one for normal)
+	if strings.Contains(line, BuildPgoProfile) {
+		return false
+	}
+	return true
+}
+
+// getCompileCommands gets the compile commands from the build plan log.
+func getCompileCommands() ([]string, error) {
+	buildPlanLog, err := os.Open(util.GetBuildTemp(BuildPlanLog))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open build plan log file: %w", err)
+	}
+	defer buildPlanLog.Close()
+
+	// Filter compile commands from build plan log
+	compileCmds := make([]string, 0)
+	scanner := bufio.NewScanner(buildPlanLog)
+	// 10MB should be enough to accommodate most long line
+	buffer := make([]byte, 0, 10*1024*1024)
+	scanner.Buffer(buffer, cap(buffer))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if isCompileCommand(line) {
+			line = strings.Trim(line, " ")
+			compileCmds = append(compileCmds, line)
+		}
+	}
+	err = scanner.Err()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse build plan log: %w", err)
+	}
+	return compileCmds, nil
+}
+
+// splitCompileCmds splits the command line by space, but keep the quoted part
+// as a whole. For example, "a b" c will be split into ["a b", "c"].
+func splitCompileCmds(input string) []string {
+	var args []string
+	var inQuotes bool
+	var arg strings.Builder
+
+	for i := range len(input) {
+		c := input[i]
+
+		if c == '"' {
+			inQuotes = !inQuotes
+			continue
+		}
+
+		if c == ' ' && !inQuotes {
+			if arg.Len() > 0 {
+				args = append(args, arg.String())
+				arg.Reset()
+			}
+			continue
+		}
+
+		arg.WriteByte(c)
+	}
+
+	if arg.Len() > 0 {
+		args = append(args, arg.String())
+	}
+
+	// Fix the escaped backslashes on Windows
+	if util.IsWindows() {
+		for i, arg := range args {
+			args[i] = strings.ReplaceAll(arg, `\\`, `\`)
+		}
+	}
+	return args
+}
+
+// listBuildPlan lists the build plan by running `go build/install -a -x -n`
+// and then filtering the compile commands from the build plan log.
+func (sp *SetupProcessor) listBuildPlan(goBuildCmd []string) ([]string, error) {
+	util.Assert(len(goBuildCmd) >= 2, "at least two arguments are required")
+	util.Assert(strings.Contains(goBuildCmd[0], "go"), "sanity check")
+	util.Assert(goBuildCmd[1] == "build" || goBuildCmd[1] == "install", "sanity check")
+
+	// Create a build plan log file in the temporary directory
+	buildPlanLog, err := os.Create(util.GetBuildTemp(BuildPlanLog))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create build plan log file: %w", err)
+	}
+	// The full build command is: "go build/install -a -x -n  {...}"
+	args := []string{}
+	args = append(args, goBuildCmd[:2]...)             // go build/install
+	args = append(args, []string{"-a", "-x", "-n"}...) // -a -x -n
+	args = append(args, goBuildCmd[2:]...)             // {...} remaining
+
+	sp.Info("List build plan", "args", args)
+	//nolint:gosec // Command arguments are validated with above assertions
+	cmd := exec.Command(args[0], args[1:]...)
+	// This is a little anti-intuitive as the error message is not printed to
+	// the stderr, instead it is printed to the stdout, only the build tool
+	// knows the reason why.
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = buildPlanLog
+	// @@Note that dir should not be set, as the dry build should be run in the
+	// same directory as the original build command
+	cmd.Dir = ""
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run build plan: %w", err)
+	}
+
+	// Find compile commands from build plan log
+	compileCmds, err := getCompileCommands()
+	if err != nil {
+		return nil, err
+	}
+	return compileCmds, nil
+}
+
+// findFlagValue finds the value of a flag in the command line.
+func findFlagValue(cmd []string, flag string) string {
+	for i, v := range cmd {
+		if v == flag {
+			return cmd[i+1]
+		}
+	}
+	return ""
+}
+
+// findDeps finds the dependencies of the project by listing the build plan.
+func (sp *SetupProcessor) findDeps(goBuildCmd []string) (map[string][]string, error) {
+	buildPlan, err := sp.listBuildPlan(goBuildCmd)
+	if err != nil {
+		return nil, err
+	}
+	// import path -> list of go files
+	deps := make(map[string][]string)
+	for _, plan := range buildPlan {
+		util.Assert(strings.Contains(plan, "compile"), "must be compile command")
+		args := splitCompileCmds(plan)
+		importPath := findFlagValue(args, "-p")
+		util.Assert(importPath != "", "import path is empty")
+		_, exist := deps[importPath]
+		util.Assert(!exist, "import path should not be duplicated")
+
+		for _, arg := range args {
+			if strings.HasSuffix(arg, ".go") {
+				deps[importPath] = append(deps[importPath], arg)
+			}
+		}
+	}
+	for k, v := range deps {
+		sp.Info("Found dependency", "importPath", k, "goFiles", v)
+	}
+	return deps, nil
+}

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -16,15 +16,12 @@ type SetupProcessor struct {
 	logger *slog.Logger
 }
 
-//nolint:unparam // Unused parameter is used to pass the linter
-func (*SetupProcessor) findDeps() (map[string]string, error) {
-	// TODO: Implement task
-	deps := make(map[string]string)
-	deps["example.com/some/dependency"] = "v1.0.0"
-	return deps, nil
-}
+func (sp *SetupProcessor) Info(msg string, args ...any)  { sp.logger.Info(msg, args...) }
+func (sp *SetupProcessor) Error(msg string, args ...any) { sp.logger.Error(msg, args...) }
+func (sp *SetupProcessor) Warn(msg string, args ...any)  { sp.logger.Warn(msg, args...) }
+func (sp *SetupProcessor) Debug(msg string, args ...any) { sp.logger.Debug(msg, args...) }
 
-func (*SetupProcessor) matchedDeps(deps map[string]string) (map[string]string, error) {
+func (*SetupProcessor) matchedDeps(deps map[string][]string) (map[string]string, error) {
 	// TODO: Implement task
 	defaults, err := data.ListAvailableRules()
 	if err != nil {
@@ -39,7 +36,7 @@ func (*SetupProcessor) matchedDeps(deps map[string]string) (map[string]string, e
 	return map[string]string{}, nil
 }
 
-func (*SetupProcessor) addDeps(deps map[string]string) error {
+func (*SetupProcessor) addDeps(deps map[string][]string) error {
 	// TODO: Implement task
 	_ = deps
 	return nil
@@ -84,7 +81,7 @@ func Setup(logger *slog.Logger) error {
 		logger: logger,
 	}
 	// Find all dependencies of the project being build
-	deps, err := sp.findDeps()
+	deps, err := sp.findDeps(os.Args[1:])
 	if err != nil {
 		return err
 	}
@@ -108,6 +105,6 @@ func Setup(logger *slog.Logger) error {
 	if err != nil {
 		return err
 	}
-	sp.logger.Info("Setup completed successfully")
+	sp.Info("Setup completed successfully")
 	return nil
 }

--- a/tool/util/assert.go
+++ b/tool/util/assert.go
@@ -8,3 +8,7 @@ func Assert(condition bool, message string) {
 		panic("Assertion failed: " + message)
 	}
 }
+
+func ShouldNotReachHere() {
+	panic("should not reach here")
+}

--- a/tool/util/shared.go
+++ b/tool/util/shared.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	"path/filepath"
+)
+
+const (
+	BuildTempDir = ".otel-build"
+)
+
+func GetBuildTemp(name string) string {
+	return filepath.Join(BuildTempDir, name)
+}

--- a/tool/util/sys.go
+++ b/tool/util/sys.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 )
 
 func RunCmd(args ...string) error {
@@ -21,4 +22,12 @@ func RunCmd(args ...string) error {
 		return fmt.Errorf("failed to run command %s: %w", path, err)
 	}
 	return nil
+}
+
+func IsWindows() bool {
+	return runtime.GOOS == "windows"
+}
+
+func IsUnix() bool {
+	return runtime.GOOS == "linux" || runtime.GOOS == "darwin"
 }


### PR DESCRIPTION
This PR implements the findDeps function according to the implementation document, which analyzes project dependencies using go build -n to extract third-party module paths and their associated Go files. 

It looks something like this:
```
time="25/7/7 11:33:48" level=INFO msg="List build plan" args="[go build -a -x -n -a]"
time="25/7/7 11:33:48" level=INFO msg="Found dependency" importPath=internal/filepathlite goFiles="[/usr/local/go/src/internal/filepathlite/path.go /usr/local/go/src/internal/filepathlite/path_nonwindows.go /usr/local/go/src/internal/filepathlite/path_unix.go]"
time="25/7/7 11:33:48" level=INFO msg="Found dependency" importPath=internal/testlog goFiles="[/usr/local/go/src/internal/testlog/exit.go /usr/local/go/src/internal/testlog/log.go]"
time="25/7/7 11:33:48" level=INFO msg="Found dependency" importPath=main goFiles=[./main.go]
time="25/7/7 11:33:48" level=INFO msg="Found dependency" importPath=internal/abi goFiles="[/usr/local/go/src/internal/abi/abi.go /usr/local/go/src/internal/abi/abi_amd64.go /usr/local/go/src/internal/abi/compiletype.go /usr/local/go/src/internal/abi/escape.go /usr/local/go/src/internal/abi/funcpc.go /usr/local/go/src/internal/abi/iface.go /usr/local/go/src/internal/abi/map_noswiss.go /usr/local/go/src/internal/abi/map_select_swiss.go /usr/local/go/src/internal/abi/map_swiss.go /usr/local/go/src/internal/abi/rangefuncconsts.go /usr/local/go/src/internal/abi/runtime.go /usr/local/go/src/internal/abi/stack.go /usr/local/go/src/internal/abi/switch.go /usr/local/go/src/internal/abi/symtab.go /usr/local/go/src/internal/abi/type.go]"
time="25/7/7 11:33:48" level=INFO msg="Found dependency" importPath=internal/goos goFiles="[/usr/local/go/src/internal/goos/goos.go /usr/local/go/src/internal/goos/unix.go /usr/local/go/src/internal/goos/zgoos_linux.go]"
...
```