### PR TITLE
fix(ci): eliminate pull_request_target ACE in check-registry-diff

### DIFF
--- a/.github/workflows/check-registry-diff.yaml
+++ b/.github/workflows/check-registry-diff.yaml
@@ -5,10 +5,6 @@ on:
     paths:
       - 'pkg/instrumentation/**/semconv/**'
       - '.semconv-version'
-  pull_request_target:
-    paths:
-      - 'pkg/instrumentation/**/semconv/**'
-      - '.semconv-version'
   push:
     branches:
       - main
@@ -18,13 +14,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-
-env:
-  # OTel Weaver version to use for registry checks
-  WEAVER_VERSION: v0.19.0
-  # Semantic conventions registry URL
-  SEMCONV_REGISTRY: https://github.com/open-telemetry/semantic-conventions.git
 
 jobs:
   registry-check:
@@ -85,121 +74,3 @@ jobs:
         run: |
           echo "Validating semantic convention registry for version ${{ steps.read-version.outputs.current_version }}"
           make lint/semantic-conventions
-
-  registry-diff:
-    name: Check Available Updates (Non-blocking)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
-        with:
-          go-version-file: 'go.mod'
-      - name: Install OTel Weaver
-        run: make weaver-install
-
-      - name: Read semconv version
-        id: read-version
-        run: |
-          CURRENT_VERSION=$(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' .semconv-version | head -1 | tr -d '[:space:]')
-          echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Current version: $CURRENT_VERSION"
-
-      - name: Generate registry diff (current vs latest)
-        continue-on-error: true
-        run: |
-          echo "Generating diff between current version and latest (main branch)"
-          make semantic-conventions/diff || echo "::warning::Registry diff generation failed (non-blocking)"
-
-      - name: Upload diff report
-        if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
-        with:
-          name: registry-diff-report
-          path: tmp/registry-diff-latest.md
-          retention-days: 30
-          if-no-files-found: warn
-
-      - name: Comment PR with diff summary
-        if: always()
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
-        with:
-          script: |
-            const fs = require('fs');
-            const diffFile = 'tmp/registry-diff-latest.md';
-
-            let comment = '## 📊 Semantic Convention Registry Update Check\n\n';
-
-            const currentVersion = '${{ steps.read-version.outputs.current_version }}';
-            comment += `**Current Project Version**: \`${currentVersion}\` (from \`.semconv-version\`)\n\n`;
-
-            comment += '> ℹ️ This is a **non-blocking informational check** that shows what semantic convention updates are available. ';
-            comment += 'It helps you stay informed about new conventions without requiring immediate action.\n\n';
-
-            comment += '### 🆕 Available Updates\n\n';
-            comment += `Comparing **latest** (main branch) vs **${currentVersion}** (current)\n\n`;
-
-            if (fs.existsSync(diffFile)) {
-              const diffContent = fs.readFileSync(diffFile, 'utf8');
-              if (diffContent.includes('Registry diff generation failed')) {
-                comment += '⚠️ Could not generate diff (possibly due to network issues). This check is non-blocking.\n\n';
-              } else if (diffContent.trim().length < 50 || diffContent.includes('No changes')) {
-                comment += '✅ **Your project is using the latest semantic conventions!**\n\n';
-                comment += 'No updates are available at this time.\n\n';
-              } else {
-                comment += '💡 **New semantic conventions are available.** Consider updating if these changes are relevant to your instrumentation:\n\n';
-                comment += '<details>\n<summary>📋 View available updates</summary>\n\n';
-                comment += diffContent;
-                comment += '\n</details>\n\n';
-              }
-            } else {
-              comment += '⚠️ Diff report was not generated. This check is non-blocking.\n\n';
-            }
-
-            comment += '---\n\n';
-            comment += '### 📝 What This Means\n\n';
-            comment += '- **Non-blocking**: This check will never fail your PR\n';
-            comment += '- **Informational**: Shows what\'s new in the semantic conventions\n';
-            comment += '- **Optional**: You can choose when to adopt new conventions\n\n';
-
-            comment += '**How to Update** (if desired):\n';
-            comment += '1. Review the changes above to see if they\'re relevant to your use case\n';
-            comment += '2. Update Go imports in `pkg/instrumentation/**/semconv/` to the new semconv version\n';
-            comment += '3. Update the version in `.semconv-version` file\n';
-            comment += '4. Run `make registry-check` locally to validate\n\n';
-
-            comment += '*Generated by [OTel Weaver](https://github.com/open-telemetry/weaver) • Run `make semantic-conventions/diff` locally for details*';
-
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('Semantic Convention Registry Update Check')
-            );
-
-            // Update or create comment
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: comment
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: comment
-              });
-            }

--- a/.github/workflows/comment-registry-diff.yaml
+++ b/.github/workflows/comment-registry-diff.yaml
@@ -1,0 +1,136 @@
+name: Comment Registry Diff
+
+on:
+  workflow_run:
+    workflows: ["Generate Registry Diff"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post Registry Diff Comment
+    runs-on: ubuntu-latest
+    if: "github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'"
+    steps:
+      - name: Download diff report artifact
+        id: download
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6.0.0
+        with:
+          name: registry-diff-report
+          path: tmp
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+        continue-on-error: true
+
+      - name: Validate PR metadata
+        if: steps.download.outcome == 'success'
+        id: validate
+        run: |
+          if [ ! -f tmp/pr-number.txt ]; then
+            echo "::error::PR number file not found in artifact"
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR_NUMBER=$(tr -d '[:space:]' < tmp/pr-number.txt)
+          if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+            echo "::error::Invalid PR number in artifact: $PR_NUMBER"
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+          SEMCONV_VERSION="unknown"
+          if [ -f tmp/semconv-version.txt ]; then
+            RAW_VERSION=$(tr -d '[:space:]' < tmp/semconv-version.txt)
+            if echo "$RAW_VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+              SEMCONV_VERSION="$RAW_VERSION"
+            else
+              echo "::warning::Invalid semconv version format in artifact: $RAW_VERSION"
+            fi
+          fi
+          echo "semconv_version=$SEMCONV_VERSION" >> "$GITHUB_OUTPUT"
+          echo "valid=true" >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment with diff summary
+        if: steps.download.outcome == 'success' && steps.validate.outputs.valid == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        env:
+          PR_NUMBER: ${{ steps.validate.outputs.pr_number }}
+          SEMCONV_VERSION: ${{ steps.validate.outputs.semconv_version }}
+        with:
+          script: |
+            const fs = require('fs');
+            const diffFile = 'tmp/registry-diff-latest.md';
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const currentVersion = process.env.SEMCONV_VERSION;
+
+            let comment = '## 📊 Semantic Convention Registry Update Check\n\n';
+            comment += `**Current Project Version**: \`${currentVersion}\` (from \`.semconv-version\`)\n\n`;
+            comment += '> ℹ️ This is a **non-blocking informational check** that shows what semantic convention updates are available. ';
+            comment += 'It helps you stay informed about new conventions without requiring immediate action.\n\n';
+
+            comment += '### 🆕 Available Updates\n\n';
+            comment += `Comparing **latest** (main branch) vs **${currentVersion}** (current)\n\n`;
+
+            if (fs.existsSync(diffFile)) {
+              const diffContent = fs.readFileSync(diffFile, 'utf8');
+              if (diffContent.includes('Registry diff generation failed')) {
+                comment += '⚠️ Could not generate diff (possibly due to network issues). This check is non-blocking.\n\n';
+              } else if (diffContent.trim().length < 50 || diffContent.includes('No changes')) {
+                comment += '✅ **Your project is using the latest semantic conventions!**\n\n';
+                comment += 'No updates are available at this time.\n\n';
+              } else {
+                comment += '💡 **New semantic conventions are available.** Consider updating if these changes are relevant to your instrumentation:\n\n';
+                comment += '<details>\n<summary>📋 View available updates</summary>\n\n';
+                comment += diffContent;
+                comment += '\n</details>\n\n';
+              }
+            } else {
+              comment += '⚠️ Diff report was not generated. This check is non-blocking.\n\n';
+            }
+
+            comment += '---\n\n';
+            comment += '### 📝 What This Means\n\n';
+            comment += '- **Non-blocking**: This check will never fail your PR\n';
+            comment += '- **Informational**: Shows what\'s new in the semantic conventions\n';
+            comment += '- **Optional**: You can choose when to adopt new conventions\n\n';
+
+            comment += '**How to Update** (if desired):\n';
+            comment += '1. Review the changes above to see if they\'re relevant to your use case\n';
+            comment += '2. Update Go imports in `pkg/instrumentation/**/semconv/` to the new semconv version\n';
+            comment += '3. Update the version in `.semconv-version` file\n';
+            comment += '4. Run `make registry-check` locally to validate\n\n';
+
+            comment += '*Generated by [OTel Weaver](https://github.com/open-telemetry/weaver) • Run `make semantic-conventions/diff` locally for details*';
+
+            // Find existing bot comment to update instead of duplicating
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' &&
+              c.body.includes('Semantic Convention Registry Update Check')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: comment,
+              });
+            }

--- a/.github/workflows/generate-registry-diff.yaml
+++ b/.github/workflows/generate-registry-diff.yaml
@@ -1,0 +1,54 @@
+name: Generate Registry Diff
+
+on:
+  pull_request:
+    paths:
+      - 'pkg/instrumentation/**/semconv/**'
+      - '.semconv-version'
+
+permissions:
+  contents: read
+
+jobs:
+  registry-diff:
+    name: Generate Registry Diff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install OTel Weaver
+        run: make weaver-install
+
+      - name: Read semconv version
+        id: read-version
+        run: |
+          CURRENT_VERSION=$(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' .semconv-version | head -1 | tr -d '[:space:]')
+          echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Current version: $CURRENT_VERSION"
+
+      - name: Generate registry diff (current vs latest)
+        continue-on-error: true
+        run: |
+          echo "Generating diff between current version and latest (main branch)"
+          make semantic-conventions/diff || echo "::warning::Registry diff generation failed (non-blocking)"
+
+      - name: Save PR metadata
+        run: |
+          mkdir -p tmp
+          echo "${{ github.event.pull_request.number }}" > tmp/pr-number.txt
+          echo "${{ steps.read-version.outputs.current_version }}" > tmp/semconv-version.txt
+
+      - name: Upload diff report and PR metadata
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        with:
+          name: registry-diff-report
+          path: |
+            tmp/registry-diff-latest.md
+            tmp/pr-number.txt
+            tmp/semconv-version.txt
+          retention-days: 7
+          if-no-files-found: warn


### PR DESCRIPTION
## Description

Replaces the vulnerable `registry-diff` job in `check-registry-diff.yaml` with a safe two-workflow artifact bridge pattern.

**The vulnerability**: The `registry-diff` job triggered on `pull_request_target` (base repo privileges, `pull-requests: write` token) and explicitly checked out fork code with `ref: ${{ github.event.pull_request.head.sha }}`, then executed `make weaver-install` and `make semantic-conventions/diff` from the attacker's Makefile. Any GitHub user could trigger this by opening a fork PR touching `pkg/instrumentation/**/semconv/**` or `.semconv-version`, achieving arbitrary code execution and GITHUB_TOKEN exfiltration for PR comment manipulation.

This is the same class of vulnerability exploited by the HackerBot-CLAW campaign against open source GitHub Actions workflows.

## Motivation

Closes the attack surface by splitting the job across a trust boundary:

- **`generate-registry-diff.yaml`** — runs on `pull_request` (fork PRs get a read-only sandbox token). Generates the diff from PR code, saves `pr-number.txt` + `semconv-version.txt` + diff markdown as artifacts. No write access.
- **`comment-registry-diff.yaml`** — runs on `workflow_run` (trusted base-repo context). Downloads the artifact, validates the PR number against `^[0-9]+$` and version against `^v[0-9]+\.[0-9]+\.[0-9]+$`, then posts the PR comment. Never executes any fork code.
- **`check-registry-diff.yaml`** — `pull_request_target` trigger, `pull-requests: write` permission, `env:` block, and the entire `registry-diff` job removed. The `registry-check` job is untouched.

Fixes #<!-- issue number -->

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [ ] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Documentation updated (if applicable)