### PR TITLE
chore(ci): unify done job format to auto-pass when skipped

### DIFF
--- a/.github/workflows/check-license-headers.yaml
+++ b/.github/workflows/check-license-headers.yaml
@@ -35,9 +35,12 @@ jobs:
     steps:
       - name: Check result
         run: |
-          echo ${{ needs.check-license-headers.result }}
-          if [ "${{ needs.check-license-headers.result }}" = "success" ] || [ "${{ needs.check-license-headers.result }}" = "skipped" ]; then
+          result="${{ needs.check-license-headers.result }}"
+          echo "Test result: $result"
+          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+            echo "✅ Tests passed or were skipped"
             exit 0
           else
+            echo "❌ Tests failed"
             exit 1
           fi

--- a/.github/workflows/lint-golang.yaml
+++ b/.github/workflows/lint-golang.yaml
@@ -41,9 +41,12 @@ jobs:
     steps:
       - name: Check result
         run: |
-          echo ${{ needs.golangci-lint.result }}
-          if [ "${{ needs.golangci-lint.result }}" = "success" ] || [ "${{ needs.golangci-lint.result }}" = "skipped" ]; then
+          result="${{ needs.golangci-lint.result }}"
+          echo "Test result: $result"
+          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+            echo "✅ Tests passed or were skipped"
             exit 0
           else
+            echo "❌ Tests failed"
             exit 1
           fi

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -66,8 +66,16 @@ jobs:
     name: Done (E2E Tests)
     runs-on: ubuntu-latest
     needs: [test-e2e]
+    if: always()
     steps:
-      - name: Success
+      - name: Check result
         run: |
-          echo ${{ needs.test-e2e.result }}
-          test ${{ needs.test-e2e.result }} == "success"
+          result="${{ needs.test-e2e.result }}"
+          echo "Test result: $result"
+          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+            echo "✅ Tests passed or were skipped"
+            exit 0
+          else
+            echo "❌ Tests failed"
+            exit 1
+          fi

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -67,8 +67,16 @@ jobs:
     name: Done (Integration Tests)
     runs-on: ubuntu-latest
     needs: [test-integration]
+    if: always()
     steps:
-      - name: Success
+      - name: Check result
         run: |
-          echo ${{ needs.test-integration.result }}
-          test ${{ needs.test-integration.result }} == "success"
+          result="${{ needs.test-integration.result }}"
+          echo "Test result: $result"
+          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+            echo "✅ Tests passed or were skipped"
+            exit 0
+          else
+            echo "❌ Tests failed"
+            exit 1
+          fi

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -71,8 +71,16 @@ jobs:
     name: Done (Unit Tests)
     runs-on: ubuntu-latest
     needs: [test-unit]
+    if: always()
     steps:
-      - name: Success
+      - name: Check result
         run: |
-          echo ${{ needs.test-unit.result }}
-          test ${{ needs.test-unit.result }} == "success"
+          result="${{ needs.test-unit.result }}"
+          echo "Test result: $result"
+          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+            echo "✅ Tests passed or were skipped"
+            exit 0
+          else
+            echo "❌ Tests failed"
+            exit 1
+          fi


### PR DESCRIPTION
Make required check done jobs auto-pass when parent jobs are skipped
due to path filters not matching (e.g., Renovate dependency updates).

This prevents unrelated PRs from being blocked by required checks that
don't need to run for those changes.

Changes:
- Add if: always() to test workflow done jobs
- Unify format across all 5 required check workflows
- Use bash [[ ]] syntax and clear success/failure messages
- Accept both 'success' and 'skipped' as passing results

Unblock PRs like: https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pull/198