### PR TITLE
feat: instrument.load matched rules from setup phase

### DIFF
--- a/tool/cmd/main.go
+++ b/tool/cmd/main.go
@@ -21,6 +21,7 @@ const (
 	ActionGo         = "go"
 	ActionIntoolexec = "toolexec"
 	ActionVersion    = "version"
+	DebugLog         = "debug.log"
 )
 
 func cleanBuildTemp() {
@@ -40,14 +41,14 @@ func initLogger(phase string) (*slog.Logger, error) {
 			}
 		}
 		// Configure slog to write to the debug.log file
-		path := util.GetBuildTemp("debug.log")
+		path := util.GetBuildTemp(DebugLog)
 		logFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o777)
 		if err != nil {
 			return nil, ex.Errorf(err, "failed to open log file")
 		}
 		writer = logFile
 	case ActionIntoolexec:
-		path := util.GetBuildTemp("debug.log")
+		path := util.GetBuildTemp(DebugLog)
 		logFile, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o777)
 		if err != nil {
 			return nil, ex.Errorf(err, "failed to open log file")

--- a/tool/data/export.go
+++ b/tool/data/export.go
@@ -12,7 +12,7 @@ import (
 //go:embed *.yaml
 var dataFs embed.FS
 
-func ListAvailableRules() ([]string, error) {
+func ListEmbedFiles() ([]string, error) {
 	rules, err := dataFs.ReadDir(".")
 	if err != nil {
 		return nil, ex.Errorf(err, "failed to read directory")

--- a/tool/data/helloworld.yaml
+++ b/tool/data/helloworld.yaml
@@ -11,4 +11,3 @@ hook_helloworld:
   advice:
     - before: MyHookBefore
     - after: MyHookAfter
-xx

--- a/tool/ex/wrap.go
+++ b/tool/ex/wrap.go
@@ -48,17 +48,7 @@ func getFrames() []string {
 }
 
 func Error(previousErr error) error {
-	se := &stackfulError{}
-	if errors.As(previousErr, &se) {
-		se.message = append(se.message, previousErr.Error())
-		return previousErr
-	}
-	e := &stackfulError{
-		message: []string{previousErr.Error()},
-		frame:   getFrames(),
-		wrapped: previousErr,
-	}
-	return e
+	return Errorf(previousErr, "")
 }
 
 // Errorf wraps an error with stack trace information and a formatted message
@@ -69,8 +59,13 @@ func Errorf(previousErr error, format string, args ...any) error {
 		se.message = append(se.message, fmt.Sprintf(format, args...))
 		return previousErr
 	}
+	// User defined error message + existing error message
+	errMsg := fmt.Sprintf(format, args...)
+	if previousErr != nil {
+		errMsg = fmt.Sprintf("%s: %s", errMsg, previousErr.Error())
+	}
 	e := &stackfulError{
-		message: []string{fmt.Sprintf(format, args...)},
+		message: []string{errMsg},
 		frame:   getFrames(),
 		wrapped: previousErr,
 	}

--- a/tool/internal/instrument/load.go
+++ b/tool/internal/instrument/load.go
@@ -3,7 +3,32 @@
 
 package instrument
 
-func (*InstrumentPhase) load() error {
-	// TODO: Implement task
-	return nil
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
+)
+
+// load loads the matched rules from the build temp directory.
+// TODO: Shared memory across all sub-processes is possible
+func (ip *InstrumentPhase) load() ([]*rule.InstRule, error) {
+	f := util.GetMatchedRuleFile()
+	content, err := os.ReadFile(f)
+	if err != nil {
+		return nil, ex.Errorf(err, "failed to read file %s", f)
+	}
+	if len(content) == 0 {
+		return nil, nil
+	}
+
+	rules := make([]*rule.InstRule, 0)
+	err = json.Unmarshal(content, &rules)
+	if err != nil {
+		return nil, ex.Errorf(err, "failed to unmarshal rules from file %s", f)
+	}
+	ip.Info("Loaded matched rules", "rules", rules)
+	return rules, nil
 }

--- a/tool/internal/instrument/match.go
+++ b/tool/internal/instrument/match.go
@@ -3,8 +3,11 @@
 
 package instrument
 
-func (*InstrumentPhase) match(args []string) bool {
+import "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
+
+func (*InstrumentPhase) match(args []string, rules []*rule.InstRule) bool {
 	// TODO: Implement task
 	_ = args
+	_ = rules
 	return false
 }

--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -13,18 +13,23 @@ type InstrumentPhase struct {
 	logger *slog.Logger
 }
 
+func (ip *InstrumentPhase) Info(msg string, args ...any)  { ip.logger.Info(msg, args...) }
+func (ip *InstrumentPhase) Error(msg string, args ...any) { ip.logger.Error(msg, args...) }
+func (ip *InstrumentPhase) Warn(msg string, args ...any)  { ip.logger.Warn(msg, args...) }
+func (ip *InstrumentPhase) Debug(msg string, args ...any) { ip.logger.Debug(msg, args...) }
+
 func Toolexec(logger *slog.Logger, args []string) error {
 	ip := &InstrumentPhase{
 		logger: logger,
 	}
 	// Load matched hook rules from setup phase
-	err := ip.load()
+	rules, err := ip.load()
 	if err != nil {
 		return err
 	}
 	// Check if the current package should be instrumented by matching the current
 	// command with list of matched rules
-	if ip.match(args) {
+	if ip.match(args, rules) {
 		// Okay, this package should be instrumented.
 		err = ip.instrument(args)
 		if err != nil {

--- a/tool/internal/rule/def.go
+++ b/tool/internal/rule/def.go
@@ -8,15 +8,15 @@ import (
 )
 
 type Advice struct {
-	Before string `yaml:"before"`
-	After  string `yaml:"after"`
+	Before string `json:"before" yaml:"before"`
+	After  string `json:"after"  yaml:"after"`
 }
 
 type InstRule struct {
-	Name     string   `yaml:"name,omitempty"`
-	Path     string   `yaml:"path"`
-	Pointcut string   `yaml:"pointcut"`
-	Advice   []Advice `yaml:"advice"`
+	Name     string   `json:"name,omitempty" yaml:"name,omitempty"`
+	Path     string   `json:"path"           yaml:"path"`
+	Pointcut string   `json:"pointcut"       yaml:"pointcut"`
+	Advice   []Advice `json:"advice"         yaml:"advice"`
 }
 
 func (r *InstRule) String() string {

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -44,7 +44,7 @@ func materalizeRules(availables []string) ([]*rule.InstRule, error) {
 }
 
 func (sp *SetupPhase) matchedDeps(deps []*Dependency) ([]*rule.InstRule, error) {
-	availables, err := data.ListAvailableRules()
+	availables, err := data.ListEmbedFiles()
 	if err != nil {
 		return nil, err
 	}

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -4,10 +4,12 @@
 package setup
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
 
@@ -36,7 +38,7 @@ func isSetup() bool {
 	return false
 }
 
-// This function is intended to prepare the environment for instrumentation.
+// Setup prepares the environment for further instrumentation.
 func Setup(logger *slog.Logger) error {
 	if isSetup() {
 		logger.Info("Setup has already been completed, skipping setup.")
@@ -72,5 +74,32 @@ func Setup(logger *slog.Logger) error {
 		return err
 	}
 	sp.Info("Setup completed successfully")
+	return nil
+}
+
+// BuildWithToolexec builds the project with the toolexec mode
+func BuildWithToolexec(logger *slog.Logger, args []string) error {
+	// Add -toolexec=otel to the original build command and run it
+	execPath, err := os.Executable()
+	if err != nil {
+		return ex.Errorf(err, "failed to get executable path")
+	}
+	insert := "-toolexec=" + execPath
+	newArgs := make([]string, 0, len(args)+1) // Avoid in-place modification
+	newArgs = append(newArgs, args[:2]...)    // Add "go build"
+	newArgs = append(newArgs, insert)         // Add "-toolexec=..."
+	newArgs = append(newArgs, args[2:]...)    // Add the rest
+	logger.Info("Running go build with toolexec", "args", newArgs)
+
+	// Tell the sub-process the working directory
+	env := os.Environ()
+	pwd := util.GetOtelWorkDir()
+	util.Assert(pwd != "", "invalid working directory")
+	env = append(env, fmt.Sprintf("%s=%s", util.EnvOtelWorkDir, pwd))
+
+	err = util.RunCmdWithEnv(env, newArgs...)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -4,13 +4,10 @@
 package setup
 
 import (
-	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 
-	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
-	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
 
@@ -31,22 +28,6 @@ func (sp *SetupPhase) recordModified(name string) {
 	if err != nil {
 		sp.Warn("failed to copy file", "file", name, "error", err)
 	}
-}
-
-func (*SetupPhase) store(matched []*rule.InstRule) error {
-	f := util.GetBuildTemp("matched.txt")
-	file, err := os.Create(f)
-	if err != nil {
-		return ex.Errorf(err, "failed to create file %s", f)
-	}
-	defer file.Close()
-	for _, r := range matched {
-		_, err = fmt.Fprintf(file, "%s\n", r.Name)
-		if err != nil {
-			return ex.Errorf(err, "failed to write to file %s", f)
-		}
-	}
-	return nil
 }
 
 // This function can be used to check if the setup has been completed.

--- a/tool/internal/setup/store.go
+++ b/tool/internal/setup/store.go
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
+)
+
+// store stores the matched rules to the file
+// It's the pair of the InstrumentPhase.load
+func (sp *SetupPhase) store(matched []*rule.InstRule) error {
+	f := util.GetMatchedRuleFile()
+	file, err := os.Create(f)
+	if err != nil {
+		return ex.Errorf(err, "failed to create file %s", f)
+	}
+	defer file.Close()
+
+	bs, err := json.Marshal(matched)
+	if err != nil {
+		return ex.Errorf(err, "failed to marshal rules to JSON")
+	}
+
+	_, err = file.Write(bs)
+	if err != nil {
+		return ex.Errorf(err, "failed to write JSON to file %s", f)
+	}
+	sp.Info("Stored matched rules", "rules", matched)
+	return nil
+}

--- a/tool/util/shared.go
+++ b/tool/util/shared.go
@@ -4,17 +4,33 @@
 package util
 
 import (
+	"os"
 	"path/filepath"
 )
 
 const (
-	BuildTempDir = ".otel-build"
-	OtelRoot     = "github.com/open-telemetry/opentelemetry-go-compile-instrumentation"
+	EnvOtelWorkDir = "OTEL_WORK_DIR"
+	BuildTempDir   = ".otel-build"
+	OtelRoot       = "github.com/open-telemetry/opentelemetry-go-compile-instrumentation"
 )
+
+func GetMatchedRuleFile() string {
+	const matchedRuleFile = "matched.json"
+	return GetBuildTemp(matchedRuleFile)
+}
+
+func GetOtelWorkDir() string {
+	wd := os.Getenv(EnvOtelWorkDir)
+	if wd == "" {
+		wd, _ = os.Getwd()
+		return wd
+	}
+	return wd
+}
 
 // GetBuildTemp returns the path to the build temp directory $BUILD_TEMP/name
 func GetBuildTemp(name string) string {
-	return filepath.Join(BuildTempDir, name)
+	return filepath.Join(GetOtelWorkDir(), BuildTempDir, name)
 }
 
 func copyBackupFiles(names []string, src, dst string) {

--- a/tool/util/sys.go
+++ b/tool/util/sys.go
@@ -13,18 +13,23 @@ import (
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 )
 
-func RunCmd(args ...string) error {
+func RunCmdWithEnv(env []string, args ...string) error {
 	path := args[0]
 	args = args[1:]
 	cmd := exec.Command(path, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Env = env
 	err := cmd.Run()
 	if err != nil {
 		return ex.Errorf(err, "failed to run command %s", path)
 	}
 	return nil
+}
+
+func RunCmd(args ...string) error {
+	return RunCmdWithEnv(nil, args...)
 }
 
 func IsWindows() bool {


### PR DESCRIPTION
Subtask of #29 

In instrument phase, we first load matched rules from previous setup phase, and match with current compile command to see if we need to instrument this compile command.

This patch implements the `instrument.load` functionality.