### PR TITLE
chore(demo): fix go cache mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,14 +110,14 @@ build-demo: build-demo-grpc build-demo-http
 build-demo-grpc: go-protobuf-plugins ## Build gRPC demo server and client
 	@echo "Building gRPC demo..."
 	@rm -f demo/grpc/server/otel.runtime.go demo/grpc/client/otel.runtime.go
-	@(cd demo/grpc/server && go generate && go build -o server .)
-	@(cd demo/grpc/client && go build -o client .)
+	@(cd demo/grpc/server && go generate && go build -a -o server .)
+	@(cd demo/grpc/client && go build -a -o client .)
 
 build-demo-http: ## Build HTTP demo server and client
 	@echo "Building HTTP demo..."
 	@rm -f demo/http/server/otel.runtime.go demo/http/client/otel.runtime.go
-	@(cd demo/http/server && go build -o server .)
-	@(cd demo/http/client && go build -o client .)
+	@(cd demo/http/server && go build -a -o server .)
+	@(cd demo/http/client && go build -a -o client .)
 
 ##@ Code Quality
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/133#issuecomment-3660206266

Replication steps:
- `make build-demo`
- `cd test && go test -json -v ./integration/http_client_test.go`
- `.. && make build-demo`

`make build-demo` builds using the cache. In the first try, the cache is empty, so it builds correctly and populates the cache. The integration test does `go build -a` so it regenerates the caches in a different context. When we do again a `make build-demo`, it used the old cached targets for doing the //go linkname. As they don't match because they were regenerated during integration test, it fails.

The fix should be as simple as forcing rebuild for demo builds.