### PR TITLE
docs(adr): initialize ADR scaffold with Makefile targets and initial records

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,11 +141,35 @@ The following development tools are used and will be automatically installed on 
 - **[ratchet](https://github.com/sethvargo/ratchet)** - GitHub Actions security pinning
 - **[embedmd](https://github.com/campoy/embedmd)** - Embed code in markdown files
 
+### Architecture Decision Records
+
+Significant architectural decisions are documented as Architecture Decision Records (ADRs) in [`docs/adr/`](docs/adr/). Read them to understand *why* the project is structured the way it is.
+
+Create a new ADR when proposing:
+
+- Changes to the instrumentation API or hook model
+- New external dependencies or replacements
+- Changes to the two-phase build process
+- Any decision the SIG discusses and reaches consensus on
+
+To create a new ADR:
+
+```sh
+make adr-new TITLE="Title of Your Decision"
+```
+
+This requires `adr-tools` (`npryce/adr-tools`). Run `make adr-tools` to install it. To list existing ADRs:
+
+```sh
+make adr-list
+```
+
 ## AI Usage
 
 This project welcomes the use of AI tools. Please read the [AI Usage Policy](AI_POLICY.md) before
 contributing. The critical rule is: **you must understand every line of code you submit.**
 Contributors using AI tools are held to the same quality standards as any other contribution.
+
 
 ## Pull Requests
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ SHELL := /bin/bash
         test-unit/update-golden test-unit/tool test-unit/pkg test-unit/demo \
         test-unit/coverage test-unit/tool/coverage test-unit/pkg/coverage \
         test-integration/coverage test-e2e/coverage \
-        registry-diff registry-check registry-resolve weaver-install tidy/test-apps
+        registry-diff registry-check registry-resolve weaver-install tidy/test-apps \
+        adr-tools adr-new adr-list
 
 # Constant variables
 BINARY_NAME := otelc
@@ -261,6 +262,53 @@ tmp/make-help.txt: ## Generate make help output for embedding in documentation
 tmp/make-help.txt: $(MAKEFILE_LIST)
 	@mkdir -p tmp
 	@$(MAKE) --no-print-directory help > tmp/make-help.txt
+
+##@ Architecture Decision Records
+
+adr-tools: ## Install adr-tools if not present
+	@if command -v adr >/dev/null 2>&1; then \
+		echo "adr-tools is already installed at $$(command -v adr)"; \
+	else \
+		echo "Installing adr-tools..."; \
+		if [ "$$(uname -s)" = "Darwin" ]; then \
+			if command -v brew >/dev/null 2>&1; then \
+				brew install adr-tools; \
+			else \
+				echo "Error: Homebrew not found. Install Homebrew from https://brew.sh/ and try again."; \
+				exit 1; \
+			fi; \
+		elif [ "$$(uname -s)" = "Linux" ]; then \
+			TMPDIR=$$(mktemp -d); \
+			git clone --depth 1 https://github.com/npryce/adr-tools.git "$$TMPDIR/adr-tools"; \
+			mkdir -p "$$(go env GOPATH)/bin"; \
+			cp "$$TMPDIR/adr-tools/src/"adr-* "$$(go env GOPATH)/bin/"; \
+			chmod +x "$$(go env GOPATH)/bin/adr-"*; \
+			rm -rf "$$TMPDIR"; \
+			echo "Installed adr-tools to $$(go env GOPATH)/bin/"; \
+		else \
+			echo "Error: Unsupported platform $$(uname -s)"; \
+			echo "Please install adr-tools manually from https://github.com/npryce/adr-tools"; \
+			exit 1; \
+		fi; \
+	fi
+
+adr-new: ## Create a new ADR: make adr-new TITLE="Short decision title"
+	@if ! command -v adr >/dev/null 2>&1; then \
+		echo "adr-tools not found. Run 'make adr-tools' to install."; \
+		exit 1; \
+	fi
+	@if [ -z "$(TITLE)" ]; then \
+		echo "Usage: make adr-new TITLE=\"Short decision title\""; \
+		exit 1; \
+	fi
+	adr new -c docs/adr "$(TITLE)"
+
+adr-list: ## List all ADRs
+	@if ! command -v adr >/dev/null 2>&1; then \
+		echo "adr-tools not found. Run 'make adr-tools' to install."; \
+		exit 1; \
+	fi
+	adr list -c docs/adr
 
 ##@ Validation
 

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,34 @@
+# 1. Record Architecture Decisions
+
+Date: 2026-03-19
+
+## Status
+
+Accepted
+
+## Context
+
+As the OpenTelemetry Go compile-time instrumentation project grows and more contributors join the SIG, we need a lightweight way to capture significant architectural decisions with their context and rationale. Without this, it becomes difficult to understand *why* things are the way they are, leading to repeated debates or inadvertent reversals of past decisions.
+
+## Decision
+
+We will use Architecture Decision Records (ADRs) as described by Michael Nygard in his article [Documenting Architecture Decisions](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+ADRs will be stored in `docs/adr/` as numbered Markdown files. The `adr-tools` CLI (`npryce/adr-tools`) is available for creating and linking records. A `.adr-dir` file at the repository root points tools to the correct directory.
+
+New ADRs should be created for:
+
+- Significant changes to the instrumentation API or hook model
+- Adoption or rejection of external dependencies
+- Changes to the two-phase build process (setup/instrument)
+- Decisions about semantic convention support
+- Any decision the SIG discusses and reaches consensus on
+
+Use `make adr-new "Title of Decision"` to create a new ADR from the template.
+
+## Consequences
+
+- Architectural decisions are discoverable alongside the code.
+- Contributors can understand the reasoning behind the current design without reading meeting notes.
+- New decisions require a short writeup, which is a small but deliberate overhead.
+- ADRs are immutable records: superseded decisions are marked as such rather than deleted.

--- a/docs/adr/0002-api-design-and-project-structure.md
+++ b/docs/adr/0002-api-design-and-project-structure.md
@@ -1,0 +1,37 @@
+# 2. API Design and Project Structure
+
+Date: 2026-03-19
+
+## Status
+
+Accepted
+
+## Context
+
+Compile-time instrumentation requires a clear contract between the tool that rewrites code and the hook functions that are injected. Without a stable API design, adding new instrumentations becomes difficult to reason about and the generated code becomes fragile.
+
+The project also needs a project layout that separates the compile-time tool from the runtime instrumentation packages, since they have fundamentally different lifecycles and dependency graphs.
+
+## Decision
+
+The full design is documented in [`docs/api-design-and-project-structure.md`](../api-design-and-project-structure.md). The key decisions captured here are:
+
+**Hook model**: Instrumentation is expressed as pairs of plain Go functions — `Before*` and `After*` hooks — injected around target function calls via AST rewriting. This is simpler than an instrumenter hierarchy and avoids heavy abstractions.
+
+**HookContext interface**: A single interface (`inst.HookContext`) is injected as the first parameter of every hook function. It provides `GetParam`/`SetParam` for reading and modifying target function arguments, and `GetKeyData`/`SetKeyData` for passing state between `Before` and `After` hooks.
+
+**Semantic conventions as pure functions**: Attribute extraction helpers live in `semconv` sub-packages and are pure functions. They have no side effects and no dependency on the hook lifecycle.
+
+**Two-phase build**:
+1. *Setup* (`tool/internal/setup`): Discovers dependencies, matches hook rules, generates `otel_import.go`, and runs `go mod tidy`.
+2. *Instrument* (`tool/internal/instrument`): Intercepts compilation via `-toolexec`, rewrites source files with AST manipulation using `github.com/dave/dst`, and compiles the modified files.
+
+**Project layout**: `pkg/` contains all runtime packages (public API, instrumentation implementations). `tool/` contains the compile-time tool. They are separate Go modules so that instrumented applications do not transitively depend on tool internals.
+
+## Consequences
+
+- Adding a new library instrumentation is straightforward: implement `Before`/`After` functions, create a `semconv` package, and add a YAML rule file.
+- The `HookContext` interface is the stability boundary. Changes to it require regenerating all hook call sites.
+- Using `github.com/dave/dst` instead of `go/ast` preserves comments and formatting but introduces a dependency on a third-party AST library.
+- The two-phase approach means instrumentation is baked into the binary at compile time — zero runtime overhead — at the cost of a modified build invocation (`otelc build` instead of `go build`).
+- Separate `pkg/` and `tool/` modules prevent accidental tight coupling between runtime and compile-time code.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,19 @@
+# NUMBER. TITLE
+
+Date: DATE
+
+## Status
+
+STATUS
+
+## Context
+
+CONTEXT
+
+## Decision
+
+DECISION
+
+## Consequences
+
+CONSEQUENCES


### PR DESCRIPTION
## Description

Introduces Architecture Decision Records (ADRs) to the project:

- `.adr-dir` — tells `adr-tools` where to find ADRs (`docs/adr/`)
- `docs/adr/template.md` — Michael Nygard ADR template
- `docs/adr/0001-record-architecture-decisions.md` — meta-ADR documenting the decision to use ADRs
- `docs/adr/0002-api-design-and-project-structure.md` — documents the hook model, HookContext interface, semantic conventions pattern, and two-phase build; references the existing `docs/api-design-and-project-structure.md` rather than duplicating it
- `Makefile` — three new targets under `##@ Architecture Decision Records`: `adr-tools` (install), `adr-new TITLE=...` (create), `adr-list` (enumerate)
- `CONTRIBUTING.md` — new "Architecture Decision Records" section explaining when and how to create an ADR

## Motivation

The SIG agreed to adopt ADRs to capture architectural decisions with their context and rationale, making it easier for new contributors to understand *why* the project is structured the way it is without reading through meeting notes.

Fixes #27

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [ ] Tests pass: `make test`
- [x] Tests added for new functionality — N/A (documentation only)
- [x] Tests follow [testing guidelines](docs/testing.md) — N/A
- [x] Documentation updated (if applicable)