### PR TITLE
fix: listBuildPlan cmd better error message

### DIFF
--- a/tool/internal/setup/find.go
+++ b/tool/internal/setup/find.go
@@ -95,7 +95,10 @@ func (sp *SetupPhase) listBuildPlan(ctx context.Context, goBuildCmd []string) ([
 	cmd.Dir = ""
 	err = cmd.Run()
 	if err != nil {
-		return nil, ex.Wrapf(err, "failed to run build plan")
+		// Read the build plan log to see what went wrong
+		_, _ = buildPlanLog.Seek(0, 0)
+		logContent, _ := os.ReadFile(util.GetBuildTemp(buildPlanLogName))
+		return nil, ex.Wrapf(err, "failed to run build plan: \n%s", string(logContent))
 	}
 
 	// Find compile commands from build plan log


### PR DESCRIPTION
During recent command testing, I experimented with the setup command and forgot to remove `otel_runtime.go`. This leftover file caused the following generic error:

Error:
[0] failed to run build plan: exit status 1
Stack: ...


Because this message is not very informative, it can be confusing for users (this of course can be any other error). The actual underlying issue is visible only in the build log so I was thinking about emitting more detailed message by reading it from `build-plan.log`:
```
Error:
[0] failed to run build plan: 
otel.runtime.go:7:8: no required module provides package github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/grpc; to add it:
	go get github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/grpc
otel.runtime.go:8:8: no required module provides package github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/nethttp; to add it:
	go get github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/nethttp
: exit status 1

Stack:
```

Alternatively, at minimum, we could enhance the error message to point users to the log file, for example:
```
[0] failed to run build plan: exit status 1 — see build-plan.log for details.
```
Third option of course is to leave as it is.

I'm leaving the final approach to your judgement/consideration.