### PR TITLE
refactor(tool/data): limit embed to *.yaml and *.gz files

### DIFF
--- a/tool/data/export.go
+++ b/tool/data/export.go
@@ -9,7 +9,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 )
 
-//go:embed *
+//go:embed *.yaml
 var dataFs embed.FS
 
 // ListEmbedFiles lists all the files in the embedded data


### PR DESCRIPTION
Contributing to https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/29:

- Only embedding the `*.yaml` and `*.gz` instead of wildcard in tool/data/export.go

I've just let `*.yaml` for now. Let's add `*.gz` when a file with that format is added.