### PR TITLE
fix: replace ex.Fatalf/Assert with error propagation

### DIFF
--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -84,7 +84,9 @@ func stripCompleteFlag(args []string) []string {
 func interceptCompile(ctx context.Context, args []string) ([]string, error) {
 	// Read compilation output directory
 	target := util.FindFlagValue(args, "-o")
-	util.Assert(target != "", "missing -o flag value")
+	if target == "" {
+		return nil, ex.New("missing -o flag value")
+	}
 
 	// Extract -importcfg flag
 	importCfgPath := util.FindFlagValue(args, "-importcfg")

--- a/tool/internal/setup/find.go
+++ b/tool/internal/setup/find.go
@@ -163,7 +163,9 @@ func findGoSources(sp *SetupPhase, args []string, cgoObjDirs map[string]string) 
 		Sources:    make([]string, 0),
 		CgoFiles:   make(map[string]string),
 	}
-	util.Assert(dep.ImportPath != "", "import path is empty")
+	if dep.ImportPath == "" {
+		return nil, ex.New("import path is empty (missing -p flag)")
+	}
 
 	// Find the go files belong to the package as dependency sources
 	for _, arg := range args {
@@ -233,7 +235,9 @@ func (sp *SetupPhase) findDeps(ctx context.Context, goBuildCmd []string) ([]*Dep
 		} else if util.IsCgoCommand(cmd) && currentDir != "" {
 			args := util.SplitCompileCmds(cmd)
 			objDir := util.FindFlagValue(args, "-objdir")
-			util.Assert(objDir != "", "sanity check")
+			if objDir == "" {
+				return nil, ex.Newf("cgo command missing -objdir flag: %s", cmd)
+			}
 			cgoObjDirs[util.NormalizePath(objDir)] = currentDir
 			sp.Debug("Found CGO objdir mapping", "objDir", objDir, "sourceDir", currentDir)
 		}

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -350,7 +350,9 @@ func BuildWithToolexec(ctx context.Context, cmd *cli.Command) error {
 	// Tell the sub-process the working directory
 	env := os.Environ()
 	pwd := util.GetOtelcWorkDir()
-	util.Assert(pwd != "", "invalid working directory")
+	if pwd == "" {
+		return ex.New("invalid working directory: otelc work dir not configured")
+	}
 	env = append(env, fmt.Sprintf("%s=%s", util.EnvOtelcWorkDir, pwd))
 
 	// Extract and forward build flags that affect the build context

--- a/tool/internal/setup/sync.go
+++ b/tool/internal/setup/sync.go
@@ -91,7 +91,9 @@ func (sp *SetupPhase) syncDeps(ctx context.Context, matched []*rule.InstRuleSet,
 	}
 	replaces := make([]*replaceDirective, 0)
 	for _, m := range rules {
-		util.Assert(strings.HasPrefix(m.Path, util.OtelcRoot), "sanity check")
+		if !strings.HasPrefix(m.Path, util.OtelcRoot) {
+			return ex.Newf("hook path %q does not have expected prefix %q", m.Path, util.OtelcRoot)
+		}
 		oldPath := m.Path
 		newPath := strings.TrimPrefix(oldPath, util.OtelcRoot)
 		newPath = filepath.Join(util.GetBuildTempDir(), newPath)


### PR DESCRIPTION
## Summary

`tool/util/assert.go` provided `Fatalf` and `Assert` helpers that called
`os.Exit` on failure. Calling `os.Exit` inside library code is hostile
to testing (defers don't run, test harnesses can't recover) and makes
the tool impossible to embed.

- Remove `Fatalf`/`Assert` from `tool/util`.
- Replace all call sites in `extract.go`, `sys.go`, `go.go`, `main.go`,
  and `pkgload.go` with proper `error` return and propagation.
- Keep a minimal `Unimplemented` panic for truly unreachable code paths
  (replaces the unrecoverable assertion).

## Test plan

- [ ] `make build` succeeds
- [ ] `go test -count=1 -race ./tool/...` passes
- [ ] `golangci-lint run` passes

## Why now

Identified as part of a pre-existing-issues audit of the `main` branch.