### PR TITLE
chore: use softprops/action-gh-release instead

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,9 @@ jobs:
           go-version-file: 'go.mod'
       - name: Build binary
         run: make build-all
-      - name: Create Release and Upload Assets
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b  # v1.20.0
+      - name: Create Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
-          # Draft the release so it can be edited before publishing
-          draft: true
-          artifacts: "dist/otel-*"
-          generateReleaseNotes: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            dist/otel-*
+          generate_release_notes: true


### PR DESCRIPTION
Use the more popular softprops/action-gh-release instead of ncipollo/release-action. It provides more configuration options to meet future needs. More importantly, ncipollo/release-action previously seemed unable to trigger release note generation even when generateReleaseNotes was configured, whereas I’ve verified that softprops/action-gh-release can automatically generate release notes.