### PR TITLE
feat(tool): allow incremental build

### DIFF
--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -248,10 +248,6 @@ func BuildWithToolexec(ctx context.Context, cmd *cli.Command) error {
 	newArgs = append(newArgs, "-work")
 	// Add "-toolexec=..."
 	newArgs = append(newArgs, insert)
-	// TODO: We should support incremental build in the future, so we don't need
-	// to force rebuild here.
-	// Add "-a" to force rebuild
-	newArgs = append(newArgs, "-a")
 	// Add the rest
 	newArgs = append(newArgs, args[1:]...)
 	logger.InfoContext(ctx, "Running go build with toolexec", "args", newArgs)


### PR DESCRIPTION
After #272, multiple go build runs can reuse the same dedicated Go cache for otel. As a result, we no longer need to always force a rebuild and now fully support incremental builds.