### PR TITLE
refactor: limit visibility to necessary fields and constants

### DIFF
--- a/tool/internal/instrument/impl.tmpl
+++ b/tool/internal/instrument/impl.tmpl
@@ -5,37 +5,37 @@ package instrument
 
 //line <generated>:1
 type HookContextImpl struct {
-	Params      []interface{}
-	ReturnVals  []interface{}
-	SkipCall    bool
-	Data        interface{}
-	FuncName    string
-	PackageName string
+	params      []interface{}
+	returnVals  []interface{}
+	skipCall    bool
+	data        interface{}
+	funcName    string
+	packageName string
 }
 
-func (c *HookContextImpl) SetSkipCall(skip bool)    { c.SkipCall = skip }
-func (c *HookContextImpl) IsSkipCall() bool         { return c.SkipCall }
-func (c *HookContextImpl) SetData(data interface{}) { c.Data = data }
-func (c *HookContextImpl) GetData() interface{}     { return c.Data }
+func (c *HookContextImpl) SetSkipCall(skip bool)    { c.skipCall = skip }
+func (c *HookContextImpl) IsSkipCall() bool         { return c.skipCall }
+func (c *HookContextImpl) SetData(data interface{}) { c.data = data }
+func (c *HookContextImpl) GetData() interface{}     { return c.data }
 func (c *HookContextImpl) GetKeyData(key string) interface{} {
-	if c.Data == nil {
+	if c.data == nil {
 		return nil
 	}
-	return c.Data.(map[string]interface{})[key]
+	return c.data.(map[string]interface{})[key]
 }
 
 func (c *HookContextImpl) SetKeyData(key string, val interface{}) {
-	if c.Data == nil {
-		c.Data = make(map[string]interface{})
+	if c.data == nil {
+		c.data = make(map[string]interface{})
 	}
-	c.Data.(map[string]interface{})[key] = val
+	c.data.(map[string]interface{})[key] = val
 }
 
 func (c *HookContextImpl) HasKeyData(key string) bool {
-	if c.Data == nil {
+	if c.data == nil {
 		return false
 	}
-	_, ok := c.Data.(map[string]interface{})[key]
+	_, ok := c.data.(map[string]interface{})[key]
 	return ok
 }
 
@@ -47,7 +47,7 @@ func (c *HookContextImpl) GetParam(idx int) interface{} {
 
 func (c *HookContextImpl) SetParam(idx int, val interface{}) {
 	if val == nil {
-		c.Params[idx] = nil
+		c.params[idx] = nil
 		return
 	}
 	switch idx {
@@ -62,16 +62,16 @@ func (c *HookContextImpl) GetReturnVal(idx int) interface{} {
 
 func (c *HookContextImpl) SetReturnVal(idx int, val interface{}) {
 	if val == nil {
-		c.ReturnVals[idx] = nil
+		c.returnVals[idx] = nil
 		return
 	}
 	switch idx {
 	}
 }
-func (c *HookContextImpl) GetParamCount() int     { return len(c.Params) }
-func (c *HookContextImpl) GetReturnValCount() int { return len(c.ReturnVals) }
-func (c *HookContextImpl) GetFuncName() string    { return c.FuncName }
-func (c *HookContextImpl) GetPackageName() string { return c.PackageName }
+func (c *HookContextImpl) GetParamCount() int     { return len(c.params) }
+func (c *HookContextImpl) GetReturnValCount() int { return len(c.returnVals) }
+func (c *HookContextImpl) GetFuncName() string    { return c.funcName }
+func (c *HookContextImpl) GetPackageName() string { return c.packageName }
 
 // Variable Template
 var (
@@ -94,10 +94,10 @@ func OtelBeforeTrampoline() (HookContext, bool) {
 		}
 	}()
 	hookContext := &HookContextImpl{}
-	hookContext.Params = []interface{}{}
-	hookContext.FuncName = ""
-	hookContext.PackageName = ""
-	return hookContext, hookContext.SkipCall
+	hookContext.params = []interface{}{}
+	hookContext.funcName = ""
+	hookContext.packageName = ""
+	return hookContext, hookContext.skipCall
 }
 
 func OtelAfterTrampoline(hookContext HookContext) {
@@ -113,5 +113,5 @@ func OtelAfterTrampoline(hookContext HookContext) {
 			}
 		}
 	}()
-	hookContext.(*HookContextImpl).ReturnVals = []interface{}{}
+	hookContext.(*HookContextImpl).returnVals = []interface{}{}
 }

--- a/tool/internal/setup/extract.go
+++ b/tool/internal/setup/extract.go
@@ -17,10 +17,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
 
-const (
-	EmbeddedInstPkgGzip = "otel-pkg.gz"
-)
-
 func normalizePath(name string) string {
 	const pkg, pkgTemp = "pkg", "pkg_temp"
 	cleanName := filepath.ToSlash(filepath.Clean(name))
@@ -128,8 +124,9 @@ func extractGZip(data []byte, targetDir string) error {
 }
 
 func (*SetupPhase) extract() error {
+	const embeddedInstPkgGzip = "otel-pkg.gz"
 	// Read the instrumentation code from the embedded binary file
-	bs, err := data.ReadEmbedFile(EmbeddedInstPkgGzip)
+	bs, err := data.ReadEmbedFile(embeddedInstPkgGzip)
 	if err != nil {
 		return err
 	}

--- a/tool/internal/setup/find.go
+++ b/tool/internal/setup/find.go
@@ -15,10 +15,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
 
-const (
-	BuildPlanLog = "build-plan.log"
-)
-
 type Dependency struct {
 	ImportPath string
 	Version    string
@@ -65,11 +61,13 @@ func findCompileCommands(buildPlanLog *os.File) ([]string, error) {
 // and then filtering the compile commands from the build plan log.
 func (sp *SetupPhase) listBuildPlan(ctx context.Context, goBuildCmd []string) ([]string, error) {
 	const goBuildCmdMinLen = 1 // build/install + at least one argument
+	const buildPlanLogName = "build-plan.log"
+
 	util.Assert(len(goBuildCmd) >= goBuildCmdMinLen, "at least one argument is required")
 	util.Assert(goBuildCmd[1] == "build" || goBuildCmd[1] == "install", "sanity check")
 
 	// Create a build plan log file in the temporary directory
-	buildPlanLog, err := os.Create(util.GetBuildTemp(BuildPlanLog))
+	buildPlanLog, err := os.Create(util.GetBuildTemp(buildPlanLogName))
 	if err != nil {
 		return nil, ex.Wrapf(err, "failed to create build plan log file")
 	}


### PR DESCRIPTION
Subtask #29 

Addresses previous review comments by making several fields and constants private. This change ensures we only expose the required public API, which is a better practice for code encapsulation and standardization.