### PR TITLE
fix: interface conversion: HookContext is nil, not *HookContextImpl

### DIFF
--- a/tool/internal/instrument/impl.tmpl
+++ b/tool/internal/instrument/impl.tmpl
@@ -80,7 +80,7 @@ var (
 )
 
 // Trampoline Template
-func OtelBeforeTrampoline() (HookContext, bool) {
+func OtelBeforeTrampoline() (hookContext *HookContextImpl, skipCall bool) {
 	defer func() {
 		if err := recover(); err != nil {
 			println("failed to exec Before hook", "OtelBeforeNamePlaceholder")
@@ -93,7 +93,7 @@ func OtelBeforeTrampoline() (HookContext, bool) {
 			}
 		}
 	}()
-	hookContext := &HookContextImpl{}
+	hookContext = &HookContextImpl{}
 	hookContext.params = []interface{}{}
 	hookContext.funcName = ""
 	hookContext.packageName = ""


### PR DESCRIPTION
In the original implementation, if a panic occurs inside MyHook1Before, the subsequent return statement is not executed. This causes OtelBeforeTrampoline_Example3580597051 to return a nil HookContext.
```
func OtelBeforeTrampoline_Example3580597051(m **MyStruct) (HookContext, bool) {
	defer func() {
		if err := recover(); err != nil {
			println("failed to exec Before hook", "MyHook1Before")
			if e, ok := err.(error); ok {
				println(e.Error())
			}
			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
			if fetchStack != nil && printStack != nil {
				printStack(fetchStack())
			}
		}
	}()
	hookContext := &HookContextImpl3580597051{}
	hookContext.params = []interface{}{m}
	hookContext.funcName = "Example"
	hookContext.packageName = "main"
	if MyHook1Before != nil {
		MyHook1Before(hookContext, *m)
	}
	return hookContext, hookContext.skipCall
}
```
This nil context is then passed to and used by MyHook1After, resulting in a nil pointer dereference.

This patch fixes the issue by ensuring that the hookContext is always successfully constructed and returned, regardless of whether MyHook1Before panics.