### PR TITLE
fix: debug files in .otel-build use incorrect absolute paths

### DIFF
--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -27,12 +27,12 @@ func (sp *SetupPhase) Debug(msg string, args ...any) { sp.logger.Debug(msg, args
 
 // keepForDebug copies the file to the build temp directory for debugging
 // Error is tolerated as it's not critical.
-func (sp *SetupPhase) keepForDebug(name string) {
-	base := filepath.Base(name)
-	dstFile := filepath.Join(util.GetBuildTemp("debug"), "main", base)
-	err := util.CopyFile(name, dstFile)
+func (sp *SetupPhase) keepForDebug(srcPath string) {
+	base := filepath.Base(srcPath)
+	dstPath := filepath.Join(util.GetBuildTemp("debug"), "main", base)
+	err := util.CopyFile(srcPath, dstPath)
 	if err != nil {
-		sp.Warn("failed to record added file", "file", name, "error", err)
+		sp.Warn("failed to record added file", "path", srcPath, "error", err)
 	}
 }
 


### PR DESCRIPTION
fixes #247 