### PR TITLE
chore: reduce Renovate bot trigger frequency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,15 +4,19 @@
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "schedule": ["before 8am on the 1st and 15th day of the month"],
+  "updateNotScheduled": false,
   "packageRules": [
     {
-      "groupName": "all non-major versions",
-      "matchUpdateTypes": ["patch", "minor", "digest"],
-      "schedule": ["before 8am on Monday"]
+      "matchFileNames": [".github/**"],
+      "enabled": false
     },
     {
-      "matchUpdateTypes": ["major"],
-      "schedule": ["before 8am on Monday"]
+      "groupName": "all non-major versions",
+      "matchUpdateTypes": ["patch", "minor", "digest"]
+    },
+    {
+      "matchUpdateTypes": ["major"]
     }
   ],
   "labels": [


### PR DESCRIPTION
The Renovate bot was triggering too frequently. I've made some adjustments to reduce its activity:

- Reduced frequency from weekly to twice a month (1st and 15th)
- Disabled triggering after PR merges
- Disabled scanning and updating Go dependencies in the .github/ directory

This should resolve the issue where dependency update PRs (e.g., #102 #172 #220 etc ) kept appearing after every PR merge.