### PR TITLE
fix(tool): changed ---debug to --debug flag

### DIFF
--- a/tool/cmd/main.go
+++ b/tool/cmd/main.go
@@ -33,7 +33,7 @@ func main() {
 				Value:     util.GetBuildTempDir(),
 			},
 			&cli.BoolFlag{
-				Name:    "-debug",
+				Name:    "debug",
 				Aliases: []string{"d"},
 				Usage:   "Enable debug mode",
 				Value:   false,


### PR DESCRIPTION
## Description

changed ---debug to --debug flag

## Fixes - #280 

## Result
```bash
➜ ./otel --help
NAME:
   otel - OpenTelemetry Go Compile-Time Instrumentation Tool

USAGE:
   otel [global options] [command [command options]]

COMMANDS:
   setup
   go
   version
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --work-dir string, -w string    The path to a directory where working files will be written (default: "/home/tushar/opentelemetry-go-compile-instrumentation/.otel-build")
   --debug, -d                     Enable debug mode
   --rules string, --rules string  The path to the rules configuration file
   --help, -h                      show help

Fixes #280 