### PR TITLE
chore: allow renovatebot to update all deps at once

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,7 @@
   "packageRules": [
     {
       "groupName": "all patch versions",
-      "schedule": ["before 8am every weekday"]
+      "schedule": ["before 8am on Monday"]
     }
   ],
   "labels": [


### PR DESCRIPTION
Configure Renovate to group all dependency updates into a single Pull Request, rather than creating an individual PR for each one.