### PR TITLE
refactor(tool): structured rule schema with where/do grouping

### DIFF
--- a/docs/adr/0003-structured-rule-schema.md
+++ b/docs/adr/0003-structured-rule-schema.md
@@ -1,0 +1,108 @@
+# 3. Structured Rule Schema (where/do)
+
+Date: 2026-03-26
+
+## Status
+
+Accepted
+
+## Context
+
+Rule YAML files define compile-time instrumentation rules. Each rule has two concerns:
+
+- **Matching**: which code to target (`target`, `func`, `recv`, `struct`, `version`, …)
+- **Modifying**: what transformation to apply (`before`, `after`, `path`, `raw`, `new_field`, …)
+
+The previous format mixed both concerns at the same YAML level — a flat bag of fields. This made rules harder to scan and reason about, especially as the number of rule types and modifier strategies grows.
+
+Example of the old flat format:
+
+```yaml
+server_hook:
+  target: net/http
+  func: ServeHTTP
+  recv: serverHandler
+  before: BeforeServeHTTP
+  after: AfterServeHTTP
+  path: "github.com/.../server"
+```
+
+## Decision
+
+Introduce explicit `where` (selectors) and `do` (modifiers) groupings, with named modifier actions. The modifier name also determines the rule type, replacing the previous field-presence discriminator.
+
+### New format
+
+```yaml
+server_hook:
+  where:
+    target: net/http
+    func: ServeHTTP
+    recv: serverHandler        # optional
+    version: "v1.0.0,v2.0.0"  # optional
+  do:
+    inject_hooks:
+      before: BeforeServeHTTP
+      after: AfterServeHTTP
+      path: "github.com/.../server"
+```
+
+**Top-level keys per rule:**
+
+| Key | Description |
+|---|---|
+| `where` | All selector/matcher fields |
+| `do` | Exactly one named modifier action with its parameters |
+| `imports` | Stays at top level (consumed by both phases) |
+| `name` | Optional; the YAML key already serves as name |
+
+### Modifier names and rule types
+
+| Modifier | Rule type | Selector fields |
+|---|---|---|
+| `inject_hooks` | `InstFuncRule` | `target`, `func`, `recv`, `version` |
+| `inject_code` | `InstRawRule` | `target`, `func`, `recv`, `version` |
+| `add_struct_fields` | `InstStructRule` | `target`, `struct`, `version` |
+| `add_file` | `InstFileRule` | `target`, `version` |
+| `wrap_call` | `InstCallRule` | `target`, `function_call`, `version` |
+| `expand_directive` | `InstDirectiveRule` | `target`, `directive`, `version` |
+| `assign_value` | `InstDeclRule` | `target`, `kind`, `identifier`, `version` |
+
+### Rule type inference
+
+Previously inferred from discriminator field presence (`struct` → StructRule, `func` + no `raw` → FuncRule, etc.).
+
+Now inferred from the **modifier name** inside `do`. The single key inside the `do` map determines the rule type. This eliminates priority-based disambiguation.
+
+### Implementation approach: flatten at the parsing boundary
+
+The rule Go structs (`InstFuncRule`, `InstRawRule`, etc.) represent the **internal model**. The YAML format is the **external representation**. The new format is translated to the old flat format at the parsing boundary via `normalizeRule()`:
+
+1. Parse YAML into `map[string]map[string]any`
+2. Detect new format: check for `where` or `do` keys
+3. Extract `where` fields, `do` modifier fields, and top-level `imports`/`name`
+4. Flatten into a single `map[string]any` (identical to the old flat format)
+5. Re-marshal to YAML bytes and pass to existing constructors unchanged
+
+This means:
+
+- **Zero changes** to rule struct YAML tags
+- **Zero changes** to rule constructors or validation
+- **Zero changes** to JSON serialization (setup → instrument phase)
+- **All changes** confined to two parsing locations (`tool/internal/setup/match.go` and `tool/internal/instrument/instrument_test.go`) plus YAML files
+
+### Backward compatibility
+
+Clean break — old flat format is no longer used in YAML files. The `normalizeRule` function does pass through flat-format YAML unchanged (for backward compatibility in inline test strings), but no YAML files use the old format.
+
+## Consequences
+
+**Positive:**
+- Rules are visually scannable — selectors vs. modifiers separated at a glance
+- Modifier name makes intent explicit without needing to know the discriminator rules
+- Extensible: future modifier types (`prepend_statements`, `modify_body`) slot in naturally
+- Zero churn on internal model or JSON serialization format
+
+**Negative:**
+- YAML files are slightly more verbose (indentation depth +1 for all fields)
+- Requires awareness of the normalization layer when debugging parsing issues

--- a/docs/instrument-guide.md
+++ b/docs/instrument-guide.md
@@ -18,19 +18,22 @@ Create a new file `tool/data/<library-name>.yaml`. Below is an example configura
 
 ```yaml
 inject_to_grpc_newserver:
-  target: google.golang.org/grpc
-  version: v1.63.0,v1.70.0
-  func: NewServer
-  before: BeforeNewServer
-  after: AfterNewServer
-  path: github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/grpc/server
+  where:
+    target: google.golang.org/grpc
+    version: v1.63.0,v1.70.0
+    func: NewServer
+  do:
+    inject_hooks:
+      before: BeforeNewServer
+      after: AfterNewServer
+      path: github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/grpc/server
 ```
 
-* `target`: Import path of the package to instrument.
-* `version`: Version range to match. The left bound is inclusive, the right bound is exclusive. If version is not specified, the rule is applicable to all versions.
-* `func`: Name of the function to hook.
-* `before` / `after`: Names of the hook functions.
-* `path`: Import path where the hook functions are defined.
+* `where.target`: Import path of the package to instrument.
+* `where.version`: Version range to match. The left bound is inclusive, the right bound is exclusive. If version is not specified, the rule is applicable to all versions.
+* `where.func`: Name of the function to hook.
+* `do.inject_hooks.before` / `do.inject_hooks.after`: Names of the hook functions.
+* `do.inject_hooks.path`: Import path where the hook functions are defined.
 
 > [!NOTE]
 > In addition to function rules, there are other types of rules available. For detailed information on these, refer to [rules.md](rules.md).

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2,12 +2,32 @@
 
 This document explains the different types of instrumentation rules used by the Go compile-time instrumentation tool. These rules, defined in YAML files, allow for the injection of code into target Go packages.
 
+## Rule Structure
+
+Every rule uses a structured `where`/`do` format:
+
+```yaml
+rule_name:
+  where:          # selector fields — which code to target
+    target: ...
+    # type-specific selector fields
+  do:             # exactly one modifier action
+    modifier_name:
+      # modifier-specific fields
+  imports:        # optional; stays at top level
+    alias: "import/path"
+```
+
+- `where` — groups all selector/matcher fields (`target`, `version`, `func`, `recv`, `struct`, etc.)
+- `do` — contains exactly one named modifier action that determines the rule type
+- `imports` — optional map of import alias → import path; stays at the rule top level
+
 ## Common Fields
 
-All rules share a set of common fields that define the target of the instrumentation.
+The following fields appear in the `where` block and are shared across all rule types.
 
-- `target` (string, required): The import path of the Go package to be instrumented. For example, `golang.org/x/time/rate` or `main` for the main package.
-- `version` (string, optional): Specifies a version range for the target package. The rule will only be applied if the package's version falls within this range. The format is `start_inclusive,end_exclusive`. For example, `v0.11.0,v0.12.0` means the rule applies to versions greater than or equal to `v0.11.0` and less than `v0.12.0`. If omitted, the rule applies to all versions.
+- `where.target` (string, required): The import path of the Go package to be instrumented. For example, `golang.org/x/time/rate` or `main` for the main package.
+- `where.version` (string, optional): Specifies a version range for the target package. The rule will only be applied if the package's version falls within this range. The format is `start_inclusive,end_exclusive`. For example, `v0.11.0,v0.12.0` means the rule applies to versions greater than or equal to `v0.11.0` and less than `v0.12.0`. If omitted, the rule applies to all versions.
 - `imports` (map[string]string, optional): A map of imports to inject into the instrumented file. The key is the import alias and the value is the import path. For standard imports without an alias, use the package name as both key and value. For blank imports, use `_` as the key. This field is used by raw, struct, and call rules. Function hook rules do not require it — their imports are detected automatically from the hook source file.
 
   Examples:
@@ -35,10 +55,13 @@ This is the most common rule type. It injects function calls at the beginning (`
 - Adding logging statements to function entries and exits.
 - Recording metrics about function calls.
 
-**Fields:**
+**Selector fields (in `where`):**
 
 - `func` (string, required): The name of the target function to be instrumented.
 - `recv` (string, optional): The receiver type for a method. For a standalone function, this field should be omitted. For a pointer receiver, it should be prefixed with `*`, e.g., `*MyStruct`.
+
+**Modifier fields (in `do > inject_hooks`):**
+
 - `before` (string, optional): The name of the function to be called at the entry of the target function.
 - `after` (string, optional): The name of the function to be called just before the target function returns.
 - `path` (string, required): The import path for the package containing the `before` and `after` hook functions.
@@ -47,11 +70,14 @@ This is the most common rule type. It injects function calls at the beginning (`
 
 ```yaml
 hook_helloworld:
-  target: main
-  func: Example
-  before: MyHookBefore
-  after: MyHookAfter
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/helloworld"
+  where:
+    target: main
+    func: Example
+  do:
+    inject_hooks:
+      before: MyHookBefore
+      after: MyHookAfter
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/helloworld"
 ```
 
 This rule will inject `MyHookBefore` at the start of the `Example` function in the `main` package, and `MyHookAfter` at the end. The hook functions are located in the specified `path`.
@@ -67,9 +93,12 @@ This rule adds one or more new fields to a specified struct type.
 - Adding a context field to a struct to enable tracing through its methods.
 - Extending existing data structures with new information without modifying the original source code.
 
-**Fields:**
+**Selector fields (in `where`):**
 
 - `struct` (string, required): The name of the target struct.
+
+**Modifier fields (in `do > add_struct_fields`):**
+
 - `new_field` (list of objects, required): A list of new fields to add to the struct. Each object in the list must contain:
   - `name` (string, required): The name of the new field.
   - `type` (string, required): The Go type of the new field.
@@ -78,11 +107,14 @@ This rule adds one or more new fields to a specified struct type.
 
 ```yaml
 add_new_field:
-  target: main
-  struct: MyStruct
-  new_field:
-    - name: NewField
-      type: string
+  where:
+    target: main
+    struct: MyStruct
+  do:
+    add_struct_fields:
+      new_field:
+        - name: NewField
+          type: string
 ```
 
 This rule adds a new field named `NewField` of type `string` to the `MyStruct` struct in the `main` package.
@@ -95,11 +127,14 @@ Example:
 
 ```yaml
 add_context_field:
-  target: main
-  struct: MyStruct
-  new_field:
-    - name: ctx
-      type: context.Context
+  where:
+    target: main
+    struct: MyStruct
+  do:
+    add_struct_fields:
+      new_field:
+        - name: ctx
+          type: context.Context
   imports:
     context: "context"
 ```
@@ -115,20 +150,29 @@ This rule injects a string of raw Go code at the beginning of a target function.
 - Prototyping new instrumentation strategies.
 - Custom instrumentation for traces and metrics.
 
-**Fields:**
+**Selector fields (in `where`):**
 
 - `func` (string, required): The name of the target function.
 - `recv` (string, optional): The receiver type for a method.
+
+**Modifier fields (in `do > inject_code`):**
+
 - `raw` (string, required): The raw Go code to be injected. The code will be inserted at the beginning of the target function.
+
+**Top-level fields:**
+
 - `imports` (map[string]string, optional): A map of imports to inject into the target file. Required when the injected code references packages not already imported by the target. Same format as [Common Fields](#common-fields).
 
 **Example:**
 
 ```yaml
 raw_helloworld:
-  target: main
-  func: Example
-  raw: "go func(){ println(\"RawCode\") }()"
+  where:
+    target: main
+    func: Example
+  do:
+    inject_code:
+      raw: "go func(){ println(\"RawCode\") }()"
 ```
 
 This rule injects a new goroutine that prints "RawCode" at the start of the `Example` function in the `main` package.
@@ -139,14 +183,17 @@ Raw code frequently references packages that the target file does not already im
 
 ```yaml
 raw_with_hash:
-  target: main
-  func: Example
-  raw: |
-    go func(){
-      h := sha256.New()
-      h.Write([]byte("RawCode"))
-      fmt.Printf("RawCode: %x\n", h.Sum(nil))
-    }()
+  where:
+    target: main
+    func: Example
+  do:
+    inject_code:
+      raw: |
+        go func(){
+          h := sha256.New()
+          h.Write([]byte("RawCode"))
+          fmt.Printf("RawCode: %x\n", h.Sum(nil))
+        }()
   imports:
     fmt: "fmt"
     sha256: "crypto/sha256"
@@ -163,10 +210,16 @@ This rule wraps function calls at call sites with instrumentation code. Unlike t
 - Monitoring third-party library calls without modifying the library.
 - Call-site specific instrumentation (different behavior per call location).
 
-**Fields:**
+**Selector fields (in `where`):**
 
 - `function_call` (string, required): Qualified function name in format `package/path.FunctionName`. Matches calls to functions from a specific import path.
+
+**Modifier fields (in `do > wrap_call`):**
+
 - `template` (string, required): Wrapper template using Go's `text/template` syntax with `{{ . }}` placeholder for the original call. The template must be a valid Go expression that produces a call expression (current limitation).
+
+**Top-level fields:**
+
 - `imports` (map, optional): Additional imports needed for wrapper code (alias: path).
 
 **Template System:**
@@ -204,9 +257,12 @@ Examples:
 
 ```yaml
 wrap_http_get:
-  target: myapp/server
-  function_call: net/http.Get
-  template: "tracedGet({{ . }})"
+  where:
+    target: myapp/server
+    function_call: net/http.Get
+  do:
+    wrap_call:
+      template: "tracedGet({{ . }})"
 ```
 
 In the `myapp/server` package, this transforms:
@@ -236,9 +292,12 @@ func fetchData(url string) {
 
 ```yaml
 wrap_redis_get:
-  target: myapp/cache
-  function_call: github.com/redis/go-redis/v9.Get
-  template: "tracedRedisGet(ctx, {{ . }})"
+  where:
+    target: myapp/cache
+    function_call: github.com/redis/go-redis/v9.Get
+  do:
+    wrap_call:
+      template: "tracedRedisGet(ctx, {{ . }})"
 ```
 
 In the `myapp/cache` package:
@@ -263,9 +322,12 @@ This example demonstrates the power of the `text/template` system by using an II
 
 ```yaml
 wrap_with_unsafe:
-  target: client
-  function_call: myapp/utils.Helper
-  template: "(func() (float32, error) { r, e := {{ . }}; _ = unsafe.Sizeof(r); return r, e })()"
+  where:
+    target: client
+    function_call: myapp/utils.Helper
+  do:
+    wrap_call:
+      template: "(func() (float32, error) { r, e := {{ . }}; _ = unsafe.Sizeof(r); return r, e })()"
 ```
 
 This uses an immediately-invoked function expression (IIFE) to inject logic after the call:
@@ -310,10 +372,16 @@ This rule instruments functions annotated with a magic comment (a "directive") b
 - Adding logging or metrics boilerplate that developers annotate functions with.
 - Any "opt-in" instrumentation where the annotation lives in source code rather than a rule file.
 
-**Fields:**
+**Selector fields (in `where`):**
 
 - `directive` (string, required): The directive name to match, without the leading `//`. Must not contain spaces. For example, `otelc:span` matches the comment `//otelc:span`. Note that a space after `//` (e.g., `// otelc:span`) does **not** match — the directive must immediately follow `//`.
+
+**Modifier fields (in `do > expand_directive`):**
+
 - `template` (string, required): Go statements to prepend to each matching function body. Rendered with [fasttemplate](https://github.com/valyala/fasttemplate) using `{{` / `}}` delimiters. The only supported placeholder is `{{FuncName}}`, which is replaced with the name of the annotated function.
+
+**Top-level fields:**
+
 - `imports` (map[string]string, optional): Additional imports needed by the injected code. Same format as [Common Fields](#common-fields).
 
 **Template Placeholders:**
@@ -326,11 +394,14 @@ This rule instruments functions annotated with a magic comment (a "directive") b
 
 ```yaml
 span_directive:
-  target: main
-  directive: "otelc:span"
-  template: |-
-    println("span start: {{FuncName}}")
-    defer println("span end: {{FuncName}}")
+  where:
+    target: main
+    directive: "otelc:span"
+  do:
+    expand_directive:
+      template: |-
+        println("span start: {{FuncName}}")
+        defer println("span end: {{FuncName}}")
 ```
 
 Given this source file:
@@ -370,7 +441,7 @@ This rule adds a new Go source file to the target package.
 - Adding new helper functions required by other hooks.
 - Introducing new functionalities or APIs to an existing package.
 
-**Fields:**
+**Modifier fields (in `do > add_file`):**
 
 - `file` (string, required): The name of the new file to be added (e.g., `newfile.go`).
 - `path` (string, required): The import path of the package where the content of the new file is located. The instrumentation tool will find the file within this package.
@@ -379,9 +450,12 @@ This rule adds a new Go source file to the target package.
 
 ```yaml
 add_new_file:
-  target: main
-  file: "new_helpers.go"
-  path: "github.com/my-org/my-repo/instrumentation/helpers"
+  where:
+    target: main
+  do:
+    add_file:
+      file: "new_helpers.go"
+      path: "github.com/my-org/my-repo/instrumentation/helpers"
 ```
 
 This rule would take the file `new_helpers.go` from the `github.com/my-org/my-repo/instrumentation/helpers` package and add it to the `main` package during compilation.
@@ -394,9 +468,12 @@ Example:
 
 ```yaml
 add_file_with_extra_imports:
-  target: main
-  file: "helpers.go"
-  path: "github.com/my-org/my-repo/instrumentation/helpers"
+  where:
+    target: main
+  do:
+    add_file:
+      file: "helpers.go"
+      path: "github.com/my-org/my-repo/instrumentation/helpers"
   imports:
     log: "log"  # Add extra import to the copied file
 ```
@@ -411,25 +488,34 @@ This rule targets a named package-level symbol (variable, constant, function, or
 - Toggling a package-level flag or sentinel value for observability purposes.
 - Substituting a registered implementation at compile time.
 
-**Fields:**
+**Selector fields (in `where`):**
 
 - `kind` (string, optional): Constrains the kind of symbol to match. Valid values: `var`, `const`, or omitted/empty to match any kind. (`func` and `type` are recognized but not currently supported — no action can be applied to them.)
 - `identifier` (string, required): The name of the top-level symbol to match.
+
+**Modifier fields (in `do > assign_value`):**
+
 - `value` (string, required): A Go expression to assign as the new value of the matched `var` or `const`. Not valid when `kind` is `func` or `type`.
+
+**Top-level fields:**
+
 - `imports` (map[string]string, optional): Additional imports needed by the injected expression. Same format as [Common Fields](#common-fields).
 
 **Example:**
 
 ```yaml
 assign_default_transport:
-  target: net/http
-  kind: var
-  identifier: DefaultTransport
-  value: |
-    &http.Transport{
-      MaxIdleConns:    100,
-      MaxConnsPerHost: 100,
-    }
+  where:
+    target: net/http
+    kind: var
+    identifier: DefaultTransport
+  do:
+    assign_value:
+      value: |
+        &http.Transport{
+          MaxIdleConns:    100,
+          MaxConnsPerHost: 100,
+        }
   imports:
     http: "net/http"
 ```

--- a/pkg/instrumentation/basic/basic.yaml
+++ b/pkg/instrumentation/basic/basic.yaml
@@ -1,122 +1,170 @@
 hook_helloworld:
-  target: main
-  func: Example
-  before: MyHookBefore
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
+  where:
+    target: main
+    func: Example
+  do:
+    inject_hooks:
+      before: MyHookBefore
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
 
 add_new_field:
-  target: main
-  struct: MyStruct
-  new_field:
-    - name: NewField
-      type: string
-    - name: ctx
-      type: context.Context
+  where:
+    target: main
+    struct: MyStruct
+  do:
+    add_struct_fields:
+      new_field:
+        - name: NewField
+          type: string
+        - name: ctx
+          type: context.Context
   imports:
     context: "context"
 
 raw_helloworld:
-  target: main
-  func: Example
-  raw: |
-    go func(){
-      h := sha256.New()
-      h.Write([]byte("RawCode"))
-      fmt.Printf("RawCode: %x\n", h.Sum(nil))
-    }()
+  where:
+    target: main
+    func: Example
+  do:
+    inject_code:
+      raw: |
+        go func(){
+          h := sha256.New()
+          h.Write([]byte("RawCode"))
+          fmt.Printf("RawCode: %x\n", h.Sum(nil))
+        }()
   imports:
     fmt: "fmt"
     sha256: "crypto/sha256"
 
 hook_recv:
-  target: main
-  func: Example
-  recv: "*MyStruct"
-  before: MyHook1Before
-  after: MyHook1After
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
+  where:
+    target: main
+    func: Example
+    recv: "*MyStruct"
+  do:
+    inject_hooks:
+      before: MyHook1Before
+      after: MyHook1After
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
 
 hook_no_recv:
-  target: main
-  func: Example2
-  recv: "MyStruct"
-  before: MyHook2Before
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
+  where:
+    target: main
+    func: Example2
+    recv: "MyStruct"
+  do:
+    inject_hooks:
+      before: MyHook2Before
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
 
 version_range:
-  target: golang.org/x/time/rate
-  version: "v0.14.0,v0.15.0"
-  func: Every
-  raw: |
-    fmt.Println("Every1 from fmt")
+  where:
+    target: golang.org/x/time/rate
+    version: "v0.14.0,v0.15.0"
+    func: Every
+  do:
+    inject_code:
+      raw: |
+        fmt.Println("Every1 from fmt")
   imports:
     fmt: "fmt"
 
 version_min_bad:
-  target: golang.org/x/time/rate
-  version: "v0.15.0"
-  func: Every
-  raw: |
-    fmt.Println("Every2 from fmt")
+  where:
+    target: golang.org/x/time/rate
+    version: "v0.15.0"
+    func: Every
+  do:
+    inject_code:
+      raw: |
+        fmt.Println("Every2 from fmt")
   imports:
     fmt: "fmt"
 
 version_min_good:
-  target: golang.org/x/time/rate
-  version: "v0.11.0"
-  func: Every
-  raw: |
-    fmt.Println("Every3 from fmt")
+  where:
+    target: golang.org/x/time/rate
+    version: "v0.11.0"
+    func: Every
+  do:
+    inject_code:
+      raw: |
+        fmt.Println("Every3 from fmt")
   imports:
     fmt: "fmt"
 
 only_after:
-  target: main
-  func: Example
-  after: MyHookAfter
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
+  where:
+    target: main
+    func: Example
+  do:
+    inject_hooks:
+      after: MyHookAfter
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
 
 underscore_param:
-  target: main
-  func: Underscore
-  before: BeforeUnderscore
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
+  where:
+    target: main
+    func: Underscore
+  do:
+    inject_hooks:
+      before: BeforeUnderscore
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
 
 hook_generic:
-  target: main
-  func: GenericExample
-  before: MyHookGenericBefore
-  after: MyHookGenericAfter
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
+  where:
+    target: main
+    func: GenericExample
+  do:
+    inject_hooks:
+      before: MyHookGenericBefore
+      after: MyHookGenericAfter
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
 
 hook_generic_recv:
-  target: main
-  func: GenericRecvExample
-  recv: "*GenStruct"
-  before: MyHookRecvBefore
-  after: MyHookRecvAfter
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
+  where:
+    target: main
+    func: GenericRecvExample
+    recv: "*GenStruct"
+  do:
+    inject_hooks:
+      before: MyHookRecvBefore
+      after: MyHookRecvAfter
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
 
 hook_ellipsis:
-  target: main
-  func: Ellipsis
-  before: MyHookEllipsisBefore
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
+  where:
+    target: main
+    func: Ellipsis
+  do:
+    inject_hooks:
+      before: MyHookEllipsisBefore
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
 
 hook_function_a:
-  target: main
-  func: FunctionA
-  before: FunctionABefore
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
+  where:
+    target: main
+    func: FunctionA
+  do:
+    inject_hooks:
+      before: FunctionABefore
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
 
 hook_function_b:
-  target: main
-  func: FunctionB
-  before: FunctionBBefore
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
+  where:
+    target: main
+    func: FunctionB
+  do:
+    inject_hooks:
+      before: FunctionBBefore
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
 
 hook_auto_detect:
-  target: main
-  func: AutoDetect
-  before: AutoDetectBefore
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"
+  where:
+    target: main
+    func: AutoDetect
+  do:
+    inject_hooks:
+      before: AutoDetectBefore
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/basic"

--- a/pkg/instrumentation/databasesql/db.yaml
+++ b/pkg/instrumentation/databasesql/db.yaml
@@ -1,208 +1,280 @@
 add_new_field_db:
-  target: database/sql
-  struct: DB
-  new_field:
-    - name: Endpoint
-      type: string
-    - name: DbName
-      type: string
-    - name: DriverName
-      type: string
-    - name: DSN
-      type: string
+  where:
+    target: database/sql
+    struct: DB
+  do:
+    add_struct_fields:
+      new_field:
+        - name: Endpoint
+          type: string
+        - name: DbName
+          type: string
+        - name: DriverName
+          type: string
+        - name: DSN
+          type: string
 
 add_new_field_stmt:
-  target: database/sql
-  struct: Stmt
-  new_field:
-    - name: Data
-      type: map[string]string
-    - name: DriverName
-      type: string
-    - name: DSN
-      type: string
+  where:
+    target: database/sql
+    struct: Stmt
+  do:
+    add_struct_fields:
+      new_field:
+        - name: Data
+          type: map[string]string
+        - name: DriverName
+          type: string
+        - name: DSN
+          type: string
 
 add_new_field_tx:
-  target: database/sql
-  struct: Tx
-  new_field:
-    - name: Endpoint
-      type: string
-    - name: DbName
-      type: string
-    - name: DriverName
-      type: string
-    - name: DSN
-      type: string
+  where:
+    target: database/sql
+    struct: Tx
+  do:
+    add_struct_fields:
+      new_field:
+        - name: Endpoint
+          type: string
+        - name: DbName
+          type: string
+        - name: DriverName
+          type: string
+        - name: DSN
+          type: string
 
 add_new_field_conn:
-  target: database/sql
-  struct: Conn
-  new_field:
-    - name: Endpoint
-      type: string
-    - name: DbName
-      type: string
-    - name: DriverName
-      type: string
-    - name: DSN
-      type: string
+  where:
+    target: database/sql
+    struct: Conn
+  do:
+    add_struct_fields:
+      new_field:
+        - name: Endpoint
+          type: string
+        - name: DbName
+          type: string
+        - name: DriverName
+          type: string
+        - name: DSN
+          type: string
 
 hook_open:
-  target: database/sql
-  func: Open
-  before: beforeOpenInstrumentation
-  after: afterOpenInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: Open
+  do:
+    inject_hooks:
+      before: beforeOpenInstrumentation
+      after: afterOpenInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_db_ping_context:
-  target: database/sql
-  func: PingContext
-  recv: "*DB"
-  before: beforePingContextInstrumentation
-  after: afterPingContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: PingContext
+    recv: "*DB"
+  do:
+    inject_hooks:
+      before: beforePingContextInstrumentation
+      after: afterPingContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_db_prepare_context:
-  target: database/sql
-  func: PrepareContext
-  recv: "*DB"
-  before: beforePrepareContextInstrumentation
-  after: afterPrepareContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: PrepareContext
+    recv: "*DB"
+  do:
+    inject_hooks:
+      before: beforePrepareContextInstrumentation
+      after: afterPrepareContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_db_exec_context:
-  target: database/sql
-  func: ExecContext
-  recv: "*DB"
-  before: beforeExecContextInstrumentation
-  after: afterExecContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: ExecContext
+    recv: "*DB"
+  do:
+    inject_hooks:
+      before: beforeExecContextInstrumentation
+      after: afterExecContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_db_query_context:
-  target: database/sql
-  func: QueryContext
-  recv: "*DB"
-  before: beforeQueryContextInstrumentation
-  after: afterQueryContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: QueryContext
+    recv: "*DB"
+  do:
+    inject_hooks:
+      before: beforeQueryContextInstrumentation
+      after: afterQueryContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_db_begin_tx:
-  target: database/sql
-  func: BeginTx
-  recv: "*DB"
-  before: beforeTxInstrumentation
-  after: afterTxInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: BeginTx
+    recv: "*DB"
+  do:
+    inject_hooks:
+      before: beforeTxInstrumentation
+      after: afterTxInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_db_conn:
-  target: database/sql
-  func: Conn
-  recv: "*DB"
-  before: beforeConnInstrumentation
-  after: afterConnInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: Conn
+    recv: "*DB"
+  do:
+    inject_hooks:
+      before: beforeConnInstrumentation
+      after: afterConnInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_conn_ping_context:
-  target: database/sql
-  func: PingContext
-  recv: "*Conn"
-  before: beforeConnPingContextInstrumentation
-  after: afterConnPingContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: PingContext
+    recv: "*Conn"
+  do:
+    inject_hooks:
+      before: beforeConnPingContextInstrumentation
+      after: afterConnPingContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_conn_prepare_context:
-  target: database/sql
-  func: PrepareContext
-  recv: "*Conn"
-  before: beforeConnPrepareContextInstrumentation
-  after: afterConnPrepareContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: PrepareContext
+    recv: "*Conn"
+  do:
+    inject_hooks:
+      before: beforeConnPrepareContextInstrumentation
+      after: afterConnPrepareContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_conn_exec_context:
-  target: database/sql
-  func: ExecContext
-  recv: "*Conn"
-  before: beforeConnExecContextInstrumentation
-  after: afterConnExecContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: ExecContext
+    recv: "*Conn"
+  do:
+    inject_hooks:
+      before: beforeConnExecContextInstrumentation
+      after: afterConnExecContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_conn_query_context:
-  target: database/sql
-  func: QueryContext
-  recv: "*Conn"
-  before: beforeConnQueryContextInstrumentation
-  after: afterConnQueryContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: QueryContext
+    recv: "*Conn"
+  do:
+    inject_hooks:
+      before: beforeConnQueryContextInstrumentation
+      after: afterConnQueryContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_conn_begin_tx:
-  target: database/sql
-  func: BeginTx
-  recv: "*Conn"
-  before: beforeConnTxInstrumentation
-  after: afterConnTxInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: BeginTx
+    recv: "*Conn"
+  do:
+    inject_hooks:
+      before: beforeConnTxInstrumentation
+      after: afterConnTxInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_tx_stmt_context:
-  target: database/sql
-  func: StmtContext
-  recv: "*Tx"
-  before: beforeTxStmtContextInstrumentation
-  after: afterTxStmtContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: StmtContext
+    recv: "*Tx"
+  do:
+    inject_hooks:
+      before: beforeTxStmtContextInstrumentation
+      after: afterTxStmtContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_tx_prepare_context:
-  target: database/sql
-  func: PrepareContext
-  recv: "*Tx"
-  before: beforeTxPrepareContextInstrumentation
-  after: afterTxPrepareContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: PrepareContext
+    recv: "*Tx"
+  do:
+    inject_hooks:
+      before: beforeTxPrepareContextInstrumentation
+      after: afterTxPrepareContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_tx_exec_context:
-  target: database/sql
-  func: ExecContext
-  recv: "*Tx"
-  before: beforeTxExecContextInstrumentation
-  after: afterTxExecContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: ExecContext
+    recv: "*Tx"
+  do:
+    inject_hooks:
+      before: beforeTxExecContextInstrumentation
+      after: afterTxExecContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_tx_query_context:
-  target: database/sql
-  func: QueryContext
-  recv: "*Tx"
-  before: beforeTxQueryContextInstrumentation
-  after: afterTxQueryContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: QueryContext
+    recv: "*Tx"
+  do:
+    inject_hooks:
+      before: beforeTxQueryContextInstrumentation
+      after: afterTxQueryContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_tx_commit:
-  target: database/sql
-  func: Commit
-  recv: "*Tx"
-  before: beforeTxCommitInstrumentation
-  after: afterTxCommitInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: Commit
+    recv: "*Tx"
+  do:
+    inject_hooks:
+      before: beforeTxCommitInstrumentation
+      after: afterTxCommitInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_tx_rollback:
-  target: database/sql
-  func: Rollback
-  recv: "*Tx"
-  before: beforeTxRollbackInstrumentation
-  after: afterTxRollbackInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: Rollback
+    recv: "*Tx"
+  do:
+    inject_hooks:
+      before: beforeTxRollbackInstrumentation
+      after: afterTxRollbackInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_stmt_exec_context:
-  target: database/sql
-  func: ExecContext
-  recv: "*Stmt"
-  before: beforeStmtExecContextInstrumentation
-  after: afterStmtExecContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: ExecContext
+    recv: "*Stmt"
+  do:
+    inject_hooks:
+      before: beforeStmtExecContextInstrumentation
+      after: afterStmtExecContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
 
 hook_stmt_query_context:
-  target: database/sql
-  func: QueryContext
-  recv: "*Stmt"
-  before: beforeStmtQueryContextInstrumentation
-  after: afterStmtQueryContextInstrumentation
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"
+  where:
+    target: database/sql
+    func: QueryContext
+    recv: "*Stmt"
+  do:
+    inject_hooks:
+      before: beforeStmtQueryContextInstrumentation
+      after: afterStmtQueryContextInstrumentation
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/databasesql"

--- a/pkg/instrumentation/grpc/client/client.yaml
+++ b/pkg/instrumentation/grpc/client/client.yaml
@@ -1,13 +1,19 @@
 client_hook_newclient:
-  target: google.golang.org/grpc
-  func: NewClient
-  before: BeforeNewClient
-  after: AfterNewClient
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/grpc/client"
+  where:
+    target: google.golang.org/grpc
+    func: NewClient
+  do:
+    inject_hooks:
+      before: BeforeNewClient
+      after: AfterNewClient
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/grpc/client"
 
 client_hook_dialcontext:
-  target: google.golang.org/grpc
-  func: DialContext
-  before: BeforeDialContext
-  after: AfterDialContext
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/grpc/client"
+  where:
+    target: google.golang.org/grpc
+    func: DialContext
+  do:
+    inject_hooks:
+      before: BeforeDialContext
+      after: AfterDialContext
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/grpc/client"

--- a/pkg/instrumentation/grpc/server/server.yaml
+++ b/pkg/instrumentation/grpc/server/server.yaml
@@ -1,6 +1,9 @@
 server_hook:
-  target: google.golang.org/grpc
-  func: NewServer
-  before: BeforeNewServer
-  after: AfterNewServer
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/grpc/server"
+  where:
+    target: google.golang.org/grpc
+    func: NewServer
+  do:
+    inject_hooks:
+      before: BeforeNewServer
+      after: AfterNewServer
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/grpc/server"

--- a/pkg/instrumentation/nethttp/client/client.yaml
+++ b/pkg/instrumentation/nethttp/client/client.yaml
@@ -1,7 +1,10 @@
 client_hook:
-  target: net/http
-  func: RoundTrip
-  recv: "*Transport"
-  before: BeforeRoundTrip
-  after: AfterRoundTrip
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/nethttp/client"
+  where:
+    target: net/http
+    func: RoundTrip
+    recv: "*Transport"
+  do:
+    inject_hooks:
+      before: BeforeRoundTrip
+      after: AfterRoundTrip
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/nethttp/client"

--- a/pkg/instrumentation/nethttp/server/server.yaml
+++ b/pkg/instrumentation/nethttp/server/server.yaml
@@ -1,8 +1,10 @@
 server_hook:
-  target: net/http
-  func: ServeHTTP
-  recv: serverHandler
-  before: BeforeServeHTTP
-  after: AfterServeHTTP
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/nethttp/server"
-
+  where:
+    target: net/http
+    func: ServeHTTP
+    recv: serverHandler
+  do:
+    inject_hooks:
+      before: BeforeServeHTTP
+      after: AfterServeHTTP
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/nethttp/server"

--- a/pkg/instrumentation/redis/v9/v9.yaml
+++ b/pkg/instrumentation/redis/v9/v9.yaml
@@ -1,39 +1,54 @@
 redis_hook_newclient:
-  target: github.com/redis/go-redis/v9
-  func: NewClient
-  after: afterNewRedisClientV9
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"
-
+  where:
+    target: github.com/redis/go-redis/v9
+    func: NewClient
+  do:
+    inject_hooks:
+      after: afterNewRedisClientV9
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"
 
 redis_hook_newfailoverclient:
-  target: github.com/redis/go-redis/v9
-  func: NewFailoverClient
-  after: afterNewFailOverRedisClientV9
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"
-
+  where:
+    target: github.com/redis/go-redis/v9
+    func: NewFailoverClient
+  do:
+    inject_hooks:
+      after: afterNewFailOverRedisClientV9
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"
 
 redis_hook_newsentinelclient:
-  target: github.com/redis/go-redis/v9
-  func: NewSentinelClient
-  after: afterNewSentinelClientV9
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"
-
+  where:
+    target: github.com/redis/go-redis/v9
+    func: NewSentinelClient
+  do:
+    inject_hooks:
+      after: afterNewSentinelClientV9
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"
 
 redis_client_hook:
-  target: github.com/redis/go-redis/v9
-  func: Conn
-  recv: "*Client"
-  after: afterClientConnV9
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"
+  where:
+    target: github.com/redis/go-redis/v9
+    func: Conn
+    recv: "*Client"
+  do:
+    inject_hooks:
+      after: afterClientConnV9
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"
 
 redis_hook_newringclient:
-  target: github.com/redis/go-redis/v9
-  func: NewRing
-  after: afterNewRingClientV9
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"
+  where:
+    target: github.com/redis/go-redis/v9
+    func: NewRing
+  do:
+    inject_hooks:
+      after: afterNewRingClientV9
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"
 
 redis_hook_newclusterclient:
-  target: github.com/redis/go-redis/v9
-  func: NewClusterClient
-  after: afterNewClusterClientV9
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"
+  where:
+    target: github.com/redis/go-redis/v9
+    func: NewClusterClient
+  do:
+    inject_hooks:
+      after: afterNewClusterClientV9
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/redis/v9"

--- a/pkg/instrumentation/runtime/runtime.yaml
+++ b/pkg/instrumentation/runtime/runtime.yaml
@@ -1,22 +1,31 @@
 add_gls_field:
-  target: "runtime"
-  struct: "g"
-  new_field:
-    - name: "otel_trace_context"
-      type: "interface{}"
-    - name: "otel_baggage_container"
-      type: "interface{}"
+  where:
+    target: "runtime"
+    struct: "g"
+  do:
+    add_struct_fields:
+      new_field:
+        - name: "otel_trace_context"
+          type: "interface{}"
+        - name: "otel_baggage_container"
+          type: "interface{}"
 
 gls_linker:
-  target: "runtime"
-  file: "runtime_gls.go"
-  path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/runtime"
+  where:
+    target: "runtime"
+  do:
+    add_file:
+      file: "runtime_gls.go"
+      path: "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/instrumentation/runtime"
 
 goroutine_propagate:
-  target: "runtime"
-  func: "newproc1"
-  raw: |
-    defer func(){
-      _unnamedRetVal0.otel_trace_context = propagateOtelContext(callergp.otel_trace_context);
-      _unnamedRetVal0.otel_baggage_container = propagateOtelContext(callergp.otel_baggage_container);
-    }()
+  where:
+    target: "runtime"
+    func: "newproc1"
+  do:
+    inject_code:
+      raw: |
+        defer func(){
+          _unnamedRetVal0.otel_trace_context = propagateOtelContext(callergp.otel_trace_context);
+          _unnamedRetVal0.otel_baggage_container = propagateOtelContext(callergp.otel_baggage_container);
+        }()

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -118,16 +118,16 @@ func normalizeRuleFields(fields map[string]any) map[string]any {
 
 	// Merge selector fields from the where block.
 	if whereRaw, ok := fields["where"]; ok {
-		if whereMap, ok := whereRaw.(map[string]any); ok {
+		if whereMap, isMap := whereRaw.(map[string]any); isMap {
 			maps.Copy(flat, whereMap)
 		}
 	}
 
 	// Merge modifier fields from the do block (exactly one modifier key).
 	if doRaw, ok := fields["do"]; ok {
-		if doMap, ok := doRaw.(map[string]any); ok {
+		if doMap, isMap := doRaw.(map[string]any); isMap {
 			for _, modifierVal := range doMap {
-				if modFields, ok := modifierVal.(map[string]any); ok {
+				if modFields, isModMap := modifierVal.(map[string]any); isModMap {
 					maps.Copy(flat, modFields)
 				}
 			}

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -96,6 +97,46 @@ func runTest(t *testing.T, testName string) {
 	verifyGoldenFiles(t, tempDir, testName)
 }
 
+// normalizeRuleFields translates the structured where/do format to the flat
+// format expected by rule constructors. Fields not using the new format are
+// returned unchanged.
+func normalizeRuleFields(fields map[string]any) map[string]any {
+	_, hasWhere := fields["where"]
+	_, hasDo := fields["do"]
+	if !hasWhere && !hasDo {
+		return fields
+	}
+
+	flat := make(map[string]any)
+
+	// Copy top-level fields (e.g. imports, name) excluding where/do.
+	for k, v := range fields {
+		if k != "where" && k != "do" {
+			flat[k] = v
+		}
+	}
+
+	// Merge selector fields from the where block.
+	if whereRaw, ok := fields["where"]; ok {
+		if whereMap, ok := whereRaw.(map[string]any); ok {
+			maps.Copy(flat, whereMap)
+		}
+	}
+
+	// Merge modifier fields from the do block (exactly one modifier key).
+	if doRaw, ok := fields["do"]; ok {
+		if doMap, ok := doRaw.(map[string]any); ok {
+			for _, modifierVal := range doMap {
+				if modFields, ok := modifierVal.(map[string]any); ok {
+					maps.Copy(flat, modFields)
+				}
+			}
+		}
+	}
+
+	return flat
+}
+
 func loadRulesYAML(t *testing.T, testName, sourceFile string) *rule.InstRuleSet {
 	data, err := os.ReadFile(filepath.Join(testdataDir, goldenDir, testName, rulesFileName))
 	require.NoError(t, err)
@@ -123,7 +164,8 @@ func loadRulesYAML(t *testing.T, testName, sourceFile string) *rule.InstRuleSet 
 	slices.Sort(ruleNames)
 
 	for _, name := range ruleNames {
-		props := rawRules[name]
+		// Translate where/do format to the flat format expected by constructors.
+		props := normalizeRuleFields(rawRules[name])
 		props["name"] = name
 		ruleData, _ := yaml.Marshal(props)
 

--- a/tool/internal/instrument/testdata/golden/after-only/rules.yml
+++ b/tool/internal/instrument/testdata/golden/after-only/rules.yml
@@ -1,13 +1,18 @@
 hook_after_only:
-  target: main
-  func: Func1
-  after: H1After
-  path: testdata
+  where:
+    target: main
+    func: Func1
+  do:
+    inject_hooks:
+      after: H1After
+      path: testdata
 
 hook_with_receiver_after_only:
-  target: main
-  func: Func1
-  recv: "*T"
-  after: H8After
-  path: testdata
-
+  where:
+    target: main
+    func: Func1
+    recv: "*T"
+  do:
+    inject_hooks:
+      after: H8After
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/before-only/rules.yml
+++ b/tool/internal/instrument/testdata/golden/before-only/rules.yml
@@ -1,6 +1,8 @@
 hook_before_only:
-  target: main
-  func: Func1
-  before: H1Before
-  path: testdata
-
+  where:
+    target: main
+    func: Func1
+  do:
+    inject_hooks:
+      before: H1Before
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/call-rule-only/rules.yml
+++ b/tool/internal/instrument/testdata/golden/call-rule-only/rules.yml
@@ -1,4 +1,7 @@
 wrap_sizeof_call:
-  target: main
-  function_call: unsafe.Sizeof
-  template: "Wrapper({{ . }})"
+  where:
+    target: main
+    function_call: unsafe.Sizeof
+  do:
+    wrap_call:
+      template: "Wrapper({{ . }})"

--- a/tool/internal/instrument/testdata/golden/call-rule-template-features/rules.yml
+++ b/tool/internal/instrument/testdata/golden/call-rule-template-features/rules.yml
@@ -1,4 +1,7 @@
 wrap_nested_call:
-  target: main
-  function_call: unsafe.Sizeof
-  template: "(func() uintptr { return {{ . }} })()"
+  where:
+    target: main
+    function_call: unsafe.Sizeof
+  do:
+    wrap_call:
+      template: "(func() uintptr { return {{ . }} })()"

--- a/tool/internal/instrument/testdata/golden/call-rule-with-import/rules.yml
+++ b/tool/internal/instrument/testdata/golden/call-rule-with-import/rules.yml
@@ -1,6 +1,9 @@
 wrap_sizeof_with_strings:
-  target: main
-  function_call: unsafe.Sizeof
-  template: "(func() uintptr { fmt.Println(\"Wrapped!\"); return {{ . }} })()"
+  where:
+    target: main
+    function_call: unsafe.Sizeof
+  do:
+    wrap_call:
+      template: "(func() uintptr { fmt.Println(\"Wrapped!\"); return {{ . }} })()"
   imports:
     fmt: "fmt"

--- a/tool/internal/instrument/testdata/golden/combined-rules/rules.yml
+++ b/tool/internal/instrument/testdata/golden/combined-rules/rules.yml
@@ -1,24 +1,35 @@
 hook_func:
-  target: main
-  func: Func1
-  before: H1Before
-  after: H1After
-  path: testdata
+  where:
+    target: main
+    func: Func1
+  do:
+    inject_hooks:
+      before: H1Before
+      after: H1After
+      path: testdata
 
 add_field:
-  target: main
-  struct: T
-  new_field:
-    - name: NewField
-      type: string
+  where:
+    target: main
+    struct: T
+  do:
+    add_struct_fields:
+      new_field:
+        - name: NewField
+          type: string
 
 add_raw:
-  target: main
-  func: Func1
-  raw: "_ = 789"
+  where:
+    target: main
+    func: Func1
+  do:
+    inject_code:
+      raw: "_ = 789"
 
 add_file:
-  target: main
-  file: newfile.go
-  path: testdata
-
+  where:
+    target: main
+  do:
+    add_file:
+      file: newfile.go
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/decl-rule-assign-const/rules.yml
+++ b/tool/internal/instrument/testdata/golden/decl-rule-assign-const/rules.yml
@@ -1,5 +1,8 @@
 assign_max_retries:
-  target: main
-  kind: const
-  identifier: MaxRetries
-  value: "99"
+  where:
+    target: main
+    kind: const
+    identifier: MaxRetries
+  do:
+    assign_value:
+      value: "99"

--- a/tool/internal/instrument/testdata/golden/decl-rule-assign-value/rules.yml
+++ b/tool/internal/instrument/testdata/golden/decl-rule-assign-value/rules.yml
@@ -1,5 +1,8 @@
 assign_global_var:
-  target: main
-  kind: var
-  identifier: GlobalVar
-  value: '"replaced"'
+  where:
+    target: main
+    kind: var
+    identifier: GlobalVar
+  do:
+    assign_value:
+      value: '"replaced"'

--- a/tool/internal/instrument/testdata/golden/directive-rule/rules.yml
+++ b/tool/internal/instrument/testdata/golden/directive-rule/rules.yml
@@ -1,6 +1,9 @@
 span_directive:
-  target: main
-  directive: "otelc:span"
-  template: |-
-    println("span start: {{FuncName}}")
-    defer println("span end: {{FuncName}}")
+  where:
+    target: main
+    directive: "otelc:span"
+  do:
+    expand_directive:
+      template: |-
+        println("span start: {{FuncName}}")
+        defer println("span end: {{FuncName}}")

--- a/tool/internal/instrument/testdata/golden/ellipsis-syntax/rules.yml
+++ b/tool/internal/instrument/testdata/golden/ellipsis-syntax/rules.yml
@@ -1,6 +1,8 @@
 hook_before_only:
-  target: main
-  func: EllipsisFunc
-  before: H9Before
-  path: testdata
-
+  where:
+    target: main
+    func: EllipsisFunc
+  do:
+    inject_hooks:
+      before: H9Before
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/file-rule-only/rules.yml
+++ b/tool/internal/instrument/testdata/golden/file-rule-only/rules.yml
@@ -1,5 +1,7 @@
 add_new_file:
-  target: main
-  file: newfile.go
-  path: testdata
-
+  where:
+    target: main
+  do:
+    add_file:
+      file: newfile.go
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/func-and-raw-rules/rules.yml
+++ b/tool/internal/instrument/testdata/golden/func-and-raw-rules/rules.yml
@@ -1,12 +1,17 @@
 hook_func:
-  target: main
-  func: Func1
-  before: H1Before
-  after: H1After
-  path: testdata
+  where:
+    target: main
+    func: Func1
+  do:
+    inject_hooks:
+      before: H1Before
+      after: H1After
+      path: testdata
 
 add_raw_code:
-  target: main
-  func: Func1
-  raw: "_ = 456"
-
+  where:
+    target: main
+    func: Func1
+  do:
+    inject_code:
+      raw: "_ = 456"

--- a/tool/internal/instrument/testdata/golden/func-rule-only/rules.yml
+++ b/tool/internal/instrument/testdata/golden/func-rule-only/rules.yml
@@ -1,7 +1,9 @@
 hook_func:
-  target: main
-  func: Func1
-  before: H1Before
-  after: H1After
-  path: testdata
-
+  where:
+    target: main
+    func: Func1
+  do:
+    inject_hooks:
+      before: H1Before
+      after: H1After
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/generic-functions/rules.yml
+++ b/tool/internal/instrument/testdata/golden/generic-functions/rules.yml
@@ -1,15 +1,20 @@
 generic_func_rule:
-  target: main
-  func: GenericFunc
-  before: GenericFuncBefore
-  after: GenericFuncAfter
-  path: testdata
+  where:
+    target: main
+    func: GenericFunc
+  do:
+    inject_hooks:
+      before: GenericFuncBefore
+      after: GenericFuncAfter
+      path: testdata
 
 generic_method_rule:
-  target: main
-  func: GenericMethod
-  recv: "*GenStruct"
-  before: GenericMethodBefore
-  after: GenericMethodAfter
-  path: testdata
-
+  where:
+    target: main
+    func: GenericMethod
+    recv: "*GenStruct"
+  do:
+    inject_hooks:
+      before: GenericMethodBefore
+      after: GenericMethodAfter
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/invalid-receiver/rules.yml
+++ b/tool/internal/instrument/testdata/golden/invalid-receiver/rules.yml
@@ -1,8 +1,10 @@
 hook_invalid_receiver:
-  target: main
-  func: Func1
-  recv: "*NonExistent"
-  before: H1Before
-  after: H1After
-  path: testdata
-
+  where:
+    target: main
+    func: Func1
+    recv: "*NonExistent"
+  do:
+    inject_hooks:
+      before: H1Before
+      after: H1After
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/method-receiver/rules.yml
+++ b/tool/internal/instrument/testdata/golden/method-receiver/rules.yml
@@ -1,14 +1,20 @@
 hook_method:
-  target: main
-  func: Func1
-  recv: "*T"
-  before: H3Before
-  after: H3After
-  path: testdata
+  where:
+    target: main
+    func: Func1
+    recv: "*T"
+  do:
+    inject_hooks:
+      before: H3Before
+      after: H3After
+      path: testdata
 
 hook_method_unnamed_recv:
-  target: main
-  func: Func3
-  recv: "T"
-  before: H11Before
-  path: testdata
+  where:
+    target: main
+    func: Func3
+    recv: "T"
+  do:
+    inject_hooks:
+      before: H11Before
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/multiple-func-rules/rules.yml
+++ b/tool/internal/instrument/testdata/golden/multiple-func-rules/rules.yml
@@ -1,14 +1,19 @@
 hook_func_1:
-  target: main
-  func: Func1
-  before: H1Before
-  after: H1After
-  path: testdata
+  where:
+    target: main
+    func: Func1
+  do:
+    inject_hooks:
+      before: H1Before
+      after: H1After
+      path: testdata
 
 hook_func_2:
-  target: main
-  func: Func1
-  before: H2Before
-  after: H2After
-  path: testdata
-
+  where:
+    target: main
+    func: Func1
+  do:
+    inject_hooks:
+      before: H2Before
+      after: H2After
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/multiple-struct-fields/rules.yml
+++ b/tool/internal/instrument/testdata/golden/multiple-struct-fields/rules.yml
@@ -1,11 +1,13 @@
 add_multiple_fields:
-  target: main
-  struct: T
-  new_field:
-    - name: Field1
-      type: string
-    - name: Field2
-      type: int
-    - name: Field3
-      type: bool
-
+  where:
+    target: main
+    struct: T
+  do:
+    add_struct_fields:
+      new_field:
+        - name: Field1
+          type: string
+        - name: Field2
+          type: int
+        - name: Field3
+          type: bool

--- a/tool/internal/instrument/testdata/golden/opt-multiple-funcs/rules.yml
+++ b/tool/internal/instrument/testdata/golden/opt-multiple-funcs/rules.yml
@@ -1,19 +1,27 @@
 opt_good:
-  target: main
-  func: OptGood
-  before: H5Before
-  path: testdata
+  where:
+    target: main
+    func: OptGood
+  do:
+    inject_hooks:
+      before: H5Before
+      path: testdata
 
 opt_bad:
-  target: main
-  func: OptBad
-  before: H6Before
-  path: testdata
+  where:
+    target: main
+    func: OptBad
+  do:
+    inject_hooks:
+      before: H6Before
+      path: testdata
 
 opt_bad2:
-  target: main
-  func: OptBad2
-  before: H7Before
-  after: H7After
-  path: testdata
-
+  where:
+    target: main
+    func: OptBad2
+  do:
+    inject_hooks:
+      before: H7Before
+      after: H7After
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/raw-rule-only/rules.yml
+++ b/tool/internal/instrument/testdata/golden/raw-rule-only/rules.yml
@@ -1,5 +1,7 @@
 add_raw_code:
-  target: main
-  func: Func1
-  raw: "_ = 123"
-
+  where:
+    target: main
+    func: Func1
+  do:
+    inject_code:
+      raw: "_ = 123"

--- a/tool/internal/instrument/testdata/golden/raw-rule-with-imports/rules.yml
+++ b/tool/internal/instrument/testdata/golden/raw-rule-with-imports/rules.yml
@@ -1,6 +1,9 @@
 inject_fmt:
-  target: main
-  func: Func1
-  raw: 'fmt.Println("Instrumented with imports")'
+  where:
+    target: main
+    func: Func1
+  do:
+    inject_code:
+      raw: 'fmt.Println("Instrumented with imports")'
   imports:
     fmt: "fmt"

--- a/tool/internal/instrument/testdata/golden/struct-rule-only/rules.yml
+++ b/tool/internal/instrument/testdata/golden/struct-rule-only/rules.yml
@@ -1,7 +1,9 @@
 add_new_field:
-  target: main
-  struct: T
-  new_field:
-    - name: NewField
-      type: string
-
+  where:
+    target: main
+    struct: T
+  do:
+    add_struct_fields:
+      new_field:
+        - name: NewField
+          type: string

--- a/tool/internal/instrument/testdata/golden/underscore-return-syntax/rules.yml
+++ b/tool/internal/instrument/testdata/golden/underscore-return-syntax/rules.yml
@@ -1,5 +1,8 @@
 hook_underscore_return:
-  target: main
-  func: UnderscoreReturnFunc
-  after: H12UnderscoreReturnAfter
-  path: testdata
+  where:
+    target: main
+    func: UnderscoreReturnFunc
+  do:
+    inject_hooks:
+      after: H12UnderscoreReturnAfter
+      path: testdata

--- a/tool/internal/instrument/testdata/golden/underscore-syntax/rules.yml
+++ b/tool/internal/instrument/testdata/golden/underscore-syntax/rules.yml
@@ -1,6 +1,8 @@
 hook_underscore:
-  target: main
-  func: UnderscoreFunc
-  before: H10Before
-  path: testdata
-
+  where:
+    target: main
+    func: UnderscoreFunc
+  do:
+    inject_hooks:
+      before: H10Before
+      path: testdata

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -32,6 +32,70 @@ const (
 	matchDepsConcurrencyMultiplier = 2
 )
 
+// normalizeRule detects the new where/do format and flattens it to the
+// internal flat format expected by rule constructors. If the fields map
+// contains neither "where" nor "do", it is returned unchanged.
+//
+// New format:
+//
+//	rule_name:
+//	  where:
+//	    target: pkg
+//	    func: Fn
+//	  do:
+//	    inject_hooks:
+//	      before: HookBefore
+//	      path: "github.com/..."
+//	  imports:
+//	    fmt: "fmt"
+//
+// Flat (internal) format that constructors expect:
+//
+//	target: pkg
+//	func: Fn
+//	before: HookBefore
+//	path: "github.com/..."
+//	imports:
+//	  fmt: "fmt"
+func normalizeRule(fields map[string]any) map[string]any {
+	_, hasWhere := fields["where"]
+	_, hasDo := fields["do"]
+	if !hasWhere && !hasDo {
+		return fields
+	}
+
+	flat := make(map[string]any)
+
+	// Copy top-level fields (e.g. imports, name) that sit outside where/do.
+	for k, v := range fields {
+		if k != "where" && k != "do" {
+			flat[k] = v
+		}
+	}
+
+	// Merge selector fields from the where block.
+	if whereRaw, ok := fields["where"]; ok {
+		if whereMap, ok := whereRaw.(map[string]any); ok {
+			maps.Copy(flat, whereMap)
+		}
+	}
+
+	// Merge modifier fields from the do block.
+	// The do block has exactly one key (the modifier name); its value is a
+	// map of modifier-specific fields.
+	if doRaw, ok := fields["do"]; ok {
+		if doMap, ok := doRaw.(map[string]any); ok {
+			for _, modifierVal := range doMap {
+				if modFields, ok := modifierVal.(map[string]any); ok {
+					maps.Copy(flat, modFields)
+				}
+			}
+		}
+	}
+
+	return flat
+}
+
 // createRuleFromFields creates a rule instance based on the field type present in the YAML
 //
 //nolint:nilnil // factory function
@@ -65,12 +129,15 @@ func parseRuleFromYaml(content []byte) ([]rule.InstRule, error) {
 	}
 	rules := make([]rule.InstRule, 0)
 	for name, fields := range h {
-		raw, err1 := yaml.Marshal(fields)
+		// Translate where/do format to the flat format expected by constructors.
+		flatFields := normalizeRule(fields)
+
+		raw, err1 := yaml.Marshal(flatFields)
 		if err1 != nil {
 			return nil, ex.Wrap(err1)
 		}
 
-		r, err2 := createRuleFromFields(raw, name, fields)
+		r, err2 := createRuleFromFields(raw, name, flatFields)
 		if err2 != nil {
 			return nil, err2
 		}

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -75,7 +75,7 @@ func normalizeRule(fields map[string]any) map[string]any {
 
 	// Merge selector fields from the where block.
 	if whereRaw, ok := fields["where"]; ok {
-		if whereMap, ok := whereRaw.(map[string]any); ok {
+		if whereMap, isMap := whereRaw.(map[string]any); isMap {
 			maps.Copy(flat, whereMap)
 		}
 	}
@@ -84,9 +84,9 @@ func normalizeRule(fields map[string]any) map[string]any {
 	// The do block has exactly one key (the modifier name); its value is a
 	// map of modifier-specific fields.
 	if doRaw, ok := fields["do"]; ok {
-		if doMap, ok := doRaw.(map[string]any); ok {
+		if doMap, isMap := doRaw.(map[string]any); isMap {
 			for _, modifierVal := range doMap {
-				if modFields, ok := modifierVal.(map[string]any); ok {
+				if modFields, isModMap := modifierVal.(map[string]any); isModMap {
 					maps.Copy(flat, modFields)
 				}
 			}

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -24,6 +24,266 @@ func (r *mockInstRule) String() string {
 	return r.Name
 }
 
+func TestNormalizeRule(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]any
+		expect map[string]any
+	}{
+		{
+			name: "flat format passthrough",
+			input: map[string]any{
+				"target": "net/http",
+				"func":   "ServeHTTP",
+				"before": "BeforeHook",
+				"path":   "github.com/example/pkg",
+			},
+			expect: map[string]any{
+				"target": "net/http",
+				"func":   "ServeHTTP",
+				"before": "BeforeHook",
+				"path":   "github.com/example/pkg",
+			},
+		},
+		{
+			name: "inject_hooks: func+recv from where, before/after/path from do",
+			input: map[string]any{
+				"where": map[string]any{
+					"target": "net/http",
+					"func":   "ServeHTTP",
+					"recv":   "serverHandler",
+				},
+				"do": map[string]any{
+					"inject_hooks": map[string]any{
+						"before": "BeforeServeHTTP",
+						"after":  "AfterServeHTTP",
+						"path":   "github.com/example/pkg",
+					},
+				},
+			},
+			expect: map[string]any{
+				"target": "net/http",
+				"func":   "ServeHTTP",
+				"recv":   "serverHandler",
+				"before": "BeforeServeHTTP",
+				"after":  "AfterServeHTTP",
+				"path":   "github.com/example/pkg",
+			},
+		},
+		{
+			name: "inject_code: func from where, raw from do",
+			input: map[string]any{
+				"where": map[string]any{
+					"target": "runtime",
+					"func":   "newproc1",
+				},
+				"do": map[string]any{
+					"inject_code": map[string]any{
+						"raw": "defer func(){}()",
+					},
+				},
+			},
+			expect: map[string]any{
+				"target": "runtime",
+				"func":   "newproc1",
+				"raw":    "defer func(){}()",
+			},
+		},
+		{
+			name: "add_struct_fields: struct from where, new_field from do",
+			input: map[string]any{
+				"where": map[string]any{
+					"target": "runtime",
+					"struct": "g",
+				},
+				"do": map[string]any{
+					"add_struct_fields": map[string]any{
+						"new_field": []any{
+							map[string]any{"name": "otel_ctx", "type": "interface{}"},
+						},
+					},
+				},
+			},
+			expect: map[string]any{
+				"target": "runtime",
+				"struct": "g",
+				"new_field": []any{
+					map[string]any{"name": "otel_ctx", "type": "interface{}"},
+				},
+			},
+		},
+		{
+			name: "add_file: target only in where, file+path from do",
+			input: map[string]any{
+				"where": map[string]any{
+					"target": "runtime",
+				},
+				"do": map[string]any{
+					"add_file": map[string]any{
+						"file": "runtime_gls.go",
+						"path": "github.com/example/pkg",
+					},
+				},
+			},
+			expect: map[string]any{
+				"target": "runtime",
+				"file":   "runtime_gls.go",
+				"path":   "github.com/example/pkg",
+			},
+		},
+		{
+			name: "wrap_call: function_call from where, template from do",
+			input: map[string]any{
+				"where": map[string]any{
+					"target":        "main",
+					"function_call": "unsafe.Sizeof",
+				},
+				"do": map[string]any{
+					"wrap_call": map[string]any{
+						"template": "Wrapper({{ . }})",
+					},
+				},
+			},
+			expect: map[string]any{
+				"target":        "main",
+				"function_call": "unsafe.Sizeof",
+				"template":      "Wrapper({{ . }})",
+			},
+		},
+		{
+			name: "expand_directive: directive from where, template from do",
+			input: map[string]any{
+				"where": map[string]any{
+					"target":    "main",
+					"directive": "otelc:span",
+				},
+				"do": map[string]any{
+					"expand_directive": map[string]any{
+						"template": `defer otelc.End()`,
+					},
+				},
+			},
+			expect: map[string]any{
+				"target":    "main",
+				"directive": "otelc:span",
+				"template":  `defer otelc.End()`,
+			},
+		},
+		{
+			name: "assign_value: kind+identifier from where, value from do",
+			input: map[string]any{
+				"where": map[string]any{
+					"target":     "main",
+					"kind":       "var",
+					"identifier": "GlobalVar",
+				},
+				"do": map[string]any{
+					"assign_value": map[string]any{
+						"value": `"replaced"`,
+					},
+				},
+			},
+			expect: map[string]any{
+				"target":     "main",
+				"kind":       "var",
+				"identifier": "GlobalVar",
+				"value":      `"replaced"`,
+			},
+		},
+		{
+			name: "imports stays at top level",
+			input: map[string]any{
+				"where": map[string]any{
+					"target": "main",
+					"func":   "Fn",
+				},
+				"do": map[string]any{
+					"inject_code": map[string]any{
+						"raw": `fmt.Println("x")`,
+					},
+				},
+				"imports": map[string]any{"fmt": "fmt"},
+			},
+			expect: map[string]any{
+				"target":  "main",
+				"func":    "Fn",
+				"raw":     `fmt.Println("x")`,
+				"imports": map[string]any{"fmt": "fmt"},
+			},
+		},
+		{
+			name: "version from where is preserved",
+			input: map[string]any{
+				"where": map[string]any{
+					"target":  "golang.org/x/time/rate",
+					"version": "v0.14.0,v0.15.0",
+					"func":    "Every",
+				},
+				"do": map[string]any{
+					"inject_code": map[string]any{
+						"raw": `fmt.Println("x")`,
+					},
+				},
+			},
+			expect: map[string]any{
+				"target":  "golang.org/x/time/rate",
+				"version": "v0.14.0,v0.15.0",
+				"func":    "Every",
+				"raw":     `fmt.Println("x")`,
+			},
+		},
+		{
+			name: "only where block (no do)",
+			input: map[string]any{
+				"where": map[string]any{
+					"target": "main",
+					"func":   "Fn",
+				},
+			},
+			expect: map[string]any{
+				"target": "main",
+				"func":   "Fn",
+			},
+		},
+		{
+			name: "only do block (no where)",
+			input: map[string]any{
+				"do": map[string]any{
+					"inject_code": map[string]any{
+						"raw": "_ = 0",
+					},
+				},
+			},
+			expect: map[string]any{
+				"raw": "_ = 0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeRule(tt.input)
+			if len(got) != len(tt.expect) {
+				t.Errorf("normalizeRule() len = %d, want %d; got %v", len(got), len(tt.expect), got)
+				return
+			}
+			for k, wantVal := range tt.expect {
+				gotVal, exists := got[k]
+				if !exists {
+					t.Errorf("normalizeRule() missing key %q", k)
+					continue
+				}
+				// Use yaml round-trip for deep equality of nested maps/slices.
+				wantYAML, _ := yaml.Marshal(wantVal)
+				gotYAML, _ := yaml.Marshal(gotVal)
+				if string(wantYAML) != string(gotYAML) {
+					t.Errorf("normalizeRule()[%q] = %v, want %v", k, gotVal, wantVal)
+				}
+			}
+		})
+	}
+}
+
 func TestMatchVersion(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Description

Introduce explicit `where` (selectors) and `do` (modifiers) blocks in rule YAML files, replacing the previous flat field layout where matcher and modifier fields were mixed at the same level.

**Before:**
```yaml
server_hook:
  target: net/http
  func: ServeHTTP
  recv: serverHandler
  before: BeforeServeHTTP
  after: AfterServeHTTP
  path: "github.com/.../server"
```

**After:**
```yaml
server_hook:
  where:
    target: net/http
    func: ServeHTTP
    recv: serverHandler
  do:
    inject_hooks:
      before: BeforeServeHTTP
      after: AfterServeHTTP
      path: "github.com/.../server"
```

The modifier name inside `do` determines the rule type: `inject_hooks`, `inject_code`, `add_struct_fields`, `add_file`, `wrap_call`, `expand_directive`, `assign_value`.

A `normalizeRule()` function at the YAML parsing boundary translates the new format to the internal flat representation — rule structs, constructors, validation, and JSON serialization are unchanged.

## Motivation

Rules have two concerns — **what to match** and **what to do** — but they were expressed as a flat bag of fields. Scanability suffers: it takes effort to tell selectors from modifiers without knowing the rule type. The new schema makes intent visible at a glance and gives future modifier types (`prepend_statements`, `modify_body`, etc.) a natural place to live.

ADR: `docs/adr/0003-structured-rule-schema.md`

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [x] Documentation updated (if applicable)