### PR TITLE
feat(filter): implement package name filter (OP4.5)

### DIFF
--- a/pkg/inst/insttest/mock_hook_context.go
+++ b/pkg/inst/insttest/mock_hook_context.go
@@ -59,6 +59,7 @@ func (m *MockHookContext) GetParam(idx int) interface{} {
 	}
 	return m.Params[idx]
 }
+
 func (m *MockHookContext) SetParam(idx int, val interface{}) {
 	for len(m.Params) <= idx {
 		m.Params = append(m.Params, nil)
@@ -73,6 +74,7 @@ func (m *MockHookContext) GetReturnVal(idx int) interface{} {
 	}
 	return m.ReturnVals[idx]
 }
+
 func (m *MockHookContext) SetReturnVal(idx int, val interface{}) {
 	for len(m.ReturnVals) <= idx {
 		m.ReturnVals = append(m.ReturnVals, nil)

--- a/tool/internal/filter/build.go
+++ b/tool/internal/filter/build.go
@@ -82,7 +82,7 @@ func buildDef(def *rule.FilterDef) (Filter, error) {
 	case def.ImportPath != "":
 		return nil, ex.Newf("import_path filter is not yet supported")
 	case def.PackageName != "":
-		return nil, ex.Newf("package_name filter is not yet supported")
+		return &PackageNameFilter{Name: def.PackageName}, nil
 	case def.TestMain != nil:
 		return nil, ex.Newf("test_main filter is not yet supported")
 	default:

--- a/tool/internal/filter/build_test.go
+++ b/tool/internal/filter/build_test.go
@@ -119,6 +119,23 @@ func TestBuild_Error_MultipleActiveLeaves(t *testing.T) {
 	}
 }
 
+func TestBuild_PackageName(t *testing.T) {
+	t.Run("builds successfully", func(t *testing.T) {
+		def := &rule.FilterDef{PackageName: "main"}
+		f, err := filter.Build(def)
+		if err != nil {
+			t.Fatalf("Build(%+v) error = %v, want nil", def, err)
+		}
+		pnf, ok := f.(*filter.PackageNameFilter)
+		if !ok {
+			t.Fatalf("Build(PackageName) returned %T, want *filter.PackageNameFilter", f)
+		}
+		if pnf.Name != "main" {
+			t.Errorf("PackageNameFilter.Name = %q, want %q", pnf.Name, "main")
+		}
+	})
+}
+
 func TestBuild_Error_UnsupportedCombinators(t *testing.T) {
 	tests := []struct {
 		name string
@@ -143,10 +160,6 @@ func TestBuild_Error_UnsupportedCombinators(t *testing.T) {
 		{
 			name: "import_path",
 			def:  &rule.FilterDef{ImportPath: "example.com/**"},
-		},
-		{
-			name: "package_name",
-			def:  &rule.FilterDef{PackageName: "main"},
 		},
 		{
 			name: "test_main",

--- a/tool/internal/filter/package_name.go
+++ b/tool/internal/filter/package_name.go
@@ -8,8 +8,8 @@ var _ Filter = (*PackageNameFilter)(nil)
 
 // PackageNameFilter matches source files whose declared package name equals
 // the configured name. The declared package name is read from the AST
-// (ctx.AST.Name.Name) — it is always present and is the same for every file
-// in a Go package, so there is no need to store it separately on MatchContext.
+// (ctx.AST.Name.Name). Non-test files in a package share the same name;
+// external test files may declare a different name (e.g. "foo_test").
 type PackageNameFilter struct {
 	Name string
 }

--- a/tool/internal/filter/package_name.go
+++ b/tool/internal/filter/package_name.go
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+// Compile-time check that PackageNameFilter implements Filter.
+var _ Filter = (*PackageNameFilter)(nil)
+
+// PackageNameFilter matches source files whose declared package name equals
+// the configured name. The declared package name is read from the AST
+// (ctx.AST.Name.Name) — it is always present and is the same for every file
+// in a Go package, so there is no need to store it separately on MatchContext.
+type PackageNameFilter struct {
+	Name string
+}
+
+// Match reports whether the package name declared in the source file equals
+// f.Name.
+func (f *PackageNameFilter) Match(ctx *MatchContext) bool {
+	return ctx.AST.Name.Name == f.Name
+}

--- a/tool/internal/filter/package_name_test.go
+++ b/tool/internal/filter/package_name_test.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filter_test
+
+import (
+	"testing"
+
+	"github.com/dave/dst"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/filter"
+)
+
+func TestPackageNameFilter_Match(t *testing.T) {
+	tests := []struct {
+		name        string
+		filterName  string
+		packageName string
+		want        bool
+	}{
+		{
+			name:        "exact match",
+			filterName:  "main",
+			packageName: "main",
+			want:        true,
+		},
+		{
+			name:        "no match",
+			filterName:  "main",
+			packageName: "http",
+			want:        false,
+		},
+		{
+			name:        "test package suffix ignored — name is literal",
+			filterName:  "foo_test",
+			packageName: "foo_test",
+			want:        true,
+		},
+		{
+			name:        "base package name does not match _test variant",
+			filterName:  "foo",
+			packageName: "foo_test",
+			want:        false,
+		},
+		{
+			name:        "empty filter never matches non-empty package",
+			filterName:  "",
+			packageName: "main",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &filter.MatchContext{
+				ImportPath: "example.com/pkg",
+				SourceFile: "source.go",
+				AST:        &dst.File{Name: &dst.Ident{Name: tt.packageName}},
+			}
+			f := &filter.PackageNameFilter{Name: tt.filterName}
+			if got := f.Match(ctx); got != tt.want {
+				t.Errorf("PackageNameFilter{%q}.Match(pkg=%q) = %v, want %v",
+					tt.filterName, tt.packageName, got, tt.want)
+			}
+		})
+	}
+}

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"testing"
 
+	pkgast "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/ast"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/filter"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 	"github.com/stretchr/testify/assert"
@@ -124,6 +126,28 @@ func loadRulesYAML(t *testing.T, testName, sourceFile string) *rule.InstRuleSet 
 		props := rawRules[name]
 		props["name"] = name
 		ruleData, _ := yaml.Marshal(props)
+
+		// Evaluate the 'where' filter if present, mirroring preciseMatching.
+		if whereRaw, ok := props["where"]; ok {
+			whereBytes, _ := yaml.Marshal(whereRaw)
+			var filterDef rule.FilterDef
+			if unmarshalErr := yaml.Unmarshal(whereBytes, &filterDef); unmarshalErr == nil {
+				f, buildErr := filter.Build(&filterDef)
+				if buildErr == nil && f != nil {
+					tree, parseErr := pkgast.ParseFileFast(sourceFile)
+					if parseErr == nil {
+						ctx := &filter.MatchContext{
+							ImportPath: mainPackage,
+							SourceFile: sourceFile,
+							AST:        tree,
+						}
+						if !f.Match(ctx) {
+							continue // filter does not match; skip this rule
+						}
+					}
+				}
+			}
+		}
 
 		switch {
 		case props["struct"] != nil:

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -127,26 +127,8 @@ func loadRulesYAML(t *testing.T, testName, sourceFile string) *rule.InstRuleSet 
 		props["name"] = name
 		ruleData, _ := yaml.Marshal(props)
 
-		// Evaluate the 'where' filter if present, mirroring preciseMatching.
-		if whereRaw, ok := props["where"]; ok {
-			whereBytes, _ := yaml.Marshal(whereRaw)
-			var filterDef rule.FilterDef
-			if unmarshalErr := yaml.Unmarshal(whereBytes, &filterDef); unmarshalErr == nil {
-				f, buildErr := filter.Build(&filterDef)
-				if buildErr == nil && f != nil {
-					tree, parseErr := pkgast.ParseFileFast(sourceFile)
-					if parseErr == nil {
-						ctx := &filter.MatchContext{
-							ImportPath: mainPackage,
-							SourceFile: sourceFile,
-							AST:        tree,
-						}
-						if !f.Match(ctx) {
-							continue // filter does not match; skip this rule
-						}
-					}
-				}
-			}
+		if !whereFilterMatches(props, sourceFile) {
+			continue
 		}
 
 		switch {
@@ -169,6 +151,38 @@ func loadRulesYAML(t *testing.T, testName, sourceFile string) *rule.InstRuleSet 
 	}
 
 	return ruleSet
+}
+
+// whereFilterMatches evaluates the optional 'where' filter for a rule.
+// Returns true if the rule should be applied, false if it should be skipped.
+// On any parse or build error the rule is included (fail-open).
+func whereFilterMatches(props map[string]any, sourceFile string) bool {
+	whereRaw, ok := props["where"]
+	if !ok {
+		return true
+	}
+	whereBytes, err := yaml.Marshal(whereRaw)
+	if err != nil {
+		return true
+	}
+	var filterDef rule.FilterDef
+	if err = yaml.Unmarshal(whereBytes, &filterDef); err != nil {
+		return true
+	}
+	f, err := filter.Build(&filterDef)
+	if err != nil || f == nil {
+		return true
+	}
+	tree, err := pkgast.ParseFileFast(sourceFile)
+	if err != nil {
+		return true
+	}
+	ctx := &filter.MatchContext{
+		ImportPath: mainPackage,
+		SourceFile: sourceFile,
+		AST:        tree,
+	}
+	return f.Match(ctx)
 }
 
 func writeMatchedJSON(ruleSet *rule.InstRuleSet) {

--- a/tool/internal/instrument/testdata/golden/package-name-filter-match/package_name_filter_match.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/package-name-filter-match/package_name_filter_match.main.go.golden
@@ -1,0 +1,185 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import _ "unsafe"
+
+type T struct{}
+
+func (t *T) Func1(p1 string, p2 int) (float32, error) {
+	return 0.0, nil
+}
+
+func Func1(p1 string, p2 int) (_unnamedRetVal0 float32, _unnamedRetVal1 error) {
+	//line <generated>:1
+	if hookContext2393050831, _ := OtelBeforeTrampoline_Func12393050831(&p1, &p2); false {
+	} else {
+		defer OtelAfterTrampoline_Func12393050831(hookContext2393050831, &_unnamedRetVal0, &_unnamedRetVal1)
+	}
+	//line main.go:13:2
+	println("Hello, World!")
+	//line main.go:14:2
+	return 0.0, nil
+}
+
+func Func2(p1 string, _ int) {}
+
+func (T) Func3() {}
+
+func OptGood() {}
+func OptBad()  {}
+func OptBad2() {}
+
+func GenericFunc[T any](p1 T, p2 int) (T, error) {
+	return p1, nil
+}
+
+type GenStruct[T any] struct {
+	value T
+}
+
+func (g *GenStruct[T]) GenericMethod(p1 T, p2 string) (T, error) {
+	return p1, nil
+}
+
+func EllipsisFunc(p1 ...string) {}
+
+func UnderscoreFunc(_ int, _ float32) {}
+
+func main() { Func1("hello", 123) }
+
+//line <generated>:1
+type HookContextImpl2393050831 struct {
+	params      []interface{}
+	returnVals  []interface{}
+	skipCall    bool
+	data        interface{}
+	funcName    string
+	packageName string
+}
+
+func (c *HookContextImpl2393050831) SetSkipCall(skip bool)    { c.skipCall = skip }
+func (c *HookContextImpl2393050831) IsSkipCall() bool         { return c.skipCall }
+func (c *HookContextImpl2393050831) SetData(data interface{}) { c.data = data }
+func (c *HookContextImpl2393050831) GetData() interface{}     { return c.data }
+func (c *HookContextImpl2393050831) GetKeyData(key string) interface{} {
+	if c.data == nil {
+		return nil
+	}
+	return c.data.(map[string]interface{})[key]
+}
+
+func (c *HookContextImpl2393050831) SetKeyData(key string, val interface{}) {
+	if c.data == nil {
+		c.data = make(map[string]interface{})
+	}
+	c.data.(map[string]interface{})[key] = val
+}
+
+func (c *HookContextImpl2393050831) HasKeyData(key string) bool {
+	if c.data == nil {
+		return false
+	}
+	_, ok := c.data.(map[string]interface{})[key]
+	return ok
+}
+
+func (c *HookContextImpl2393050831) GetParam(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.params[0].(*string))
+	case 1:
+		return *(c.params[1].(*int))
+	}
+	return nil
+}
+
+func (c *HookContextImpl2393050831) SetParam(idx int, val interface{}) {
+	if val == nil {
+		c.params[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.params[0].(*string)) = val.(string)
+	case 1:
+		*(c.params[1].(*int)) = val.(int)
+	}
+}
+
+func (c *HookContextImpl2393050831) GetReturnVal(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.returnVals[0].(*float32))
+	case 1:
+		return *(c.returnVals[1].(*error))
+	}
+	return nil
+}
+
+func (c *HookContextImpl2393050831) SetReturnVal(idx int, val interface{}) {
+	if val == nil {
+		c.returnVals[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.returnVals[0].(*float32)) = val.(float32)
+	case 1:
+		*(c.returnVals[1].(*error)) = val.(error)
+	}
+}
+func (c *HookContextImpl2393050831) GetParamCount() int     { return len(c.params) }
+func (c *HookContextImpl2393050831) GetReturnValCount() int { return len(c.returnVals) }
+func (c *HookContextImpl2393050831) GetFuncName() string    { return c.funcName }
+func (c *HookContextImpl2393050831) GetPackageName() string { return c.packageName }
+
+// Trampoline Template
+func OtelBeforeTrampoline_Func12393050831(param0 *string, param1 *int) (hookContext *HookContextImpl2393050831, skipCall bool) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec Before hook", "H1Before")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext = &HookContextImpl2393050831{}
+	hookContext.params = []interface{}{param0, param1}
+	hookContext.funcName = "Func1"
+	hookContext.packageName = "main"
+	if H1Before != nil {
+		H1Before(hookContext, *param0, *param1)
+	}
+	return hookContext, hookContext.skipCall
+}
+
+func OtelAfterTrampoline_Func12393050831(hookContext HookContext, arg0 *float32, arg1 *error) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec After hook", "H1After")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext.(*HookContextImpl2393050831).returnVals = []interface{}{arg0, arg1}
+	if H1After != nil {
+		H1After(hookContext, *arg0, *arg1)
+	}
+}
+
+//go:linkname H1Before testdata.H1Before
+func H1Before(hookContext HookContext, param0 string, param1 int)
+
+//go:linkname H1After testdata.H1After
+func H1After(hookContext HookContext, arg0 float32, arg1 error)

--- a/tool/internal/instrument/testdata/golden/package-name-filter-match/package_name_filter_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/package-name-filter-match/package_name_filter_match.otelc.globals.go.golden
@@ -1,0 +1,41 @@
+package main
+
+// Variable Template
+var (
+	OtelGetStackImpl   func() []byte = nil
+	OtelPrintStackImpl func([]byte)  = nil
+)
+
+// !!! pkg/inst/context.go will auto-sync to tool/internal/instrument/api.tmpl
+type HookContext interface {
+	// Set the skip call flag, can be used to skip the original function call
+	SetSkipCall(bool)
+	// Get the skip call flag, can be used to skip the original function call
+	IsSkipCall() bool
+	// Set the data field, can be used to pass information between Before and After hooks
+	SetData(interface{})
+	// Get the data field, can be used to pass information between Before and After hooks
+	GetData() interface{}
+	// Get a value from the data field by key
+	GetKeyData(key string) interface{}
+	// Set a key-value pair in the data field
+	SetKeyData(key string, val interface{})
+	// Check if a key exists in the data field
+	HasKeyData(key string) bool
+	// Number of original function parameters
+	GetParamCount() int
+	// Get the original function parameter at index idx
+	GetParam(idx int) interface{}
+	// Change the original function parameter at index idx
+	SetParam(idx int, val interface{})
+	// Number of original function return values
+	GetReturnValCount() int
+	// Get the original function return value at index idx
+	GetReturnVal(idx int) interface{}
+	// Change the original function return value at index idx
+	SetReturnVal(idx int, val interface{})
+	// Get the original function name
+	GetFuncName() string
+	// Get the package name of the original function
+	GetPackageName() string
+}

--- a/tool/internal/instrument/testdata/golden/package-name-filter-match/rules.yml
+++ b/tool/internal/instrument/testdata/golden/package-name-filter-match/rules.yml
@@ -1,0 +1,8 @@
+hook_package_name:
+  target: main
+  func: Func1
+  before: H1Before
+  after: H1After
+  path: testdata
+  where:
+    package_name: "main"

--- a/tool/internal/instrument/testdata/golden/package-name-filter-no-match/package_name_filter_no_match.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/package-name-filter-no-match/package_name_filter_no_match.main.go.golden
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+type T struct{}
+
+func (t *T) Func1(p1 string, p2 int) (float32, error) {
+	return 0.0, nil
+}
+
+func Func1(p1 string, p2 int) (float32, error) {
+	println("Hello, World!")
+	return 0.0, nil
+}
+
+func Func2(p1 string, _ int) {}
+
+func (T) Func3() {}
+
+func OptGood() {}
+func OptBad()  {}
+func OptBad2() {}
+
+func GenericFunc[T any](p1 T, p2 int) (T, error) {
+	return p1, nil
+}
+
+type GenStruct[T any] struct {
+	value T
+}
+
+func (g *GenStruct[T]) GenericMethod(p1 T, p2 string) (T, error) {
+	return p1, nil
+}
+
+func EllipsisFunc(p1 ...string) {}
+
+func UnderscoreFunc(_ int, _ float32) {}
+
+func main() { Func1("hello", 123) }

--- a/tool/internal/instrument/testdata/golden/package-name-filter-no-match/rules.yml
+++ b/tool/internal/instrument/testdata/golden/package-name-filter-no-match/rules.yml
@@ -1,0 +1,8 @@
+hook_package_name:
+  target: main
+  func: Func1
+  before: H1Before
+  after: H1After
+  path: testdata
+  where:
+    package_name: "lib"

--- a/tool/internal/rule/base.go
+++ b/tool/internal/rule/base.go
@@ -51,7 +51,7 @@ type FilterDef struct {
 
 	// Import path glob filter — not yet implemented.
 	ImportPath string `json:"import_path,omitempty" yaml:"import_path,omitempty"`
-	// Package name filter — not yet implemented.
+	// Package name filter — matched by PackageNameFilter.
 	PackageName string `json:"package_name,omitempty" yaml:"package_name,omitempty"`
 	// TestMain filter — not yet implemented.
 	TestMain *bool `json:"test_main,omitempty" yaml:"test_main,omitempty"`


### PR DESCRIPTION
## Summary

Implements `PackageNameFilter` that matches source files whose declared package name equals the configured value. Reads from `ctx.AST.Name.Name` directly — no redundant field on `MatchContext`.

Note: non-test files in a package share the same declared name; external test files may declare a different name (e.g. `foo_test`).

Part of [OP4: Join point composition & filtering](#346), stacked on `kakkoyun/op4/base`.

### Changes
- `tool/internal/filter/package_name.go`: `PackageNameFilter` struct + `Match`
- `tool/internal/filter/build.go`: wired in `buildDef`
- Golden tests: `package-name-filter-match/` + `package-name-filter-no-match/`

### Test plan
- [ ] `make format && make lint` passes
- [ ] `go test -race -count=1 ./tool/...` passes
- [ ] `make check-golden-files` passes