### PR TITLE
fix(cli): Improved error handling in CLI tool

### DIFF
--- a/tool/ex/error.go
+++ b/tool/ex/error.go
@@ -141,7 +141,8 @@ func Fatalf(format string, args ...any) {
 
 func Fatal(err error) {
 	if err == nil {
-		panic("Fatal error: unknown")
+		fmt.Fprintln(os.Stderr, "Fatal error: unknown")
+		os.Exit(1)
 	}
 	e := &stackfulError{}
 	if errors.As(err, &e) {
@@ -153,7 +154,6 @@ func Fatal(err error) {
 		em += emSb149.String()
 		_, _ = fmt.Fprintf(os.Stderr, "Error:\n%s\nStack:\n%s\n",
 			em, strings.Join(e.frame, "\n"))
-		os.Exit(1)
 	}
-	panic(err)
+	os.Exit(1)
 }


### PR DESCRIPTION
## Description

This PR improves the error handling in the cli part by removing the panic part and replacing it with os.Exit(1).

## Final Output

```bash
➜ ./otel -abc
Incorrect Usage: flag provided but not defined: -abc

NAME:
   otel - OpenTelemetry Go Compile-Time Instrumentation Tool

USAGE:
   otel [global options] [command [command options]]

COMMANDS:
   setup
   go
   version
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --work-dir string, -w string  The path to a directory where working files will be written (default: "/home/tushar/opentelemetry-go-compile-instrumentation/.otel-build")
   ---debug, -d                  Enable debug mode
   --help, -h                    show help
```

Fixes #250 
---