### PR TITLE
docs: use correct instrumentation rules path in instrument-guide.md

### DIFF
--- a/docs/instrument-guide.md
+++ b/docs/instrument-guide.md
@@ -12,9 +12,9 @@ The process consists of three main steps:
 
 ## 1. Define Rules
 
-Rules are defined in YAML format and stored in `tool/data/`. These files tell the `otelc` which functions to instrument.
+Rules are defined in YAML format and stored in `pkg/instrumentation/<library-name>/<library-name>.yaml`. This file tells `otelc` which functions to instrument.
 
-Create a new file `tool/data/<library-name>.yaml`. Below is an example configuration for instrumenting a function `NewServer`:
+Create a new file `pkg/instrumentation/<library-name>/<library-name>.yaml`. Below is an example configuration for instrumenting a function `NewServer`:
 
 ```yaml
 inject_to_grpc_newserver:
@@ -120,7 +120,7 @@ make test-integration
 
 Check that your instrumentation package have following elements:
 
-* A rule YAML in `tool/data/` with a correct `target` and version range.
+* A rule YAML in `pkg/instrumentation/<library-name>/<library-name>.yaml` with a correct `target` and version range.
 * Hook implementation under `pkg/instrumentation/<library>/...`
 * Unit tests alongside the hooks for logic-level behavior.
 * Integration tests in `test/integration/` that execute an instrumented binary and validate spans/attributes.

--- a/docs/instrument-guide.md
+++ b/docs/instrument-guide.md
@@ -120,7 +120,7 @@ make test-integration
 
 Check that your instrumentation package have following elements:
 
-* A rule YAML in `pkg/instrumentation/<library-name>/<library-name>.yaml` with a correct `target` and version range.
+* A rule YAML `pkg/instrumentation/<library-name>/<library-name>.yaml` with a correct `target` and version range.
 * Hook implementation under `pkg/instrumentation/<library>/...`
 * Unit tests alongside the hooks for logic-level behavior.
 * Integration tests in `test/integration/` that execute an instrumented binary and validate spans/attributes.


### PR DESCRIPTION
## Description

Update instrumentation rules path in instrument-guide.md
`tool/data/<library-name>.yaml` -> `pkg/instrumentation/<library-name>/<library-name>.yaml`

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [ ] Code formatted: `make format`
- [ ] Linters pass: `make lint`
- [ ] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](docs/testing.md)
- [x] Documentation updated (if applicable)
