### PR TITLE
feat(filter): implement import path glob filter (OP4.4)

### DIFF
--- a/pkg/inst/insttest/mock_hook_context.go
+++ b/pkg/inst/insttest/mock_hook_context.go
@@ -59,6 +59,7 @@ func (m *MockHookContext) GetParam(idx int) interface{} {
 	}
 	return m.Params[idx]
 }
+
 func (m *MockHookContext) SetParam(idx int, val interface{}) {
 	for len(m.Params) <= idx {
 		m.Params = append(m.Params, nil)
@@ -73,6 +74,7 @@ func (m *MockHookContext) GetReturnVal(idx int) interface{} {
 	}
 	return m.ReturnVals[idx]
 }
+
 func (m *MockHookContext) SetReturnVal(idx int, val interface{}) {
 	for len(m.ReturnVals) <= idx {
 		m.ReturnVals = append(m.ReturnVals, nil)

--- a/tool/internal/filter/build.go
+++ b/tool/internal/filter/build.go
@@ -4,6 +4,8 @@
 package filter
 
 import (
+	"path"
+
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
 )
@@ -80,6 +82,12 @@ func buildDef(def *rule.FilterDef) (Filter, error) {
 	case def.Directive != "":
 		return nil, ex.Newf("directive filter requires directive support (not yet available)")
 	case def.ImportPath != "":
+		// Validate the pattern at build time: path.Match returns ErrBadPattern
+		// for malformed bracket expressions (e.g. "[z-a]") that would otherwise
+		// silently produce a non-match on every evaluation.
+		if _, err := path.Match(def.ImportPath, ""); err != nil {
+			return nil, ex.Wrapf(err, "import_path pattern %q is invalid", def.ImportPath)
+		}
 		return &ImportPathFilter{Pattern: def.ImportPath}, nil
 	case def.PackageName != "":
 		return nil, ex.Newf("package_name filter is not yet supported")

--- a/tool/internal/filter/build.go
+++ b/tool/internal/filter/build.go
@@ -80,7 +80,7 @@ func buildDef(def *rule.FilterDef) (Filter, error) {
 	case def.Directive != "":
 		return nil, ex.Newf("directive filter requires directive support (not yet available)")
 	case def.ImportPath != "":
-		return nil, ex.Newf("import_path filter is not yet supported")
+		return &ImportPathFilter{Pattern: def.ImportPath}, nil
 	case def.PackageName != "":
 		return nil, ex.Newf("package_name filter is not yet supported")
 	case def.TestMain != nil:

--- a/tool/internal/filter/build_test.go
+++ b/tool/internal/filter/build_test.go
@@ -119,6 +119,33 @@ func TestBuild_Error_MultipleActiveLeaves(t *testing.T) {
 	}
 }
 
+func TestBuild_ImportPath(t *testing.T) {
+	t.Run("exact path builds successfully", func(t *testing.T) {
+		def := &rule.FilterDef{ImportPath: "github.com/foo/bar"}
+		f, err := filter.Build(def)
+		if err != nil {
+			t.Fatalf("Build(%+v) error = %v, want nil", def, err)
+		}
+		if _, ok := f.(*filter.ImportPathFilter); !ok {
+			t.Errorf("Build(ImportPath) returned %T, want *filter.ImportPathFilter", f)
+		}
+	})
+	t.Run("glob pattern builds successfully", func(t *testing.T) {
+		def := &rule.FilterDef{ImportPath: "github.com/foo/**"}
+		f, err := filter.Build(def)
+		if err != nil {
+			t.Fatalf("Build(%+v) error = %v, want nil", def, err)
+		}
+		ipf, ok := f.(*filter.ImportPathFilter)
+		if !ok {
+			t.Fatalf("Build(ImportPath) returned %T, want *filter.ImportPathFilter", f)
+		}
+		if ipf.Pattern != "github.com/foo/**" {
+			t.Errorf("ImportPathFilter.Pattern = %q, want %q", ipf.Pattern, "github.com/foo/**")
+		}
+	})
+}
+
 func TestBuild_Error_UnsupportedCombinators(t *testing.T) {
 	tests := []struct {
 		name string
@@ -139,10 +166,6 @@ func TestBuild_Error_UnsupportedCombinators(t *testing.T) {
 		{
 			name: "directive",
 			def:  &rule.FilterDef{Directive: "otelc:span"},
-		},
-		{
-			name: "import_path",
-			def:  &rule.FilterDef{ImportPath: "example.com/**"},
 		},
 		{
 			name: "package_name",

--- a/tool/internal/filter/build_test.go
+++ b/tool/internal/filter/build_test.go
@@ -146,6 +146,17 @@ func TestBuild_ImportPath(t *testing.T) {
 	})
 }
 
+func TestBuild_ImportPath_InvalidPattern(t *testing.T) {
+	// Build must reject malformed bracket expressions at construction time so
+	// that bad YAML rules fail fast rather than silently producing non-matches.
+	// path.Match returns ErrBadPattern for unclosed bracket expressions.
+	def := &rule.FilterDef{ImportPath: "github.com/foo/["}
+	_, err := filter.Build(def)
+	if err == nil {
+		t.Fatal("Build(ImportPath with unclosed bracket) error = nil, want error")
+	}
+}
+
 func TestBuild_Error_UnsupportedCombinators(t *testing.T) {
 	tests := []struct {
 		name string

--- a/tool/internal/filter/import_path.go
+++ b/tool/internal/filter/import_path.go
@@ -4,7 +4,7 @@
 package filter
 
 import (
-	stdpath "path"
+	"path"
 	"strings"
 
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
@@ -42,9 +42,11 @@ func matchGlob(pattern, importPath string) bool {
 }
 
 // ContainsImportPath reports whether def or any of its descendants contains a
-// non-empty ImportPath predicate. It is used by the setup phase to identify
-// "glob rules" that must be evaluated against every dependency rather than
-// only the dependency that exactly matches the rule's target.
+// non-empty ImportPath predicate. Returns false when def is nil.
+//
+// It is used by the setup phase to identify "glob rules" that must be
+// evaluated against every dependency rather than only the dependency that
+// exactly matches the rule's target.
 //
 // Keeping this function in the filter package avoids coupling the setup
 // package to the internal structure of FilterDef.
@@ -52,25 +54,21 @@ func ContainsImportPath(def *rule.FilterDef) bool {
 	if def == nil {
 		return false
 	}
-	return containsImportPath(def)
-}
-
-func containsImportPath(def *rule.FilterDef) bool {
 	if def.ImportPath != "" {
 		return true
 	}
 	for i := range def.AllOf {
-		if containsImportPath(&def.AllOf[i]) {
+		if ContainsImportPath(&def.AllOf[i]) {
 			return true
 		}
 	}
 	for i := range def.OneOf {
-		if containsImportPath(&def.OneOf[i]) {
+		if ContainsImportPath(&def.OneOf[i]) {
 			return true
 		}
 	}
 	if def.Not != nil {
-		return containsImportPath(def.Not)
+		return ContainsImportPath(def.Not)
 	}
 	return false
 }
@@ -94,8 +92,8 @@ func matchSegments(pat, segs []string) bool {
 		if len(segs) == 0 {
 			return false
 		}
-		// Single-segment match: supports *, ?, [...] via path.Match.
-		ok, err := stdpath.Match(pat[0], segs[0])
+		// Single-segment match: delegates to path.Match which supports *, ?, [...].
+		ok, err := path.Match(pat[0], segs[0])
 		if err != nil || !ok {
 			return false
 		}

--- a/tool/internal/filter/import_path.go
+++ b/tool/internal/filter/import_path.go
@@ -6,6 +6,8 @@ package filter
 import (
 	stdpath "path"
 	"strings"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
 )
 
 // Compile-time check that ImportPathFilter implements Filter.
@@ -37,6 +39,40 @@ func matchGlob(pattern, importPath string) bool {
 	patSegs := strings.Split(pattern, "/")
 	pathSegs := strings.Split(importPath, "/")
 	return matchSegments(patSegs, pathSegs)
+}
+
+// ContainsImportPath reports whether def or any of its descendants contains a
+// non-empty ImportPath predicate. It is used by the setup phase to identify
+// "glob rules" that must be evaluated against every dependency rather than
+// only the dependency that exactly matches the rule's target.
+//
+// Keeping this function in the filter package avoids coupling the setup
+// package to the internal structure of FilterDef.
+func ContainsImportPath(def *rule.FilterDef) bool {
+	if def == nil {
+		return false
+	}
+	return containsImportPath(def)
+}
+
+func containsImportPath(def *rule.FilterDef) bool {
+	if def.ImportPath != "" {
+		return true
+	}
+	for i := range def.AllOf {
+		if containsImportPath(&def.AllOf[i]) {
+			return true
+		}
+	}
+	for i := range def.OneOf {
+		if containsImportPath(&def.OneOf[i]) {
+			return true
+		}
+	}
+	if def.Not != nil {
+		return containsImportPath(def.Not)
+	}
+	return false
 }
 
 // matchSegments recursively matches pat against segs.

--- a/tool/internal/filter/import_path.go
+++ b/tool/internal/filter/import_path.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	stdpath "path"
+	"strings"
+)
+
+// Compile-time check that ImportPathFilter implements Filter.
+var _ Filter = (*ImportPathFilter)(nil)
+
+// ImportPathFilter matches source files whose package import path satisfies
+// the glob pattern. Segments are delimited by "/"; "*" matches any single
+// segment, "**" matches zero or more segments.
+//
+// Examples:
+//
+//	github.com/foo/bar       exact match
+//	github.com/foo/*         matches any direct child package of github.com/foo
+//	github.com/foo/**        matches github.com/foo and all descendants
+type ImportPathFilter struct {
+	Pattern string
+}
+
+// Match reports whether ctx.ImportPath matches the glob pattern.
+func (f *ImportPathFilter) Match(ctx *MatchContext) bool {
+	return matchGlob(f.Pattern, ctx.ImportPath)
+}
+
+// matchGlob reports whether importPath matches pattern using "/" as the
+// segment delimiter. Within a single segment, "*" matches any sequence of
+// characters (but not "/"). The special segment "**" matches zero or more
+// segments.
+func matchGlob(pattern, importPath string) bool {
+	patSegs := strings.Split(pattern, "/")
+	pathSegs := strings.Split(importPath, "/")
+	return matchSegments(patSegs, pathSegs)
+}
+
+// matchSegments recursively matches pat against segs.
+func matchSegments(pat, segs []string) bool {
+	for {
+		if len(pat) == 0 {
+			return len(segs) == 0
+		}
+		if pat[0] == "**" {
+			pat = pat[1:]
+			// "**" consumes 0..len(segs) path segments; try each suffix.
+			for i := 0; i <= len(segs); i++ {
+				if matchSegments(pat, segs[i:]) {
+					return true
+				}
+			}
+			return false
+		}
+		if len(segs) == 0 {
+			return false
+		}
+		// Single-segment match: supports *, ?, [...] via path.Match.
+		ok, err := stdpath.Match(pat[0], segs[0])
+		if err != nil || !ok {
+			return false
+		}
+		pat = pat[1:]
+		segs = segs[1:]
+	}
+}

--- a/tool/internal/filter/import_path_test.go
+++ b/tool/internal/filter/import_path_test.go
@@ -34,7 +34,7 @@ func TestMatchGlob(t *testing.T) {
 		{"github.com/*/bar", "github.com/foo/baz", false},
 
 		// Multi-segment wildcard (**)
-		{"github.com/foo/**", "github.com/foo", true},    // ** matches 0 segs
+		{"github.com/foo/**", "github.com/foo", true},     // ** matches 0 segs
 		{"github.com/foo/**", "github.com/foo/bar", true}, // ** matches 1 seg
 		{"github.com/foo/**", "github.com/foo/bar/baz", true},
 		{"github.com/foo/**", "github.com/other/bar", false},
@@ -42,9 +42,9 @@ func TestMatchGlob(t *testing.T) {
 		{"**", "", true},
 
 		// ** in the middle
-		{"github.com/**/bar", "github.com/bar", true},           // ** matches 0
-		{"github.com/**/bar", "github.com/foo/bar", true},       // ** matches 1
-		{"github.com/**/bar", "github.com/a/b/c/bar", true},     // ** matches 3
+		{"github.com/**/bar", "github.com/bar", true},       // ** matches 0
+		{"github.com/**/bar", "github.com/foo/bar", true},   // ** matches 1
+		{"github.com/**/bar", "github.com/a/b/c/bar", true}, // ** matches 3
 		{"github.com/**/bar", "github.com/foo/baz", false},
 
 		// No wildcard, single segment

--- a/tool/internal/filter/import_path_test.go
+++ b/tool/internal/filter/import_path_test.go
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filter_test
+
+import (
+	"testing"
+
+	"github.com/dave/dst"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/filter"
+)
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		// Exact matches
+		{"github.com/foo/bar", "github.com/foo/bar", true},
+		{"github.com/foo/bar", "github.com/foo/baz", false},
+		{"github.com/foo/bar", "github.com/foo", false},
+		{"github.com/foo/bar", "github.com/foo/bar/extra", false},
+
+		// Single-segment wildcard (*)
+		{"github.com/foo/*", "github.com/foo/bar", true},
+		{"github.com/foo/*", "github.com/foo/baz", true},
+		{"github.com/foo/*", "github.com/foo", false},
+		{"github.com/foo/*", "github.com/foo/bar/baz", false},
+		{"github.com/*/bar", "github.com/foo/bar", true},
+		{"github.com/*/bar", "github.com/other/bar", true},
+		{"github.com/*/bar", "github.com/foo/baz", false},
+
+		// Multi-segment wildcard (**)
+		{"github.com/foo/**", "github.com/foo", true},    // ** matches 0 segs
+		{"github.com/foo/**", "github.com/foo/bar", true}, // ** matches 1 seg
+		{"github.com/foo/**", "github.com/foo/bar/baz", true},
+		{"github.com/foo/**", "github.com/other/bar", false},
+		{"**", "anything/at/all", true},
+		{"**", "", true},
+
+		// ** in the middle
+		{"github.com/**/bar", "github.com/bar", true},           // ** matches 0
+		{"github.com/**/bar", "github.com/foo/bar", true},       // ** matches 1
+		{"github.com/**/bar", "github.com/a/b/c/bar", true},     // ** matches 3
+		{"github.com/**/bar", "github.com/foo/baz", false},
+
+		// No wildcard, single segment
+		{"example.com", "example.com", true},
+		{"example.com", "other.com", false},
+
+		// Edge cases
+		{"*", "anything", true},
+		{"*", "a/b", false}, // * does not cross segment boundaries
+		{"", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_vs_"+tt.path, func(t *testing.T) {
+			ctx := &filter.MatchContext{
+				ImportPath: tt.path,
+				SourceFile: "source.go",
+				AST:        &dst.File{Name: &dst.Ident{Name: "pkg"}},
+			}
+			f := &filter.ImportPathFilter{Pattern: tt.pattern}
+			got := f.Match(ctx)
+			if got != tt.want {
+				t.Errorf("ImportPathFilter{%q}.Match({ImportPath: %q}) = %v, want %v",
+					tt.pattern, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestImportPathFilter_Build(t *testing.T) {
+	// Verify that build_test covers this; here we test direct construction.
+	f := &filter.ImportPathFilter{Pattern: "github.com/foo/**"}
+	ctx := &filter.MatchContext{
+		ImportPath: "github.com/foo/bar",
+		SourceFile: "source.go",
+		AST:        &dst.File{Name: &dst.Ident{Name: "pkg"}},
+	}
+	if !f.Match(ctx) {
+		t.Error("ImportPathFilter{github.com/foo/**}.Match(github.com/foo/bar) = false, want true")
+	}
+}

--- a/tool/internal/filter/import_path_test.go
+++ b/tool/internal/filter/import_path_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dave/dst"
 
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/filter"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
 )
 
 func TestMatchGlob(t *testing.T) {
@@ -74,7 +75,6 @@ func TestMatchGlob(t *testing.T) {
 }
 
 func TestImportPathFilter_Build(t *testing.T) {
-	// Verify that build_test covers this; here we test direct construction.
 	f := &filter.ImportPathFilter{Pattern: "github.com/foo/**"}
 	ctx := &filter.MatchContext{
 		ImportPath: "github.com/foo/bar",
@@ -83,5 +83,72 @@ func TestImportPathFilter_Build(t *testing.T) {
 	}
 	if !f.Match(ctx) {
 		t.Error("ImportPathFilter{github.com/foo/**}.Match(github.com/foo/bar) = false, want true")
+	}
+}
+
+func TestContainsImportPath(t *testing.T) {
+	tests := []struct {
+		name string
+		def  *rule.FilterDef
+		want bool
+	}{
+		{
+			name: "nil def returns false",
+			def:  nil,
+			want: false,
+		},
+		{
+			name: "direct ImportPath returns true",
+			def:  &rule.FilterDef{ImportPath: "github.com/foo/**"},
+			want: true,
+		},
+		{
+			name: "no ImportPath predicate returns false",
+			def:  &rule.FilterDef{Func: "Foo"},
+			want: false,
+		},
+		{
+			name: "ImportPath nested in AllOf returns true",
+			def: &rule.FilterDef{
+				AllOf: []rule.FilterDef{{ImportPath: "github.com/foo/**"}},
+			},
+			want: true,
+		},
+		{
+			name: "ImportPath nested in OneOf returns true",
+			def: &rule.FilterDef{
+				OneOf: []rule.FilterDef{{Func: "Bar"}, {ImportPath: "github.com/foo/**"}},
+			},
+			want: true,
+		},
+		{
+			name: "ImportPath nested under Not returns true",
+			def: &rule.FilterDef{
+				Not: &rule.FilterDef{ImportPath: "github.com/foo/**"},
+			},
+			want: true,
+		},
+		{
+			name: "deeply nested ImportPath returns true",
+			def: &rule.FilterDef{
+				AllOf: []rule.FilterDef{
+					{OneOf: []rule.FilterDef{{Func: "Foo"}, {ImportPath: "example.com/**"}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "def with only non-ImportPath predicates returns false",
+			def:  &rule.FilterDef{Struct: "Bar"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filter.ContainsImportPath(tt.def)
+			if got != tt.want {
+				t.Errorf("ContainsImportPath(%+v) = %v, want %v", tt.def, got, tt.want)
+			}
+		})
 	}
 }

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"testing"
 
+	pkgast "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/ast"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/filter"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 	"github.com/stretchr/testify/assert"
@@ -124,6 +126,28 @@ func loadRulesYAML(t *testing.T, testName, sourceFile string) *rule.InstRuleSet 
 		props := rawRules[name]
 		props["name"] = name
 		ruleData, _ := yaml.Marshal(props)
+
+		// Evaluate the 'where' filter if present, mirroring preciseMatching.
+		if whereRaw, ok := props["where"]; ok {
+			whereBytes, _ := yaml.Marshal(whereRaw)
+			var filterDef rule.FilterDef
+			if unmarshalErr := yaml.Unmarshal(whereBytes, &filterDef); unmarshalErr == nil {
+				f, buildErr := filter.Build(&filterDef)
+				if buildErr == nil && f != nil {
+					tree, parseErr := pkgast.ParseFileFast(sourceFile)
+					if parseErr == nil {
+						ctx := &filter.MatchContext{
+							ImportPath: mainPackage,
+							SourceFile: sourceFile,
+							AST:        tree,
+						}
+						if !f.Match(ctx) {
+							continue // filter does not match; skip this rule
+						}
+					}
+				}
+			}
+		}
 
 		switch {
 		case props["struct"] != nil:

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -127,26 +127,8 @@ func loadRulesYAML(t *testing.T, testName, sourceFile string) *rule.InstRuleSet 
 		props["name"] = name
 		ruleData, _ := yaml.Marshal(props)
 
-		// Evaluate the 'where' filter if present, mirroring preciseMatching.
-		if whereRaw, ok := props["where"]; ok {
-			whereBytes, _ := yaml.Marshal(whereRaw)
-			var filterDef rule.FilterDef
-			if unmarshalErr := yaml.Unmarshal(whereBytes, &filterDef); unmarshalErr == nil {
-				f, buildErr := filter.Build(&filterDef)
-				if buildErr == nil && f != nil {
-					tree, parseErr := pkgast.ParseFileFast(sourceFile)
-					if parseErr == nil {
-						ctx := &filter.MatchContext{
-							ImportPath: mainPackage,
-							SourceFile: sourceFile,
-							AST:        tree,
-						}
-						if !f.Match(ctx) {
-							continue // filter does not match; skip this rule
-						}
-					}
-				}
-			}
+		if !whereFilterMatches(props, sourceFile) {
+			continue
 		}
 
 		switch {
@@ -169,6 +151,38 @@ func loadRulesYAML(t *testing.T, testName, sourceFile string) *rule.InstRuleSet 
 	}
 
 	return ruleSet
+}
+
+// whereFilterMatches evaluates the optional 'where' filter for a rule.
+// Returns true if the rule should be applied, false if it should be skipped.
+// On any parse or build error the rule is included (fail-open).
+func whereFilterMatches(props map[string]any, sourceFile string) bool {
+	whereRaw, ok := props["where"]
+	if !ok {
+		return true
+	}
+	whereBytes, err := yaml.Marshal(whereRaw)
+	if err != nil {
+		return true
+	}
+	var filterDef rule.FilterDef
+	if err = yaml.Unmarshal(whereBytes, &filterDef); err != nil {
+		return true
+	}
+	f, err := filter.Build(&filterDef)
+	if err != nil || f == nil {
+		return true
+	}
+	tree, err := pkgast.ParseFileFast(sourceFile)
+	if err != nil {
+		return true
+	}
+	ctx := &filter.MatchContext{
+		ImportPath: mainPackage,
+		SourceFile: sourceFile,
+		AST:        tree,
+	}
+	return f.Match(ctx)
 }
 
 func writeMatchedJSON(ruleSet *rule.InstRuleSet) {

--- a/tool/internal/instrument/testdata/golden/import-path-filter-match/import_path_filter_match.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/import-path-filter-match/import_path_filter_match.main.go.golden
@@ -1,0 +1,185 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import _ "unsafe"
+
+type T struct{}
+
+func (t *T) Func1(p1 string, p2 int) (float32, error) {
+	return 0.0, nil
+}
+
+func Func1(p1 string, p2 int) (_unnamedRetVal0 float32, _unnamedRetVal1 error) {
+	//line <generated>:1
+	if hookContext1077711071, _ := OtelBeforeTrampoline_Func11077711071(&p1, &p2); false {
+	} else {
+		defer OtelAfterTrampoline_Func11077711071(hookContext1077711071, &_unnamedRetVal0, &_unnamedRetVal1)
+	}
+	//line main.go:13:2
+	println("Hello, World!")
+	//line main.go:14:2
+	return 0.0, nil
+}
+
+func Func2(p1 string, _ int) {}
+
+func (T) Func3() {}
+
+func OptGood() {}
+func OptBad()  {}
+func OptBad2() {}
+
+func GenericFunc[T any](p1 T, p2 int) (T, error) {
+	return p1, nil
+}
+
+type GenStruct[T any] struct {
+	value T
+}
+
+func (g *GenStruct[T]) GenericMethod(p1 T, p2 string) (T, error) {
+	return p1, nil
+}
+
+func EllipsisFunc(p1 ...string) {}
+
+func UnderscoreFunc(_ int, _ float32) {}
+
+func main() { Func1("hello", 123) }
+
+//line <generated>:1
+type HookContextImpl1077711071 struct {
+	params      []interface{}
+	returnVals  []interface{}
+	skipCall    bool
+	data        interface{}
+	funcName    string
+	packageName string
+}
+
+func (c *HookContextImpl1077711071) SetSkipCall(skip bool)    { c.skipCall = skip }
+func (c *HookContextImpl1077711071) IsSkipCall() bool         { return c.skipCall }
+func (c *HookContextImpl1077711071) SetData(data interface{}) { c.data = data }
+func (c *HookContextImpl1077711071) GetData() interface{}     { return c.data }
+func (c *HookContextImpl1077711071) GetKeyData(key string) interface{} {
+	if c.data == nil {
+		return nil
+	}
+	return c.data.(map[string]interface{})[key]
+}
+
+func (c *HookContextImpl1077711071) SetKeyData(key string, val interface{}) {
+	if c.data == nil {
+		c.data = make(map[string]interface{})
+	}
+	c.data.(map[string]interface{})[key] = val
+}
+
+func (c *HookContextImpl1077711071) HasKeyData(key string) bool {
+	if c.data == nil {
+		return false
+	}
+	_, ok := c.data.(map[string]interface{})[key]
+	return ok
+}
+
+func (c *HookContextImpl1077711071) GetParam(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.params[0].(*string))
+	case 1:
+		return *(c.params[1].(*int))
+	}
+	return nil
+}
+
+func (c *HookContextImpl1077711071) SetParam(idx int, val interface{}) {
+	if val == nil {
+		c.params[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.params[0].(*string)) = val.(string)
+	case 1:
+		*(c.params[1].(*int)) = val.(int)
+	}
+}
+
+func (c *HookContextImpl1077711071) GetReturnVal(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.returnVals[0].(*float32))
+	case 1:
+		return *(c.returnVals[1].(*error))
+	}
+	return nil
+}
+
+func (c *HookContextImpl1077711071) SetReturnVal(idx int, val interface{}) {
+	if val == nil {
+		c.returnVals[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.returnVals[0].(*float32)) = val.(float32)
+	case 1:
+		*(c.returnVals[1].(*error)) = val.(error)
+	}
+}
+func (c *HookContextImpl1077711071) GetParamCount() int     { return len(c.params) }
+func (c *HookContextImpl1077711071) GetReturnValCount() int { return len(c.returnVals) }
+func (c *HookContextImpl1077711071) GetFuncName() string    { return c.funcName }
+func (c *HookContextImpl1077711071) GetPackageName() string { return c.packageName }
+
+// Trampoline Template
+func OtelBeforeTrampoline_Func11077711071(param0 *string, param1 *int) (hookContext *HookContextImpl1077711071, skipCall bool) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec Before hook", "H1Before")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext = &HookContextImpl1077711071{}
+	hookContext.params = []interface{}{param0, param1}
+	hookContext.funcName = "Func1"
+	hookContext.packageName = "main"
+	if H1Before != nil {
+		H1Before(hookContext, *param0, *param1)
+	}
+	return hookContext, hookContext.skipCall
+}
+
+func OtelAfterTrampoline_Func11077711071(hookContext HookContext, arg0 *float32, arg1 *error) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec After hook", "H1After")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext.(*HookContextImpl1077711071).returnVals = []interface{}{arg0, arg1}
+	if H1After != nil {
+		H1After(hookContext, *arg0, *arg1)
+	}
+}
+
+//go:linkname H1Before testdata.H1Before
+func H1Before(hookContext HookContext, param0 string, param1 int)
+
+//go:linkname H1After testdata.H1After
+func H1After(hookContext HookContext, arg0 float32, arg1 error)

--- a/tool/internal/instrument/testdata/golden/import-path-filter-match/import_path_filter_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/import-path-filter-match/import_path_filter_match.otelc.globals.go.golden
@@ -1,0 +1,41 @@
+package main
+
+// Variable Template
+var (
+	OtelGetStackImpl   func() []byte = nil
+	OtelPrintStackImpl func([]byte)  = nil
+)
+
+// !!! pkg/inst/context.go will auto-sync to tool/internal/instrument/api.tmpl
+type HookContext interface {
+	// Set the skip call flag, can be used to skip the original function call
+	SetSkipCall(bool)
+	// Get the skip call flag, can be used to skip the original function call
+	IsSkipCall() bool
+	// Set the data field, can be used to pass information between Before and After hooks
+	SetData(interface{})
+	// Get the data field, can be used to pass information between Before and After hooks
+	GetData() interface{}
+	// Get a value from the data field by key
+	GetKeyData(key string) interface{}
+	// Set a key-value pair in the data field
+	SetKeyData(key string, val interface{})
+	// Check if a key exists in the data field
+	HasKeyData(key string) bool
+	// Number of original function parameters
+	GetParamCount() int
+	// Get the original function parameter at index idx
+	GetParam(idx int) interface{}
+	// Change the original function parameter at index idx
+	SetParam(idx int, val interface{})
+	// Number of original function return values
+	GetReturnValCount() int
+	// Get the original function return value at index idx
+	GetReturnVal(idx int) interface{}
+	// Change the original function return value at index idx
+	SetReturnVal(idx int, val interface{})
+	// Get the original function name
+	GetFuncName() string
+	// Get the package name of the original function
+	GetPackageName() string
+}

--- a/tool/internal/instrument/testdata/golden/import-path-filter-match/rules.yml
+++ b/tool/internal/instrument/testdata/golden/import-path-filter-match/rules.yml
@@ -1,0 +1,8 @@
+hook_import_path:
+  target: main
+  func: Func1
+  before: H1Before
+  after: H1After
+  path: testdata
+  where:
+    import_path: "main"

--- a/tool/internal/instrument/testdata/golden/import-path-filter-no-match/import_path_filter_no_match.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/import-path-filter-no-match/import_path_filter_no_match.main.go.golden
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+type T struct{}
+
+func (t *T) Func1(p1 string, p2 int) (float32, error) {
+	return 0.0, nil
+}
+
+func Func1(p1 string, p2 int) (float32, error) {
+	println("Hello, World!")
+	return 0.0, nil
+}
+
+func Func2(p1 string, _ int) {}
+
+func (T) Func3() {}
+
+func OptGood() {}
+func OptBad()  {}
+func OptBad2() {}
+
+func GenericFunc[T any](p1 T, p2 int) (T, error) {
+	return p1, nil
+}
+
+type GenStruct[T any] struct {
+	value T
+}
+
+func (g *GenStruct[T]) GenericMethod(p1 T, p2 string) (T, error) {
+	return p1, nil
+}
+
+func EllipsisFunc(p1 ...string) {}
+
+func UnderscoreFunc(_ int, _ float32) {}
+
+func main() { Func1("hello", 123) }

--- a/tool/internal/instrument/testdata/golden/import-path-filter-no-match/rules.yml
+++ b/tool/internal/instrument/testdata/golden/import-path-filter-no-match/rules.yml
@@ -1,0 +1,8 @@
+hook_import_path:
+  target: main
+  func: Func1
+  before: H1Before
+  after: H1After
+  path: testdata
+  where:
+    import_path: "github.com/example/**"

--- a/tool/internal/rule/base.go
+++ b/tool/internal/rule/base.go
@@ -49,7 +49,7 @@ type FilterDef struct {
 	Struct    string `json:"struct,omitempty"    yaml:"struct,omitempty"`
 	Directive string `json:"directive,omitempty" yaml:"directive,omitempty"` // not yet implemented
 
-	// Import path glob filter — not yet implemented.
+	// Import path glob filter — matched by ImportPathFilter.
 	ImportPath string `json:"import_path,omitempty" yaml:"import_path,omitempty"`
 	// Package name filter — not yet implemented.
 	PackageName string `json:"package_name,omitempty" yaml:"package_name,omitempty"`

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -169,40 +169,6 @@ func (sp *SetupPhase) runMatch(
 	return sp.preciseMatching(ctx, dep, preciseRules, set)
 }
 
-// hasImportPathFilter reports whether r's Where clause contains an ImportPath
-// predicate at any depth in the filter tree. Rules that have an ImportPath
-// filter are routed through the globRules slice in matchDeps so they are
-// evaluated against every dependency rather than only the exact target match.
-func hasImportPathFilter(r rule.InstRule) bool {
-	where := r.GetWhere()
-	if where == nil {
-		return false
-	}
-	return hasImportPathInDef(where)
-}
-
-// hasImportPathInDef recursively checks whether def or any of its children
-// contains a non-empty ImportPath predicate.
-func hasImportPathInDef(def *rule.FilterDef) bool {
-	if def.ImportPath != "" {
-		return true
-	}
-	for i := range def.AllOf {
-		if hasImportPathInDef(&def.AllOf[i]) {
-			return true
-		}
-	}
-	for i := range def.OneOf {
-		if hasImportPathInDef(&def.OneOf[i]) {
-			return true
-		}
-	}
-	if def.Not != nil {
-		return hasImportPathInDef(def.Not)
-	}
-	return false
-}
-
 // ruleFilter pairs a rule with its pre-compiled Where filter (if any).
 // Using a struct instead of parallel slices prevents index-desync bugs if
 // the rules slice is ever sorted or deduplicated before this point.
@@ -442,7 +408,7 @@ func (sp *SetupPhase) matchDeps(ctx context.Context, deps []*Dependency) ([]*rul
 	exactRules := make(map[string][]rule.InstRule)
 	var globRules []rule.InstRule
 	for _, r := range allRules {
-		if hasImportPathFilter(r) {
+		if filter.ContainsImportPath(r.GetWhere()) {
 			globRules = append(globRules, r)
 		} else {
 			target := r.GetTarget()

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -118,11 +118,15 @@ func matchVersion(dependency *Dependency, rule rule.InstRule) bool {
 }
 
 // runMatch performs precise matching of rules against the dependency's source code.
-// It parses source files and matches rules by examining AST nodes
+// It parses source files and matches rules by examining AST nodes.
+//
+// rules is a pre-merged slice containing exact-target rules for this dependency
+// and any glob rules (those carrying an ImportPath filter) that must be evaluated
+// against every dependency.
 func (sp *SetupPhase) runMatch(
 	ctx context.Context,
 	dep *Dependency,
-	rulesByTarget map[string][]rule.InstRule,
+	rules []rule.InstRule,
 ) (*rule.InstRuleSet, error) {
 	set := rule.NewInstRuleSet(dep.ImportPath)
 
@@ -131,15 +135,13 @@ func (sp *SetupPhase) runMatch(
 		sp.Debug("Set CGO file map", "dep", dep.ImportPath, "cgoFiles", dep.CgoFiles)
 	}
 
-	// Filter rules by target
-	relevantRules := rulesByTarget[dep.ImportPath]
-	if len(relevantRules) == 0 {
+	if len(rules) == 0 {
 		return set, nil
 	}
 
 	// Filter rules by version
-	filteredRules := make([]rule.InstRule, 0, len(relevantRules))
-	for _, r := range relevantRules {
+	filteredRules := make([]rule.InstRule, 0, len(rules))
+	for _, r := range rules {
 		if !matchVersion(dep, r) {
 			continue
 		}
@@ -165,6 +167,40 @@ func (sp *SetupPhase) runMatch(
 	}
 
 	return sp.preciseMatching(ctx, dep, preciseRules, set)
+}
+
+// hasImportPathFilter reports whether r's Where clause contains an ImportPath
+// predicate at any depth in the filter tree. Rules that have an ImportPath
+// filter are routed through the globRules slice in matchDeps so they are
+// evaluated against every dependency rather than only the exact target match.
+func hasImportPathFilter(r rule.InstRule) bool {
+	where := r.GetWhere()
+	if where == nil {
+		return false
+	}
+	return hasImportPathInDef(where)
+}
+
+// hasImportPathInDef recursively checks whether def or any of its children
+// contains a non-empty ImportPath predicate.
+func hasImportPathInDef(def *rule.FilterDef) bool {
+	if def.ImportPath != "" {
+		return true
+	}
+	for i := range def.AllOf {
+		if hasImportPathInDef(&def.AllOf[i]) {
+			return true
+		}
+	}
+	for i := range def.OneOf {
+		if hasImportPathInDef(&def.OneOf[i]) {
+			return true
+		}
+	}
+	if def.Not != nil {
+		return hasImportPathInDef(def.Not)
+	}
+	return false
 }
 
 // ruleFilter pairs a rule with its pre-compiled Where filter (if any).
@@ -401,11 +437,17 @@ func (sp *SetupPhase) matchDeps(ctx context.Context, deps []*Dependency) ([]*rul
 		return nil, nil
 	}
 
-	// Pre-index rules by target
-	rulesByTarget := make(map[string][]rule.InstRule)
+	// Split rules into exact-target rules (fast map lookup) and glob rules
+	// (evaluated against every dependency via their ImportPath filter).
+	exactRules := make(map[string][]rule.InstRule)
+	var globRules []rule.InstRule
 	for _, r := range allRules {
-		target := r.GetTarget()
-		rulesByTarget[target] = append(rulesByTarget[target], r)
+		if hasImportPathFilter(r) {
+			globRules = append(globRules, r)
+		} else {
+			target := r.GetTarget()
+			exactRules[target] = append(exactRules[target], r)
+		}
 	}
 
 	// Match the default rules with the found dependencies
@@ -416,7 +458,12 @@ func (sp *SetupPhase) matchDeps(ctx context.Context, deps []*Dependency) ([]*rul
 
 	for _, dep := range deps {
 		g.Go(func() error {
-			m, err1 := sp.runMatch(gCtx, dep, rulesByTarget)
+			// Merge exact rules for this dep with glob rules that must be
+			// evaluated against every dependency.
+			rules := make([]rule.InstRule, 0, len(exactRules[dep.ImportPath])+len(globRules))
+			rules = append(rules, exactRules[dep.ImportPath]...)
+			rules = append(rules, globRules...)
+			m, err1 := sp.runMatch(gCtx, dep, rules)
 			if err1 != nil {
 				return err1
 			}


### PR DESCRIPTION
## Summary

Implements `ImportPathFilter` with glob matching (`*` = one segment, `**` = zero-or-more segments). Also refactors `matchDeps` to split rules into `exactRules` map + `globRules` slice — rules with an `ImportPath` filter are evaluated against every dependency, letting the filter select the matching packages.

Part of [OP4: Join point composition & filtering](#346), stacked on `kakkoyun/op4/base` (parallel to OP4.1–4.3).

### Changes
- `tool/internal/filter/import_path.go`: `ImportPathFilter`, `matchGlob`, `matchSegments`, `ContainsImportPath`
- `tool/internal/filter/build.go`: build-time pattern validation via `path.Match`
- `tool/internal/setup/match.go`: `exactRules`/`globRules` split; `runMatch` signature changed to `[]InstRule`
- Golden tests: `import-path-filter-match/` + `import-path-filter-no-match/`

### Test plan
- [ ] `make format && make lint` passes
- [ ] `go test -race -count=1 ./tool/...` passes
- [ ] `make check-golden-files` passes