### PR TITLE
fix: cannot use _ as value or type

### DIFF
--- a/demo/basic/main.go
+++ b/demo/basic/main.go
@@ -38,6 +38,8 @@ func Example() {
 	// [MyHook] hello world is instrumented!
 }
 
+func Underscore(_ int, _ float32) {}
+
 func main() {
 	context := &traceContext{
 		traceID: "123",

--- a/pkg/instrumentation/helloworld/helloworld_hook.go
+++ b/pkg/instrumentation/helloworld/helloworld_hook.go
@@ -70,3 +70,5 @@ func MyHook1Before(ictx inst.HookContext, recv interface{}) {
 func MyHook1After(ictx inst.HookContext) {
 	println("After MyStruct.Example()")
 }
+
+func BeforeUnderscore(ictx inst.HookContext, _ int, _ float32) {}

--- a/tool/data/helloworld.yaml
+++ b/tool/data/helloworld.yaml
@@ -51,3 +51,9 @@ only_after:
   func: Example
   after: MyHookAfter
   path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/helloworld"
+
+underscore_param:
+  target: main
+  func: Underscore
+  before: BeforeUnderscore
+  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/helloworld"

--- a/tool/internal/ast/primitives.go
+++ b/tool/internal/ast/primitives.go
@@ -35,10 +35,12 @@ func Ident(name string) *dst.Ident {
 	}
 }
 
-func AddressOf(expr dst.Expr) *dst.UnaryExpr {
-	e, ok := dst.Clone(expr).(dst.Expr)
-	util.Assert(ok, "expr is not a UnaryExpr")
-	return &dst.UnaryExpr{Op: token.AND, X: e}
+func Nil() *dst.Ident {
+	return &dst.Ident{Name: IdentNil}
+}
+
+func AddressOf(name string) *dst.UnaryExpr {
+	return &dst.UnaryExpr{Op: token.AND, X: Ident(name)}
 }
 
 func CallTo(name string, args []dst.Expr) *dst.CallExpr {

--- a/tool/internal/instrument/apply_func.go
+++ b/tool/internal/instrument/apply_func.go
@@ -50,26 +50,24 @@ func findJumpPoint(jumpIf *dst.IfStmt) *dst.BlockStmt {
 	return nil
 }
 
-func collectReturnValues(funcDecl *dst.FuncDecl) []dst.Expr {
+func collectReturnValues(funcDecl *dst.FuncDecl) []string {
 	// Add explicit names for return values, they can be further referenced if
 	// we're willing
-	var retVals []dst.Expr // nil by default
+	var retVals []string // nil by default
 	if retList := funcDecl.Type.Results; retList != nil {
 		idx := 0
 		for _, field := range retList.List {
 			if field.Names == nil {
-				// Rename
+				// Rename (for referenceability)
 				name := fmt.Sprintf("%s%d", unnamedRetValName, idx)
 				field.Names = []*dst.Ident{ast.Ident(name)}
 				idx++
 				// Collect (for further use)
-				i, ok := dst.Clone(ast.Ident(name)).(*dst.Ident)
-				util.Assert(ok, "ident is not a Ident")
-				retVals = append(retVals, i)
+				retVals = append(retVals, name)
 			} else {
 				// Collect only (for further use)
 				for _, name := range field.Names {
-					retVals = append(retVals, ast.Ident(name.Name))
+					retVals = append(retVals, name.Name)
 				}
 			}
 		}
@@ -78,36 +76,47 @@ func collectReturnValues(funcDecl *dst.FuncDecl) []dst.Expr {
 	return retVals
 }
 
-func collectArguments(funcDecl *dst.FuncDecl) []dst.Expr {
-	args := make([]dst.Expr, 0)
+func collectArguments(funcDecl *dst.FuncDecl) []string {
+	args := make([]string, 0)
 	if ast.HasReceiver(funcDecl) {
 		receiver := funcDecl.Recv.List[0].Names[0].Name
-		args = append(args, ast.AddressOf(ast.Ident(receiver)))
+		args = append(args, receiver)
 	}
 	for _, field := range funcDecl.Type.Params.List {
 		for _, name := range field.Names {
-			args = append(args, ast.AddressOf(ast.Ident(name.Name)))
+			args = append(args, name.Name)
 		}
 	}
 	return args
 }
 
+func createHookArgs(names []string) []dst.Expr {
+	exprs := make([]dst.Expr, 0)
+	// If we find "a type" in target func, we pass "&a" to trampoline func,
+	// if we find "_ type" in target func, we pass "nil" to trampoline func,
+	for _, name := range names {
+		if name == "_" {
+			exprs = append(exprs, ast.Nil())
+		} else {
+			exprs = append(exprs, ast.AddressOf(name))
+		}
+	}
+	return exprs
+}
+
 func createTJumpIf(t *rule.InstFuncRule, funcDecl *dst.FuncDecl,
-	args []dst.Expr, retVals []dst.Expr,
+	args, retVals []string,
 ) *dst.IfStmt {
 	funcSuffix := util.CRC32(t.String())
-	beforeCall := ast.CallTo(makeName(t, funcDecl, true), args)
-	afterCall := ast.CallTo(makeName(t, funcDecl, false), func() []dst.Expr {
-		// NB. DST framework disallows duplicated node in the
-		// AST tree, we need to replicate the return values
-		// as they are already used in return statement above
-		clone := make([]dst.Expr, len(retVals)+1)
-		clone[0] = ast.Ident(trampolineHookContextName + funcSuffix)
-		for i := 1; i < len(clone); i++ {
-			clone[i] = ast.AddressOf(retVals[i-1])
-		}
-		return clone
-	}())
+	// Transparently pass the target function's parameters to trampoline func,
+	// with the only exception being that if the target func parameter is "_",
+	// then we directly pass "nil"
+	argsToBefore := createHookArgs(args)
+	argsToAfter := createHookArgs(retVals)
+	argHookContext := ast.Ident(trampolineHookContextName + funcSuffix)
+	argsToAfter = append([]dst.Expr{argHookContext}, argsToAfter...)
+	beforeCall := ast.CallTo(makeName(t, funcDecl, true), argsToBefore)
+	afterCall := ast.CallTo(makeName(t, funcDecl, false), argsToAfter)
 	tjumpInit := ast.DefineStmts(
 		ast.Exprs(
 			ast.Ident(trampolineHookContextName+funcSuffix),
@@ -116,9 +125,13 @@ func createTJumpIf(t *rule.InstFuncRule, funcDecl *dst.FuncDecl,
 		ast.Exprs(beforeCall),
 	)
 	tjumpCond := ast.Ident(trampolineSkipName + funcSuffix)
+	tjumpReturn := make([]dst.Expr, 0)
+	for _, retVal := range retVals {
+		tjumpReturn = append(tjumpReturn, ast.Ident(retVal))
+	}
 	tjumpBody := ast.BlockStmts(
 		ast.ExprStmt(afterCall),
-		ast.ReturnStmt(retVals),
+		ast.ReturnStmt(tjumpReturn),
 	)
 	tjumpElse := ast.Block(ast.DeferStmt(afterCall))
 	tjump := ast.IfStmt(tjumpInit, tjumpCond, tjumpBody, tjumpElse)
@@ -178,11 +191,10 @@ func (ip *InstrumentPhase) insertTJump(t *rule.InstFuncRule, funcDecl *dst.FuncD
 	// Record the target function for the whole trampoline creation process
 	ip.targetFunc = funcDecl
 
-	// Collect return values for the trampoline function
+	// Collect return values from target function
 	retVals := collectReturnValues(funcDecl)
 
-	// Collect all arguments for the trampoline function, including the receiver
-	// and the original target function arguments
+	// Collect all arguments from target function, including the receiver
 	args := collectArguments(funcDecl)
 
 	// Generate the trampoline-jump-if. The trampoline-jump-if is a conditional

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -154,6 +154,15 @@ func createTestRuleJSON(mainGoFile string) ([]byte, error) {
 						Recv:  "*T",
 						After: "H3After",
 					},
+					{
+						InstBaseRule: rule.InstBaseRule{
+							Name:   "underscore_param",
+							Target: "main",
+						},
+						Path:   filepath.Join(".", "testdata"),
+						Func:   "Func2",
+						Before: "H4Before",
+					},
 				},
 			},
 			RawRules: map[string][]*rule.InstRawRule{

--- a/tool/internal/instrument/optimize.go
+++ b/tool/internal/instrument/optimize.go
@@ -117,7 +117,7 @@ func populateHookContextLiteral(tjump *TJump, expr dst.Expr) {
 	// Populate call context literal with addresses of all arguments
 	names := make([]dst.Expr, 0)
 	for _, name := range getNames(targetFunc.Type.Params) {
-		names = append(names, ast.AddressOf(ast.Ident(name)))
+		names = append(names, ast.AddressOf(name))
 	}
 	paramLiteral, _ := paramElem.(*dst.KeyValueExpr).Value.(*dst.CompositeLit)
 	paramLiteral.Elts = names
@@ -125,7 +125,7 @@ func populateHookContextLiteral(tjump *TJump, expr dst.Expr) {
 	if targetFunc.Type.Results != nil {
 		rets := make([]dst.Expr, 0)
 		for _, name := range getNames(targetFunc.Type.Results) {
-			rets = append(rets, ast.AddressOf(ast.Ident(name)))
+			rets = append(rets, ast.AddressOf(name))
 		}
 		returnLiteral, _ := returnElem.(*dst.KeyValueExpr).Value.(*dst.CompositeLit)
 		returnLiteral.Elts = rets

--- a/tool/internal/instrument/testdata/hook.go
+++ b/tool/internal/instrument/testdata/hook.go
@@ -28,3 +28,6 @@ func H3Before(ctx inst.HookContext, recv interface{}, p1 string, p2 int) {}
 
 //go:linkname H3After main.H3After
 func H3After(ctx inst.HookContext, r1 float32, r2 error) {}
+
+//go:linkname H4Before main.H4Before
+func H4Before(ctx inst.HookContext, p1 string, _ int) {}

--- a/tool/internal/instrument/testdata/source.go
+++ b/tool/internal/instrument/testdata/source.go
@@ -14,4 +14,6 @@ func Func1(p1 string, p2 int) (float32, error) {
 	return 0.0, nil
 }
 
+func Func2(p1 string, _ int) {}
+
 func main() { Func1("hello", 123) }

--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -412,22 +412,40 @@ func addHookContext(list *dst.FieldList) {
 }
 
 func (ip *InstrumentPhase) buildTrampolineType(before bool) *dst.FieldList {
+	// Since target function parameter names might be "_", we may use the target
+	// function parameters in the trampoline function, which would cause a syntax
+	// error, so we assign them a specific name and use them.
+	idx := 0
+	renameField := func(field *dst.Field, prefix string) {
+		for _, names := range field.Names {
+			names.Name = fmt.Sprintf("%s%d", prefix, idx)
+			idx++
+		}
+	}
+	// Build parameter list of trampoline function.
+	// For before trampoline, it's signature is:
+	// func S(h* HookContext, recv type, arg1 type, arg2 type, ...)
+	// For after trampoline, it's signature is:
+	// func S(h* HookContext, arg1 type, arg2 type, ...)
 	paramList := &dst.FieldList{List: []*dst.Field{}}
 	if before {
 		if ast.HasReceiver(ip.targetFunc) {
 			recvField, ok := dst.Clone(ip.targetFunc.Recv.List[0]).(*dst.Field)
 			util.Assert(ok, "recvField is not a Field")
+			renameField(recvField, "recv")
 			paramList.List = append(paramList.List, recvField)
 		}
 		for _, field := range ip.targetFunc.Type.Params.List {
 			paramField, ok := dst.Clone(field).(*dst.Field)
 			util.Assert(ok, "paramField is not a Field")
+			renameField(paramField, "param")
 			paramList.List = append(paramList.List, paramField)
 		}
 	} else if ip.targetFunc.Type.Results != nil {
 		for _, field := range ip.targetFunc.Type.Results.List {
 			retField, ok := dst.Clone(field).(*dst.Field)
 			util.Assert(ok, "retField is not a Field")
+			renameField(retField, "arg")
 			paramList.List = append(paramList.List, retField)
 		}
 	}


### PR DESCRIPTION
In the current implementation, compilation fails when target function parameters contain '_'.

This patch fixes this issue