### PR TITLE
feat(tool): add join point filter interface

### DIFF
--- a/docs/adr/0003-join-point-filter-interface.md
+++ b/docs/adr/0003-join-point-filter-interface.md
@@ -1,0 +1,51 @@
+# 3. Join Point Filter Interface
+
+Date: 2026-03-19
+
+## Status
+
+Accepted
+
+## Context
+
+The tool supports flat, single-predicate rules: one `func`, `struct`, `call`, `raw`, or
+`file` field per rule. There is no way to compose multiple conditions — for example,
+"instrument functions annotated with `//otelc:span`" — or to filter on package-level
+properties such as import path patterns.
+
+Orchestrion (DataDog's equivalent tool) uses an Aspect-Oriented Programming model with a
+three-phase `Point` interface: `PackageMayMatch`, `FileMayMatch`, and `Matches`. The first
+two phases allow cheap early-exit before source files are parsed.
+
+## Decision
+
+Introduce an optional `where` clause to rules. The clause holds a `FilterDef` (YAML) that
+is compiled into a `Filter` interface at rule-load time and evaluated per source file during
+`preciseMatching`.
+
+```go
+type Filter interface {
+    Match(ctx *MatchContext) bool
+}
+```
+
+`MatchContext` carries import path, source file path, and the parsed AST. Filters are built
+once per rule and evaluated once per source file — not once per invocation. The `where`
+clause is optional; all existing rules continue to work unchanged.
+
+The `Filter` type lives in `tool/internal/filter/`; the YAML schema type `FilterDef` lives
+in `tool/internal/rule/` alongside the other rule types. This keeps the import graph
+one-directional (`filter` imports `rule`, not the reverse).
+
+The accessor method is `GetWhere()` rather than `Where()` to follow the existing
+`GetName / GetTarget / GetVersion` convention. Go does not allow a field and a method to
+share the same name, so `Where()` would collide with the `Where *FilterDef` struct field.
+
+## Consequences
+
+- Combinators (`all-of`, `one-of`, `not`) and additional leaf types (`import_path`,
+  `package_name`, `test_main`, `directive`) are stubbed and return descriptive errors until
+  their respective follow-on branches land.
+- `Filter` implementations must be safe for concurrent use; they are evaluated from parallel
+  goroutines in `matchDeps`.
+- Branch 4 (`import_path` glob) requires a change to `matchDeps` indexing — see ADR-0004.

--- a/docs/adr/0004-import-path-glob-matching.md
+++ b/docs/adr/0004-import-path-glob-matching.md
@@ -1,0 +1,41 @@
+# 4. Import Path Glob Matching
+
+Date: 2026-03-19
+
+## Status
+
+Accepted (implementation deferred to OP4 branch 4)
+
+## Context
+
+`matchDeps` pre-indexes rules by exact target import path. This is O(1) per dependency and
+correct for all current rules. Adding an `import_path` filter predicate (e.g.,
+`github.com/DataDog/**`) requires matching against patterns that cannot be pre-indexed.
+
+Go's `path.Match` does not support `**` globstar — only `*` within a single path segment.
+The `doublestar` library provides this but adds an external dependency for a single function.
+
+## Decision
+
+Implement a small custom glob matcher supporting `*` (single segment) and `**` (any
+segments). No external dependency is introduced.
+
+`matchDeps` will separate rules into two sets:
+
+- `exactRules` — indexed by exact target (current behaviour, O(1) lookup)
+- `globRules` — evaluated linearly against all dependencies (O(G) per dep, where G is the
+  number of glob rules)
+
+Glob rules are expected to be rare (custom user rules, not the default rule set). The linear
+scan is acceptable at the anticipated scale.
+
+Rules with an `import_path` filter may omit the `target` field entirely; `matchDeps` routes
+them through the glob path.
+
+## Consequences
+
+- A rule with both `target` and `where: {import_path: ...}` is an error; the predicates are
+  redundant and should be rejected at rule-load time.
+- Branch 4 adds a package-level import-path check before `ast.ParseFileFast`, recovering the
+  Orchestrion-equivalent `PackageMayMatch` short-circuit for glob rules.
+- Benchmarks should verify that the glob scan overhead is negligible for typical rule counts.

--- a/tool/internal/filter/build.go
+++ b/tool/internal/filter/build.go
@@ -1,0 +1,93 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
+)
+
+// Build constructs a runtime Filter from a FilterDef.
+//
+// Returns (nil, nil) when def is nil, meaning no additional filtering is
+// applied and the rule matches all eligible source files.
+//
+// Returns an error when def contains an invalid or not-yet-implemented
+// configuration. Unsupported combinators (all-of, one-of, not) and
+// not-yet-implemented leaf types (directive, import_path, package_name,
+// test_main) return descriptive errors.
+//
+//nolint:nilnil // nil Filter is a valid return: it means "no filtering required"
+func Build(def *rule.FilterDef) (Filter, error) {
+	if def == nil {
+		return nil, nil
+	}
+	return buildDef(def)
+}
+
+func buildDef(def *rule.FilterDef) (Filter, error) {
+	// Combinators are not yet implemented; return a clear error.
+	if len(def.AllOf) > 0 {
+		return nil, ex.Newf("all-of combinator is not yet supported")
+	}
+	if len(def.OneOf) > 0 {
+		return nil, ex.Newf("one-of combinator is not yet supported")
+	}
+	if def.Not != nil {
+		return nil, ex.Newf("not combinator is not yet supported")
+	}
+
+	// Recv without Func is a misconfiguration — catch it early.
+	if def.Recv != "" && def.Func == "" {
+		return nil, ex.Newf("recv requires func to be set in filter definition")
+	}
+
+	// Count active leaf predicates (Recv is part of Func, not independent).
+	// Keep this block in sync with the FilterDef predicate fields.
+	active := 0
+	if def.Func != "" {
+		active++
+	}
+	if def.Struct != "" {
+		active++
+	}
+	if def.Directive != "" {
+		active++
+	}
+	if def.ImportPath != "" {
+		active++
+	}
+	if def.PackageName != "" {
+		active++
+	}
+	if def.TestMain != nil {
+		active++
+	}
+
+	if active == 0 {
+		return nil, ex.Newf("filter definition has no active predicate")
+	}
+	if active > 1 {
+		return nil, ex.Newf("filter definition has multiple active predicates; use all-of to combine them")
+	}
+
+	switch {
+	case def.Func != "":
+		return &FuncFilter{Func: def.Func, Recv: def.Recv}, nil
+	case def.Struct != "":
+		return &StructFilter{Struct: def.Struct}, nil
+	case def.Directive != "":
+		return nil, ex.Newf("directive filter requires directive support (not yet available)")
+	case def.ImportPath != "":
+		return nil, ex.Newf("import_path filter is not yet supported")
+	case def.PackageName != "":
+		return nil, ex.Newf("package_name filter is not yet supported")
+	case def.TestMain != nil:
+		return nil, ex.Newf("test_main filter is not yet supported")
+	default:
+		// Unreachable: active == 1 guarantees one of the cases above matched.
+		// If this fires, a new FilterDef field was added without a matching case.
+		return nil, ex.Newf("internal error: unhandled active predicate in buildDef")
+	}
+}

--- a/tool/internal/filter/build_test.go
+++ b/tool/internal/filter/build_test.go
@@ -1,0 +1,168 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filter_test
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/filter"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
+)
+
+func TestBuild_NilDef(t *testing.T) {
+	f, err := filter.Build(nil)
+	if err != nil {
+		t.Fatalf("Build(nil) error = %v, want nil", err)
+	}
+	if f != nil {
+		t.Errorf("Build(nil) = %T, want nil", f)
+	}
+}
+
+func TestBuild_FuncFilter(t *testing.T) {
+	def := &rule.FilterDef{Func: "ServeHTTP", Recv: "*serverHandler"}
+	f, err := filter.Build(def)
+	if err != nil {
+		t.Fatalf("Build(%+v) error = %v, want nil", def, err)
+	}
+	ff, ok := f.(*filter.FuncFilter)
+	if !ok {
+		t.Fatalf("Build() returned %T, want *filter.FuncFilter", f)
+	}
+	if ff.Func != "ServeHTTP" {
+		t.Errorf("FuncFilter.Func = %q, want %q", ff.Func, "ServeHTTP")
+	}
+	if ff.Recv != "*serverHandler" {
+		t.Errorf("FuncFilter.Recv = %q, want %q", ff.Recv, "*serverHandler")
+	}
+}
+
+func TestBuild_FuncFilter_NoRecv(t *testing.T) {
+	def := &rule.FilterDef{Func: "MyFunc"}
+	f, err := filter.Build(def)
+	if err != nil {
+		t.Fatalf("Build(%+v) error = %v, want nil", def, err)
+	}
+	ff, ok := f.(*filter.FuncFilter)
+	if !ok {
+		t.Fatalf("Build() returned %T, want *filter.FuncFilter", f)
+	}
+	if ff.Func != "MyFunc" {
+		t.Errorf("FuncFilter.Func = %q, want %q", ff.Func, "MyFunc")
+	}
+	if ff.Recv != "" {
+		t.Errorf("FuncFilter.Recv = %q, want empty", ff.Recv)
+	}
+}
+
+func TestBuild_StructFilter(t *testing.T) {
+	def := &rule.FilterDef{Struct: "MyStruct"}
+	f, err := filter.Build(def)
+	if err != nil {
+		t.Fatalf("Build(%+v) error = %v, want nil", def, err)
+	}
+	sf, ok := f.(*filter.StructFilter)
+	if !ok {
+		t.Fatalf("Build() returned %T, want *filter.StructFilter", f)
+	}
+	if sf.Struct != "MyStruct" {
+		t.Errorf("StructFilter.Struct = %q, want %q", sf.Struct, "MyStruct")
+	}
+}
+
+func TestBuild_Error_EmptyFilterDef(t *testing.T) {
+	f, err := filter.Build(&rule.FilterDef{})
+	if err == nil {
+		t.Fatal("Build(empty FilterDef) error = nil, want error")
+	}
+	if f != nil {
+		t.Errorf("Build(empty FilterDef) = %T, want nil filter on error", f)
+	}
+}
+
+func TestBuild_Error_RecvWithoutFunc(t *testing.T) {
+	f, err := filter.Build(&rule.FilterDef{Recv: "*serverHandler"})
+	if err == nil {
+		t.Fatal("Build({Recv only}) error = nil, want error")
+	}
+	if f != nil {
+		t.Errorf("Build({Recv only}) = %T, want nil filter on error", f)
+	}
+}
+
+func TestBuild_Error_MultipleActiveLeaves(t *testing.T) {
+	tests := []struct {
+		name string
+		def  *rule.FilterDef
+	}{
+		{
+			name: "func and struct",
+			def:  &rule.FilterDef{Func: "Foo", Struct: "Bar"},
+		},
+		{
+			name: "func and import_path",
+			def:  &rule.FilterDef{Func: "Foo", ImportPath: "example.com/**"},
+		},
+		{
+			name: "struct and package_name",
+			def:  &rule.FilterDef{Struct: "Bar", PackageName: "main"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := filter.Build(tt.def)
+			if err == nil {
+				t.Fatalf("Build(%+v) error = nil, want error for multiple active predicates", tt.def)
+			}
+		})
+	}
+}
+
+func TestBuild_Error_UnsupportedCombinators(t *testing.T) {
+	tests := []struct {
+		name string
+		def  *rule.FilterDef
+	}{
+		{
+			name: "all-of",
+			def:  &rule.FilterDef{AllOf: []rule.FilterDef{{Func: "Foo"}}},
+		},
+		{
+			name: "one-of",
+			def:  &rule.FilterDef{OneOf: []rule.FilterDef{{Func: "Foo"}}},
+		},
+		{
+			name: "not",
+			def:  &rule.FilterDef{Not: &rule.FilterDef{Func: "Foo"}},
+		},
+		{
+			name: "directive",
+			def:  &rule.FilterDef{Directive: "otelc:span"},
+		},
+		{
+			name: "import_path",
+			def:  &rule.FilterDef{ImportPath: "example.com/**"},
+		},
+		{
+			name: "package_name",
+			def:  &rule.FilterDef{PackageName: "main"},
+		},
+		{
+			name: "test_main",
+			def:  &rule.FilterDef{TestMain: boolPtr(true)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := filter.Build(tt.def)
+			if err == nil {
+				t.Fatalf("Build(%+v) error = nil, want error for not-yet-supported predicate", tt.def)
+			}
+		})
+	}
+}
+
+// boolPtr returns a pointer to the given bool value. Used to construct
+// *bool fields in FilterDef table entries without a named local variable.
+func boolPtr(b bool) *bool { return &b }

--- a/tool/internal/filter/filter.go
+++ b/tool/internal/filter/filter.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package filter provides the Filter interface and related types for join point
+// filtering during the compile instrumentation setup phase.
+//
+// Filters are constructed once per rule from a [rule.FilterDef] (the YAML
+// representation) via [Build], then evaluated once per source file during
+// preciseMatching. A nil Filter value is valid and means "no filtering" —
+// the rule applies unconditionally to any matching source file.
+//
+// The filter tree maps directly onto the YAML where clause:
+//
+//	where:
+//	  all-of:           # AllOf combinator (not yet implemented)
+//	    - func: Foo     # FuncFilter leaf
+//	    - struct: Bar   # StructFilter leaf
+package filter
+
+import "github.com/dave/dst"
+
+// Filter is the runtime interface for join point filtering.
+// A Filter evaluates whether an instrumentation rule should be applied
+// to a specific source file based on contextual information.
+//
+// Implementations must be safe for concurrent use: a single Filter instance
+// is evaluated across multiple source files, potentially from parallel goroutines.
+type Filter interface {
+	Match(ctx *MatchContext) bool
+}
+
+// MatchContext carries per-file contextual information for filter evaluation.
+// It is constructed once per source file in preciseMatching and passed to all
+// filters associated with the rules being evaluated for that file.
+type MatchContext struct {
+	// ImportPath is the Go import path of the package containing the source file.
+	ImportPath string
+
+	// SourceFile is the absolute path to the source file being evaluated.
+	SourceFile string
+
+	// AST is the parsed decorated syntax tree of the source file.
+	// Filters that inspect declarations (FuncFilter, StructFilter) use this field.
+	// The declared package name is available via AST.Name.Name.
+	AST *dst.File
+}

--- a/tool/internal/filter/filter_test.go
+++ b/tool/internal/filter/filter_test.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filter_test
+
+import (
+	"testing"
+
+	"github.com/dave/dst"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/filter"
+)
+
+// TestMatchContext_EmptyDecls verifies that FuncFilter and StructFilter return
+// false (not panic) when the source file AST has no declarations.
+// This exercises the empty-Decls path that arises for files containing only
+// a package clause and no other declarations.
+func TestMatchContext_EmptyDecls(t *testing.T) {
+	tree := &dst.File{Name: &dst.Ident{Name: "pkg"}, Decls: nil}
+	ctx := &filter.MatchContext{
+		ImportPath: "example.com/pkg",
+		SourceFile: "/tmp/empty.go",
+		AST:        tree,
+	}
+
+	t.Run("FuncFilter on empty decls returns false", func(t *testing.T) {
+		f := &filter.FuncFilter{Func: "Missing"}
+		got := f.Match(ctx)
+		if got {
+			t.Errorf("FuncFilter{Func: %q}.Match(emptyDecls) = true, want false", f.Func)
+		}
+	})
+
+	t.Run("StructFilter on empty decls returns false", func(t *testing.T) {
+		f := &filter.StructFilter{Struct: "Missing"}
+		got := f.Match(ctx)
+		if got {
+			t.Errorf("StructFilter{Struct: %q}.Match(emptyDecls) = true, want false", f.Struct)
+		}
+	})
+}

--- a/tool/internal/filter/leaf.go
+++ b/tool/internal/filter/leaf.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/ast"
+)
+
+// Compile-time checks that FuncFilter and StructFilter implement Filter.
+// Placing these in the production package (not test) catches interface drift
+// for any build that includes this package, not only test builds.
+var (
+	_ Filter = (*FuncFilter)(nil)
+	_ Filter = (*StructFilter)(nil)
+)
+
+// FuncFilter matches source files that contain a function declaration with the
+// given name and optional receiver type.
+//
+// When Recv is empty, only free functions (no receiver) are matched.
+// When Recv is non-empty, the receiver type must also match.
+type FuncFilter struct {
+	Func string
+	Recv string // optional; empty means free function only
+}
+
+// Match reports whether the source file in ctx contains the target function.
+func (f *FuncFilter) Match(ctx *MatchContext) bool {
+	return ast.FindFuncDecl(ctx.AST, f.Func, f.Recv) != nil
+}
+
+// StructFilter matches source files that contain a struct type declaration with
+// the given name.
+type StructFilter struct {
+	Struct string
+}
+
+// Match reports whether the source file in ctx contains the target struct.
+func (f *StructFilter) Match(ctx *MatchContext) bool {
+	return ast.FindStructDecl(ctx.AST, f.Struct) != nil
+}

--- a/tool/internal/filter/leaf_test.go
+++ b/tool/internal/filter/leaf_test.go
@@ -1,0 +1,143 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filter_test
+
+import (
+	"testing"
+
+	pkgast "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/ast"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/filter"
+)
+
+// parseSource parses in-memory Go source into a decorated AST.
+// This avoids filesystem I/O in tests while exercising the same parser path
+// used by production code.
+func parseSource(t *testing.T, src string) *filter.MatchContext {
+	t.Helper()
+	parser := pkgast.NewAstParser()
+	tree, err := parser.ParseSource(src)
+	if err != nil {
+		t.Fatalf("parseSource: %v", err)
+	}
+	return &filter.MatchContext{
+		ImportPath: "example.com/pkg",
+		SourceFile: "source.go",
+		AST:        tree,
+	}
+}
+
+func TestFuncFilter_Match(t *testing.T) {
+	ctx := parseSource(t, `package main
+
+func Foo() {}
+func Bar(x int) string { return "" }
+
+type MyType struct{}
+
+func (m *MyType) Method() {}
+func (m MyType) ValueMethod() {}
+`)
+
+	tests := []struct {
+		name string
+		f    *filter.FuncFilter
+		want bool
+	}{
+		{
+			name: "matches free function",
+			f:    &filter.FuncFilter{Func: "Foo"},
+			want: true,
+		},
+		{
+			name: "matches free function with parameters",
+			f:    &filter.FuncFilter{Func: "Bar"},
+			want: true,
+		},
+		{
+			name: "no match for unknown function",
+			f:    &filter.FuncFilter{Func: "Baz"},
+			want: false,
+		},
+		{
+			name: "matches method with pointer receiver",
+			f:    &filter.FuncFilter{Func: "Method", Recv: "*MyType"},
+			want: true,
+		},
+		{
+			name: "matches method with value receiver",
+			f:    &filter.FuncFilter{Func: "ValueMethod", Recv: "MyType"},
+			want: true,
+		},
+		{
+			name: "no match: method name correct but wrong receiver",
+			f:    &filter.FuncFilter{Func: "Method", Recv: "*OtherType"},
+			want: false,
+		},
+		{
+			name: "no match: free function when receiver specified",
+			f:    &filter.FuncFilter{Func: "Foo", Recv: "*MyType"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.f.Match(ctx)
+			if got != tt.want {
+				t.Errorf("FuncFilter{Func: %q, Recv: %q}.Match() = %v, want %v",
+					tt.f.Func, tt.f.Recv, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStructFilter_Match(t *testing.T) {
+	ctx := parseSource(t, `package main
+
+type MyStruct struct {
+	Field string
+}
+
+type OtherStruct struct{}
+
+func NotAStruct() {}
+`)
+
+	tests := []struct {
+		name string
+		f    *filter.StructFilter
+		want bool
+	}{
+		{
+			name: "matches existing struct",
+			f:    &filter.StructFilter{Struct: "MyStruct"},
+			want: true,
+		},
+		{
+			name: "matches another struct",
+			f:    &filter.StructFilter{Struct: "OtherStruct"},
+			want: true,
+		},
+		{
+			name: "no match for unknown struct",
+			f:    &filter.StructFilter{Struct: "UnknownStruct"},
+			want: false,
+		},
+		{
+			name: "no match for function name",
+			f:    &filter.StructFilter{Struct: "NotAStruct"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.f.Match(ctx)
+			if got != tt.want {
+				t.Errorf("StructFilter{Struct: %q}.Match() = %v, want %v",
+					tt.f.Struct, got, tt.want)
+			}
+		})
+	}
+}

--- a/tool/internal/rule/base.go
+++ b/tool/internal/rule/base.go
@@ -19,10 +19,42 @@ import (
 // bound is exclusive. For example, "v1.0.0,v2.0.0" means the rule is applicable
 // to the target module version range [v1.0.0, v2.0.0).
 type InstRule interface {
-	String() string     // The string representation of the rule
-	GetName() string    // The unique name of the rule
-	GetTarget() string  // The target module path where the rule is applied
-	GetVersion() string // The version range of target module if available, e.g "v1.0.0,v2.0.0"
+	String() string       // The string representation of the rule
+	GetName() string      // The unique name of the rule
+	GetTarget() string    // The target module path where the rule is applied
+	GetVersion() string   // The version range of target module if available, e.g "v1.0.0,v2.0.0"
+	GetWhere() *FilterDef // The optional join point filter; nil means no additional filtering
+}
+
+// FilterDef describes a filter predicate tree for a join point. It is the YAML
+// representation of a filter and is evaluated during the setup phase to decide
+// whether a rule applies to a given source file.
+//
+// A FilterDef is either a leaf (exactly one of Func/Recv, Struct, Directive,
+// ImportPath, PackageName, TestMain) or a combinator (AllOf, OneOf, Not).
+// Combinators contain nested FilterDef instances. Setting multiple active
+// predicates in a single FilterDef is an error; use AllOf to combine them.
+//
+// Recv is only meaningful alongside Func; it narrows the function match to a
+// specific receiver type.
+type FilterDef struct {
+	// Combinators — not yet implemented; return an error from Build.
+	AllOf []FilterDef `json:"all-of,omitempty" yaml:"all-of,omitempty"`
+	OneOf []FilterDef `json:"one-of,omitempty" yaml:"one-of,omitempty"`
+	Not   *FilterDef  `json:"not,omitempty"    yaml:"not,omitempty"`
+
+	// Leaf filters — supported by Build.
+	Func      string `json:"func,omitempty"      yaml:"func,omitempty"`
+	Recv      string `json:"recv,omitempty"      yaml:"recv,omitempty"` // optional, requires Func
+	Struct    string `json:"struct,omitempty"    yaml:"struct,omitempty"`
+	Directive string `json:"directive,omitempty" yaml:"directive,omitempty"` // not yet implemented
+
+	// Import path glob filter — not yet implemented.
+	ImportPath string `json:"import_path,omitempty" yaml:"import_path,omitempty"`
+	// Package name filter — not yet implemented.
+	PackageName string `json:"package_name,omitempty" yaml:"package_name,omitempty"`
+	// TestMain filter — not yet implemented.
+	TestMain *bool `json:"test_main,omitempty" yaml:"test_main,omitempty"`
 }
 
 // InstBaseRule is the base rule for all instrumentation rules.
@@ -31,12 +63,14 @@ type InstBaseRule struct {
 	Target  string            `json:"target"            yaml:"target"`
 	Version string            `json:"version,omitempty" yaml:"version,omitempty"`
 	Imports map[string]string `json:"imports,omitempty" yaml:"imports,omitempty"` // map[alias]path
+	Where   *FilterDef        `json:"where,omitempty"   yaml:"where,omitempty"`
 }
 
-func (ibr *InstBaseRule) String() string     { return ibr.Name }
-func (ibr *InstBaseRule) GetName() string    { return ibr.Name }
-func (ibr *InstBaseRule) GetTarget() string  { return ibr.Target }
-func (ibr *InstBaseRule) GetVersion() string { return ibr.Version }
+func (ibr *InstBaseRule) String() string       { return ibr.Name }
+func (ibr *InstBaseRule) GetName() string      { return ibr.Name }
+func (ibr *InstBaseRule) GetTarget() string    { return ibr.Target }
+func (ibr *InstBaseRule) GetVersion() string   { return ibr.Version }
+func (ibr *InstBaseRule) GetWhere() *FilterDef { return ibr.Where }
 
 // InstRuleSet represents a collection of instrumentation rules that apply to a
 // single Go package within a specific module. It acts as a container for rules,

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -14,12 +14,14 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/dave/dst"
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/ast"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/filter"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
@@ -100,27 +102,19 @@ func loadDefaultRules() ([]rule.InstRule, error) {
 }
 
 func matchVersion(dependency *Dependency, rule rule.InstRule) bool {
-	// No version specified, so it's always applicable
-	if rule.GetVersion() == "" {
+	v := rule.GetVersion()
+	// No version specified, so it's always applicable.
+	if v == "" {
 		return true
 	}
 
-	// Version range? i.e. "v0.11.0,v0.12.0"
-	ruleVersion := rule.GetVersion()
-	if strings.Contains(ruleVersion, ",") {
-		commaIndex := strings.Index(ruleVersion, ",")
-		//nolint:gocritic // commaIndex is always valid
-		startInclusive := ruleVersion[:commaIndex]
-		endExclusive := ruleVersion[commaIndex+1:]
-		// Version is in the "inclusive,exclusive" range
-		if semver.Compare(dependency.Version, startInclusive) >= 0 &&
-			semver.Compare(dependency.Version, endExclusive) < 0 {
-			return true
-		}
-		return false
+	// Version range? i.e. "v0.11.0,v0.12.0" (inclusive start, exclusive end).
+	if startInclusive, endExclusive, ok := strings.Cut(v, ","); ok {
+		return semver.Compare(dependency.Version, startInclusive) >= 0 &&
+			semver.Compare(dependency.Version, endExclusive) < 0
 	}
 	// Minimal version only? i.e. "v0.11.0"
-	return semver.Compare(dependency.Version, ruleVersion) >= 0
+	return semver.Compare(dependency.Version, v) >= 0
 }
 
 // runMatch performs precise matching of rules against the dependency's source code.
@@ -144,7 +138,7 @@ func (sp *SetupPhase) runMatch(
 	}
 
 	// Filter rules by version
-	filteredRules := make([]rule.InstRule, 0)
+	filteredRules := make([]rule.InstRule, 0, len(relevantRules))
 	for _, r := range relevantRules {
 		if !matchVersion(dep, r) {
 			continue
@@ -153,7 +147,7 @@ func (sp *SetupPhase) runMatch(
 	}
 
 	// Separate file rules from rules that need precise matching
-	preciseRules := make([]rule.InstRule, 0)
+	preciseRules := make([]rule.InstRule, 0, len(filteredRules))
 	for _, r := range filteredRules {
 		// If the rule is a file rule, it is always applicable
 		if fr, ok := r.(*rule.InstFileRule); ok {
@@ -173,14 +167,46 @@ func (sp *SetupPhase) runMatch(
 	return sp.preciseMatching(ctx, dep, preciseRules, set)
 }
 
+// ruleFilter pairs a rule with its pre-compiled Where filter (if any).
+// Using a struct instead of parallel slices prevents index-desync bugs if
+// the rules slice is ever sorted or deduplicated before this point.
+type ruleFilter struct {
+	rule   rule.InstRule
+	filter filter.Filter // nil means no Where clause — apply unconditionally
+}
+
 // preciseMatching performs AST-based matching of instrumentation rules against
 // the dependency's source files. It returns the rule set with the matched rules.
+//
+// If a rule carries a Where clause, the compiled Filter is evaluated against
+// each source file before the standard AST match. Only files for which the
+// filter passes proceed to the type-specific matching step.
 func (sp *SetupPhase) preciseMatching(
 	ctx context.Context,
 	dep *Dependency,
 	rules []rule.InstRule,
 	set *rule.InstRuleSet,
 ) (*rule.InstRuleSet, error) {
+	if len(dep.Sources) == 0 {
+		return set, nil
+	}
+
+	// Pre-build filter trees for rules that carry a Where clause.
+	// Filters are built once per rule and evaluated once per source file,
+	// avoiding repeated construction inside the nested loops.
+	ruleFilters := make([]ruleFilter, 0, len(rules))
+	for _, r := range rules {
+		var f filter.Filter
+		if where := r.GetWhere(); where != nil {
+			var err error
+			f, err = filter.Build(where)
+			if err != nil {
+				return nil, ex.Wrapf(err, "build filter for rule %q", r.GetName())
+			}
+		}
+		ruleFilters = append(ruleFilters, ruleFilter{rule: r, filter: f})
+	}
+
 	for _, source := range dep.Sources {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -191,49 +217,73 @@ func (sp *SetupPhase) preciseMatching(
 		if err != nil {
 			return nil, err
 		}
-		if tree == nil {
-			return nil, ex.Newf("failed to parse file %s", source)
-		}
+		// All files in a Go package share the same declared package name, so
+		// this is idempotent across iterations; SetPackageName asserts non-empty.
 		set.SetPackageName(tree.Name.Name)
 
-		for _, r := range rules {
-			// Let's match with the rule precisely
-			switch rt := r.(type) {
-			case *rule.InstFuncRule:
-				funcDecl := ast.FindFuncDecl(tree, rt.Func, rt.Recv)
-				if funcDecl != nil {
-					set.AddFuncRule(source, rt)
-					sp.Info("Match func rule", "rule", rt, "dep", dep)
-				}
-			case *rule.InstStructRule:
-				structDecl := ast.FindStructDecl(tree, rt.Struct)
-				if structDecl != nil {
-					set.AddStructRule(source, rt)
-					sp.Info("Match struct rule", "rule", rt, "dep", dep)
-				}
-			case *rule.InstRawRule:
-				funcDecl := ast.FindFuncDecl(tree, rt.Func, rt.Recv)
-				if funcDecl != nil {
-					set.AddRawRule(source, rt)
-					sp.Info("Match raw rule", "rule", rt, "dep", dep)
-				}
-			case *rule.InstCallRule:
-				// Call rules are added unconditionally to all source files in the
-				// target package. Unlike func/struct/raw rules, there is no cheap
-				// AST predicate to pre-filter files (the matching requires import
-				// alias resolution which happens during the instrument phase).
-				// Files without matching calls are a no-op in applyCallRule.
-				set.AddCallRule(source, rt)
-				sp.Info("Match call rule", "rule", rt, "dep", dep)
-			case *rule.InstFileRule:
-				// Skip as it's already processed
+		// mctx is allocated once per source file and reused across all rules
+		// evaluated against that file. All fields are constant for a given
+		// source file, so no updates are needed inside the inner loop.
+		mctx := filter.MatchContext{
+			ImportPath: dep.ImportPath,
+			SourceFile: source,
+			AST:        tree,
+		}
+
+		for _, rf := range ruleFilters {
+			// Evaluate the Where filter if one is defined for this rule.
+			// A nil filter means the rule applies to all files unconditionally.
+			if rf.filter != nil && !rf.filter.Match(&mctx) {
 				continue
-			default:
-				util.ShouldNotReachHere()
 			}
+			sp.matchRule(rf.rule, source, tree, set, dep)
 		}
 	}
 	return set, nil
+}
+
+// matchRule performs AST-based matching for a single rule against a single
+// source file, adding the rule to set if it matches.
+func (sp *SetupPhase) matchRule(
+	r rule.InstRule,
+	source string,
+	tree *dst.File,
+	set *rule.InstRuleSet,
+	dep *Dependency,
+) {
+	// Each rule type uses a different AST query; dispatch to the correct handler.
+	switch rt := r.(type) {
+	case *rule.InstFuncRule:
+		funcDecl := ast.FindFuncDecl(tree, rt.Func, rt.Recv)
+		if funcDecl != nil {
+			set.AddFuncRule(source, rt)
+			sp.Info("Match func rule", "rule", rt, "dep", dep)
+		}
+	case *rule.InstStructRule:
+		structDecl := ast.FindStructDecl(tree, rt.Struct)
+		if structDecl != nil {
+			set.AddStructRule(source, rt)
+			sp.Info("Match struct rule", "rule", rt, "dep", dep)
+		}
+	case *rule.InstRawRule:
+		funcDecl := ast.FindFuncDecl(tree, rt.Func, rt.Recv)
+		if funcDecl != nil {
+			set.AddRawRule(source, rt)
+			sp.Info("Match raw rule", "rule", rt, "dep", dep)
+		}
+	case *rule.InstCallRule:
+		// Call rules are added unconditionally to all source files in the
+		// target package. Unlike func/struct/raw rules, there is no cheap
+		// AST predicate to pre-filter files (the matching requires import
+		// alias resolution which happens during the instrument phase).
+		// Files without matching calls are a no-op in applyCallRule.
+		set.AddCallRule(source, rt)
+		sp.Info("Match call rule", "rule", rt, "dep", dep)
+	case *rule.InstFileRule:
+		// Already dispatched in runMatch before preciseMatching is called.
+	default:
+		util.ShouldNotReachHere()
+	}
 }
 
 func ruleFromDir(path string) ([]string, error) {


### PR DESCRIPTION
## Description

Introduces the `Filter` interface and `where` clause foundation for join point composition ([#346](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/346)).

The `where` clause is optional — all existing rules continue to work unchanged. Two leaf filters are implemented: `FuncFilter` (function name + receiver) and `StructFilter` (struct name). Combinators (`all-of`, `one-of`, `not`) and additional leaf types (`import_path`, `package_name`, `test_main`, `directive`) are stubbed with descriptive errors, ready for branches 1-6 of OP4.

Architecture decisions are documented in ADR-0003 and ADR-0004.

> **Note:** This is a draft. It is the base branch of a stack; subsequent branches (combinators, glob filtering, package/test filters) will stack on top of this one.

## Motivation

Flat rules can express only a single predicate. There is currently no way to compose conditions — for example, "instrument functions annotated with `//otelc:span`" — or filter on package-level properties such as import path patterns.

Fixes #346 (partial — this is branch 0 of 6)

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [x] Documentation updated (if applicable)