### PR TITLE
fix: ast.FindFuncDecl finds wrong target func

### DIFF
--- a/tool/internal/ast/shared.go
+++ b/tool/internal/ast/shared.go
@@ -46,16 +46,19 @@ func FindFuncDeclWithoutRecv(root *dst.File, funcName string) *dst.FuncDecl {
 
 func FindFuncDecl(root *dst.File, funcName string, recv string) *dst.FuncDecl {
 	decls := findFuncDecls(root, func(funcDecl *dst.FuncDecl) bool {
-		// Receiver type is empty? Match func name only
+		// Receiver type is ignored, match func name only
 		name := funcDecl.Name.Name
 		if recv == "" {
 			return name == funcName && !HasReceiver(funcDecl)
 		}
+		// Receiver type is specified, but target function does not have receiver
+		// That's not what we want
 		if !HasReceiver(funcDecl) {
 			return false
 		}
 
-		// Receiver type is specified, Match both func name and receiver type
+		// Receiver type is specified, and target function has receiver
+		// Match both func name and receiver type
 		switch recvTypeExpr := funcDecl.Recv.List[0].Type.(type) {
 		case *dst.StarExpr: // func (*Recv)T
 			tn, ok := recvTypeExpr.X.(*dst.Ident)
@@ -64,10 +67,10 @@ func FindFuncDecl(root *dst.File, funcName string, recv string) *dst.FuncDecl {
 				return false
 			}
 			t := "*" + tn.Name
-			return t == recv
+			return t == recv && name == funcName
 		case *dst.Ident: // func (Recv)T
 			t := recvTypeExpr.Name
-			return t == recv
+			return t == recv && name == funcName
 		case *dst.IndexExpr:
 			// This is a generic type, we don't support it yet
 			return false

--- a/tool/internal/instrument/apply_func.go
+++ b/tool/internal/instrument/apply_func.go
@@ -173,6 +173,8 @@ func (ip *InstrumentPhase) insertToFunc(funcDecl *dst.FuncDecl, tjump *dst.IfStm
 
 func (ip *InstrumentPhase) insertTJump(t *rule.InstFuncRule, funcDecl *dst.FuncDecl) error {
 	util.Assert(t.Before != "" || t.After != "", "sanity check")
+	util.Assert(funcDecl.Name.Name == t.Func, "sanity check")
+
 	// Record the target function for the whole trampoline creation process
 	ip.targetFunc = funcDecl
 

--- a/tool/internal/instrument/apply_raw.go
+++ b/tool/internal/instrument/apply_raw.go
@@ -31,6 +31,8 @@ func renameReturnValues(funcDecl *dst.FuncDecl) {
 
 func insertRaw(r *rule.InstRawRule, decl *dst.FuncDecl) error {
 	util.Assert(r.Raw != "", "sanity check")
+	util.Assert(decl.Name.Name == r.Func, "sanity check")
+
 	// Rename the unnamed return values so that the raw code can reference them
 	renameReturnValues(decl)
 	// Parse the raw code into AST statements

--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -222,8 +222,8 @@ func getHookFunc(t *rule.InstFuncRule, before bool) (*dst.FuncDecl, error) {
 		target = ast.FindFuncDeclWithoutRecv(root, t.After)
 	}
 	if target == nil {
-		return nil, ex.Newf("hook %s or %s not found",
-			t.Before, t.After)
+		return nil, ex.Newf("hook %s or %s not found from %s",
+			t.Before, t.After, file)
 	}
 	return target, nil
 }


### PR DESCRIPTION
We expected to find 
`func (s *Server) Serve(lis net.Listener) error`
but actually found the wrong function:
`func (s *Server) serverWorker()`

fixes #135 