### PR TITLE
fix: pass receiver to HookContextImpl literal

### DIFF
--- a/tool/internal/instrument/optimize.go
+++ b/tool/internal/instrument/optimize.go
@@ -118,7 +118,7 @@ func newHookContextImpl(tjump *TJump) dst.Expr {
 
 	// Build params slice: []interface{}{&param1, &param2, ...}
 	// Use createHookArgs to handle underscore parameters correctly
-	paramNames := getNames(targetFunc.Type.Params)
+	paramNames := collectArguments(targetFunc)
 	paramExprs := createHookArgs(paramNames)
 	paramsSlice := ast.CompositeLit(
 		ast.ArrayType(ast.InterfaceType()),
@@ -128,7 +128,7 @@ func newHookContextImpl(tjump *TJump) dst.Expr {
 	// Build returnVals slice: []interface{}{&retval1, &retval2, ...}
 	returnExprs := make([]dst.Expr, 0)
 	if targetFunc.Type.Results != nil {
-		returnNames := getNames(targetFunc.Type.Results)
+		returnNames := collectReturnValues(targetFunc)
 		returnExprs = createHookArgs(returnNames)
 	}
 	returnValsSlice := ast.CompositeLit(

--- a/tool/internal/instrument/testdata/golden/after-only/after_only.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/after-only/after_only.main.go.golden
@@ -7,7 +7,13 @@ import _ "unsafe"
 
 type T struct{}
 
-func (t *T) Func1(p1 string, p2 int) (float32, error) {
+func (t *T) Func1(p1 string, p2 int) (_unnamedRetVal0 float32, _unnamedRetVal1 error) {
+	//line <generated>:1
+	if false {
+	} else {
+		defer OtelAfterTrampoline_Func11091117693(&HookContextImpl1091117693{params: []interface{}{&t, &p1, &p2}, returnVals: []interface{}{&_unnamedRetVal0, &_unnamedRetVal1}}, &_unnamedRetVal0, &_unnamedRetVal1)
+	}
+	//line main.go:9:2
 	return 0.0, nil
 }
 
@@ -138,3 +144,115 @@ func OtelAfterTrampoline_Func13335793671(hookContext HookContext, arg0 *float32,
 
 //go:linkname H1After testdata.H1After
 func H1After(hookContext HookContext, arg0 float32, arg1 error)
+
+//line <generated>:1
+type HookContextImpl1091117693 struct {
+	params      []interface{}
+	returnVals  []interface{}
+	skipCall    bool
+	data        interface{}
+	funcName    string
+	packageName string
+}
+
+func (c *HookContextImpl1091117693) SetSkipCall(skip bool)    { c.skipCall = skip }
+func (c *HookContextImpl1091117693) IsSkipCall() bool         { return c.skipCall }
+func (c *HookContextImpl1091117693) SetData(data interface{}) { c.data = data }
+func (c *HookContextImpl1091117693) GetData() interface{}     { return c.data }
+func (c *HookContextImpl1091117693) GetKeyData(key string) interface{} {
+	if c.data == nil {
+		return nil
+	}
+	return c.data.(map[string]interface{})[key]
+}
+
+func (c *HookContextImpl1091117693) SetKeyData(key string, val interface{}) {
+	if c.data == nil {
+		c.data = make(map[string]interface{})
+	}
+	c.data.(map[string]interface{})[key] = val
+}
+
+func (c *HookContextImpl1091117693) HasKeyData(key string) bool {
+	if c.data == nil {
+		return false
+	}
+	_, ok := c.data.(map[string]interface{})[key]
+	return ok
+}
+
+func (c *HookContextImpl1091117693) GetParam(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.params[0].(**T))
+	case 1:
+		return *(c.params[1].(*string))
+	case 2:
+		return *(c.params[2].(*int))
+	}
+	return nil
+}
+
+func (c *HookContextImpl1091117693) SetParam(idx int, val interface{}) {
+	if val == nil {
+		c.params[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.params[0].(**T)) = val.(*T)
+	case 1:
+		*(c.params[1].(*string)) = val.(string)
+	case 2:
+		*(c.params[2].(*int)) = val.(int)
+	}
+}
+
+func (c *HookContextImpl1091117693) GetReturnVal(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.returnVals[0].(*float32))
+	case 1:
+		return *(c.returnVals[1].(*error))
+	}
+	return nil
+}
+
+func (c *HookContextImpl1091117693) SetReturnVal(idx int, val interface{}) {
+	if val == nil {
+		c.returnVals[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.returnVals[0].(*float32)) = val.(float32)
+	case 1:
+		*(c.returnVals[1].(*error)) = val.(error)
+	}
+}
+func (c *HookContextImpl1091117693) GetParamCount() int     { return len(c.params) }
+func (c *HookContextImpl1091117693) GetReturnValCount() int { return len(c.returnVals) }
+func (c *HookContextImpl1091117693) GetFuncName() string    { return c.funcName }
+func (c *HookContextImpl1091117693) GetPackageName() string { return c.packageName }
+
+func OtelAfterTrampoline_Func11091117693(hookContext HookContext, arg0 *float32, arg1 *error) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec After hook", "H8After")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext.(*HookContextImpl1091117693).returnVals = []interface{}{arg0, arg1}
+	if H8After != nil {
+		H8After(hookContext, *arg0, *arg1)
+	}
+}
+
+//go:linkname H8After testdata.H8After
+func H8After(hookContext HookContext, arg0 float32, arg1 error)

--- a/tool/internal/instrument/testdata/golden/after-only/rules.yml
+++ b/tool/internal/instrument/testdata/golden/after-only/rules.yml
@@ -4,3 +4,10 @@ hook_after_only:
   after: H1After
   path: testdata
 
+hook_with_receiver_after_only:
+  target: main
+  func: Func1
+  recv: "*T"
+  after: H8After
+  path: testdata
+

--- a/tool/internal/instrument/testdata/hook.go
+++ b/tool/internal/instrument/testdata/hook.go
@@ -32,3 +32,5 @@ func H6Before(ctx inst.HookContext) { _ = ctx }
 func H7Before(ctx inst.HookContext) { ctx.SetSkipCall(true) }
 
 func H7After(ctx inst.HookContext) { _ = ctx }
+
+func H8After(ctx inst.HookContext, ret1 float32, ret2 error) {}

--- a/tool/internal/setup/extract.go
+++ b/tool/internal/setup/extract.go
@@ -17,8 +17,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
 
+const (
+	unzippedPkgDir = "pkg"
+)
+
 func normalizePath(name string) string {
-	const pkg, pkgTemp = "pkg", "pkg_temp"
+	const pkg, pkgTemp = unzippedPkgDir, "pkg_temp"
 	cleanName := filepath.ToSlash(filepath.Clean(name))
 	if strings.HasPrefix(cleanName, pkgTemp+"/") {
 		cleanName = strings.Replace(cleanName, pkgTemp+"/", pkg+"/", 1)

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -132,6 +132,10 @@ func GoBuild(ctx context.Context, args []string) error {
 		if err != nil {
 			logger.DebugContext(ctx, "failed to remove otel runtime file", "error", err)
 		}
+		err = os.RemoveAll(unzippedPkgDir)
+		if err != nil {
+			logger.DebugContext(ctx, "failed to remove unzipped pkg", "error", err)
+		}
 		err = util.RestoreFile(backupFiles)
 		if err != nil {
 			logger.DebugContext(ctx, "failed to restore files", "error", err)

--- a/tool/internal/setup/sync.go
+++ b/tool/internal/setup/sync.go
@@ -104,7 +104,7 @@ func (sp *SetupPhase) syncDeps(ctx context.Context, matched []*rule.InstRuleSet)
 	// we can remove this.
 	// Add special pkg module to go.mod
 	oldPath := util.OtelRoot + "/pkg"
-	newPath := filepath.Join(util.GetBuildTempDir(), "pkg")
+	newPath := filepath.Join(util.GetBuildTempDir(), unzippedPkgDir)
 	added, addErr := addReplace(modfile, oldPath, "", newPath, "")
 	if addErr != nil {
 		return addErr


### PR DESCRIPTION
I was taking a look at this code and find a bug:

```
func newHookContextImpl(tjump *TJump) dst.Expr {
	targetFunc := tjump.target
	structName := trampolineHookContextImplType + util.CRC32(tjump.rule.String())

	// Build params slice: []interface{}{&param1, &param2, ...}
	// Use createHookArgs to handle underscore parameters correctly
	paramNames := getNames(targetFunc.Type.Params)
	paramExprs := createHookArgs(paramNames)
	paramsSlice := ast.CompositeLit(
		ast.ArrayType(ast.InterfaceType()),
		paramExprs,
	)
```

Te current logic only includes the parameters of the targetFunc but is missing its receiver.