### PR TITLE
feat(tool): support custom rule configuration

### DIFF
--- a/tool/cmd/cmd_go.go
+++ b/tool/cmd/cmd_go.go
@@ -18,6 +18,6 @@ var commandGo = cli.Command{
 	SkipFlagParsing: true,
 	Before:          addLoggerPhaseAttribute,
 	Action: func(ctx context.Context, cmd *cli.Command) error {
-		return setup.GoBuild(ctx, cmd.Args().Slice())
+		return setup.GoBuild(ctx, cmd)
 	},
 }

--- a/tool/cmd/main.go
+++ b/tool/cmd/main.go
@@ -38,6 +38,13 @@ func main() {
 				Usage:   "Enable debug mode",
 				Value:   false,
 			},
+			&cli.StringFlag{
+				Name:      "rules",
+				Aliases:   []string{"rules"},
+				Usage:     "The path to the rules configuration file",
+				TakesFile: true,
+				Value:     "",
+			},
 		},
 		Commands: []*cli.Command{
 			&commandSetup,

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
+	"github.com/urfave/cli/v3"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -236,7 +237,8 @@ func BuildWithToolexec(ctx context.Context, args []string) error {
 	return util.RunCmdWithEnv(ctx, env, newArgs...)
 }
 
-func GoBuild(ctx context.Context, args []string) error {
+func GoBuild(ctx context.Context, cmd *cli.Command) error {
+	args := cmd.Args().Slice()
 	logger := util.LoggerFromContext(ctx)
 	backupFiles := []string{"go.mod", "go.sum", "go.work", "go.work.sum"}
 	err := util.BackupFile(backupFiles)
@@ -263,7 +265,7 @@ func GoBuild(ctx context.Context, args []string) error {
 		}
 	}()
 
-	err = Setup(ctx, os.Args[1:])
+	err = Setup(ctx, append([]string{"go"}, args...))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Allow specifying the rule configuration at compile time

e.g.
```
$ ./otel -rules=custom.yml go build -o app ./cmd/app
```