### PR TITLE
refactor: simplify error handling chain

### DIFF
--- a/.github/tools/conventionalcommit/main.go
+++ b/.github/tools/conventionalcommit/main.go
@@ -26,12 +26,13 @@ import (
 
 var (
 	conventionalLabels = map[string]string{
-		"chore":   "conventional-commit/chore",
-		"doc":     "conventional-commit/chore",
-		"docs":    "conventional-commit/chore",
-		"feat":    "conventional-commit/feat",
-		"fix":     "conventional-commit/fix",
-		"release": "conventional-commit/chore",
+		"chore":    "conventional-commit/chore",
+		"doc":      "conventional-commit/chore",
+		"docs":     "conventional-commit/chore",
+		"feat":     "conventional-commit/feat",
+		"fix":      "conventional-commit/fix",
+		"release":  "conventional-commit/chore",
+		"refactor": "conventional-commit/refactor",
 	}
 	titleRegexp = regexp.MustCompile(fmt.Sprintf(`^(%s)(?:\(.+\))?!?: .*$`, strings.Join(slices.Collect(maps.Keys(conventionalLabels)), "|")))
 )

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,7 +106,7 @@ linters:
     - usetesting # reports uses of functions with replacement inside the testing package
     - wastedassign # finds wasted assignment statements
     - whitespace # detects leading and trailing whitespace
-    - wrapcheck # checks that errors returned from external packages are wrapped
+    # - wrapcheck # checks that errors returned from external packages are wrapped
 
     ## you may want to enable
     #- decorder # checks declaration order and count of types, constants, variables and functions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ This repository requires using one of the following commit types:
 - `feat` for introduction of new features
 - `fix` for bug fixes
 - `release` when cutting a new release
+- `refactor` for code changes that do not add new features or fix bugs
 
 Please try to keep the commit title concise, yet specific: they are used to derive the release notes
 for this repository. A good litmus test for whether a pull request title is suitable or not is to
@@ -68,10 +69,14 @@ Here are some examples for the various supported commit types:
     this.
   - :white_check_mark: `fix: SEGFAULT on when cross-compiling on linux/arm64 platforms`
   - :x: `fix: check pointer for nil before dereferencing it`
-- `release:
+- `release`:
   - :information_source: What version is this commit preparing for?
   - :white_check_mark: `release: v1.2.3`
   - :x: `release: new release`
+- `refactor`:
+  - :information_source: What code is being refactored?
+  - :white_check_mark: `refactor: remove unused code`
+  - :x: `refactor: improve code readability`
 
 [conv-commit]: https://www.conventionalcommits.org/en/v1.0.0/
 

--- a/tool/cmd/main.go
+++ b/tool/cmd/main.go
@@ -38,7 +38,7 @@ func buildWithToolexec(logger *slog.Logger, args []string) error {
 	logger.Info("Running go build with toolexec", "args", newArgs)
 	err = util.RunCmd(newArgs...)
 	if err != nil {
-		return ex.Errorf(err, "failed to run command")
+		return err
 	}
 	return nil
 }

--- a/tool/data/helloworld.yaml
+++ b/tool/data/helloworld.yaml
@@ -11,3 +11,4 @@ hook_helloworld:
   advice:
     - before: MyHookBefore
     - after: MyHookAfter
+xx

--- a/tool/internal/ast/shared.go
+++ b/tool/internal/ast/shared.go
@@ -8,16 +8,15 @@ import (
 	"go/token"
 
 	"github.com/dave/dst"
-	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 )
 
 func ListFuncDecls(file string) ([]*dst.FuncDecl, error) {
 	// Parse the file to get only all the function declarations
 	// So we can use fast variant of AST parsing
 	parser := NewAstParser()
-	root, parseErr := parser.ParseFileFast(file)
-	if parseErr != nil {
-		return nil, ex.Errorf(parseErr, "failed to parse file %s", file)
+	root, err := parser.ParseFileFast(file)
+	if err != nil {
+		return nil, err
 	}
 	funcDecls := make([]*dst.FuncDecl, 0)
 	for _, decl := range root.Decls {

--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -6,7 +6,6 @@ package instrument
 import (
 	"log/slog"
 
-	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
 
@@ -21,7 +20,7 @@ func Toolexec(logger *slog.Logger, args []string) error {
 	// Load matched hook rules from setup phase
 	err := ip.load()
 	if err != nil {
-		return ex.Error(err)
+		return err
 	}
 	// Check if the current package should be instrumented by matching the current
 	// command with list of matched rules
@@ -29,14 +28,14 @@ func Toolexec(logger *slog.Logger, args []string) error {
 		// Okay, this package should be instrumented.
 		err = ip.instrument(args)
 		if err != nil {
-			return ex.Error(err)
+			return err
 		}
 		return nil
 	}
 	// Otherwise, just run the command as is
 	err = util.RunCmd(args...)
 	if err != nil {
-		return ex.Errorf(err, "failed to run command")
+		return err
 	}
 	return nil
 }

--- a/tool/internal/setup/add.go
+++ b/tool/internal/setup/add.go
@@ -5,7 +5,6 @@ package setup
 
 import (
 	"github.com/dave/dst"
-	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/ast"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
 )
@@ -47,7 +46,7 @@ func (*SetupPhase) addDeps(matched []*rule.InstRule) error {
 	// Write the ast to file
 	err := ast.WriteFile(OtelRuntimeFile, root)
 	if err != nil {
-		return ex.Errorf(err, "failed to write ast to file %s", OtelRuntimeFile)
+		return err
 	}
 	return nil
 }

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -16,7 +16,7 @@ import (
 func parseEmbeddedRule(path string) ([]*rule.InstRule, error) {
 	yamlFile, err := data.ReadEmbedFile(path)
 	if err != nil {
-		return nil, ex.Errorf(err, "failed to open yaml file")
+		return nil, err
 	}
 	rules := make(map[string]*rule.InstRule)
 	err = yaml.NewDecoder(bytes.NewReader(yamlFile)).Decode(&rules)
@@ -34,9 +34,9 @@ func parseEmbeddedRule(path string) ([]*rule.InstRule, error) {
 func materalizeRules(availables []string) ([]*rule.InstRule, error) {
 	parsedRules := []*rule.InstRule{}
 	for _, available := range availables {
-		rs, parseErr := parseEmbeddedRule(available)
-		if parseErr != nil {
-			return nil, ex.Errorf(parseErr, "failed to parse rule")
+		rs, err := parseEmbeddedRule(available)
+		if err != nil {
+			return nil, err
 		}
 		parsedRules = append(parsedRules, rs...)
 	}
@@ -46,14 +46,14 @@ func materalizeRules(availables []string) ([]*rule.InstRule, error) {
 func (sp *SetupPhase) matchedDeps(deps []*Dependency) ([]*rule.InstRule, error) {
 	availables, err := data.ListAvailableRules()
 	if err != nil {
-		return nil, ex.Errorf(err, "failed to list available rules")
+		return nil, err
 	}
 	sp.Info("Available rules", "rules", availables)
 
 	// Construct the set of default rules by parsing embedded data
 	rules, err := materalizeRules(availables)
 	if err != nil {
-		return nil, ex.Errorf(err, "failed to materialize rules")
+		return nil, err
 	}
 
 	// Match the default rules with the found dependencies
@@ -72,7 +72,7 @@ func (sp *SetupPhase) matchedDeps(deps []*Dependency) ([]*rule.InstRule, error) 
 			for _, file := range dep.Sources {
 				funcDecls, parseErr := ast.ListFuncDecls(file)
 				if parseErr != nil {
-					return nil, ex.Errorf(parseErr, "failed to list func decls")
+					return nil, parseErr
 				}
 				for _, funcDecl := range funcDecls {
 					// Same function name?

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -68,27 +68,27 @@ func Setup(logger *slog.Logger) error {
 	// Find all dependencies of the project being build
 	deps, err := sp.findDeps(os.Args[1:])
 	if err != nil {
-		return ex.Error(err)
+		return err
 	}
 	// Match the hook code with these dependencies
 	matched, err := sp.matchedDeps(deps)
 	if err != nil {
-		return ex.Error(err)
+		return err
 	}
 	// Introduce additional hook code by generating otel.instrumentation.go
 	err = sp.addDeps(matched)
 	if err != nil {
-		return ex.Error(err)
+		return err
 	}
 	// Sync new dependencies to go.mod or vendor/modules.txt
 	err = sp.syncDeps(matched)
 	if err != nil {
-		return ex.Error(err)
+		return err
 	}
 	// Write the matched hook to matched.txt for further instrument phase
 	err = sp.store(matched)
 	if err != nil {
-		return ex.Error(err)
+		return err
 	}
 	sp.Info("Setup completed successfully")
 	return nil

--- a/tool/internal/setup/sync.go
+++ b/tool/internal/setup/sync.go
@@ -41,7 +41,7 @@ func writeGoMod(gomod string, modfile *modfile.File) error {
 func runModTidy() error {
 	err := util.RunCmd("go", "mod", "tidy")
 	if err != nil {
-		return ex.Errorf(err, "failed to run go mod tidy")
+		return err
 	}
 	return nil
 }
@@ -68,7 +68,7 @@ func (sp *SetupPhase) syncDeps(matched []*rule.InstRule) error {
 	const goModFile = "go.mod"
 	modfile, err := parseGoMod(goModFile)
 	if err != nil {
-		return ex.Error(err)
+		return err
 	}
 	changed := false
 	// Add matched dependencies to go.mod
@@ -82,7 +82,7 @@ func (sp *SetupPhase) syncDeps(matched []*rule.InstRule) error {
 		replacePath = filepath.Join("..", replacePath)
 		added, addErr := addReplace(modfile, m.Path, "", replacePath, "")
 		if addErr != nil {
-			return ex.Error(addErr)
+			return addErr
 		}
 		changed = changed || added
 		if changed {
@@ -95,7 +95,7 @@ func (sp *SetupPhase) syncDeps(matched []*rule.InstRule) error {
 	// Add special pkg module to go.mod
 	added, addErr := addReplace(modfile, util.OtelRoot+"/pkg", "", "../pkg", "")
 	if addErr != nil {
-		return ex.Error(addErr)
+		return addErr
 	}
 	changed = changed || added
 	if changed {
@@ -104,11 +104,11 @@ func (sp *SetupPhase) syncDeps(matched []*rule.InstRule) error {
 	if changed {
 		err = writeGoMod(goModFile, modfile)
 		if err != nil {
-			return ex.Errorf(err, "failed to write go.mod file")
+			return err
 		}
 		err = runModTidy()
 		if err != nil {
-			return ex.Errorf(err, "failed to run go mod tidy")
+			return err
 		}
 		sp.recordModified(goModFile)
 	}


### PR DESCRIPTION
This patch simplifies the error handling chain. We only need to create the error at its source, where its stack trace is automatically recorded. The error can be propagated up the entire call stack. 

If a caller along the error chain wishes to add more information, they can still wrap the error using ex.Errorf.