### PR TITLE
fix(instrumentation): redis v9 test failure and skipping instrumentation packages in unit test discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,7 @@ test-unit/pkg: package ## Run unit tests for pkg modules only
 	@echo "Running pkg unit tests..."
 	set -euo pipefail
 	rm -f ./gotest-unit-pkg.log
-	PKG_MODULES=$$(find pkg -maxdepth 3 -name "go.mod" -type f -exec dirname {} \; | grep -v "runtime" | grep -v "databasesql" | grep -v "^pkg$$"); \
+	PKG_MODULES=$$(find pkg -maxdepth 4 -name "go.mod" -type f -exec dirname {} \; | grep -v "runtime" | grep -v "databasesql" | grep -v "^pkg$$"); \
 	for moddir in $$PKG_MODULES; do \
 		if ! find "$$moddir" -name "*_test.go" -type f | grep -q .; then \
 			echo "Skipping $$moddir (no tests)..."; \

--- a/Makefile
+++ b/Makefile
@@ -373,7 +373,7 @@ test-unit/tool: build package $(GOTESTFMT) ## Run unit tests for tool modules on
 	go test -json -v -shuffle=on -timeout=5m -count=1 ./tool/... 2>&1 | tee ./gotest-unit-tool.log
 
 # Notes on test-unit/pkg implementation:
-# - Uses find -maxdepth 3 to discover modules at pkg/instrumentation/{name}/ level only.
+# - Uses find -maxdepth 4 to discover modules at pkg/instrumentation/{name}/ and pkg/instrumentation/{name}/{sub} levels only.
 #   This naturally excludes client/ and server/ subdirectories (which will have link errors because it requires the parent module to be built).
 # - Excludes "runtime" and "databasesql" modules (have build errors because of compile-time field injection) and root "pkg" module (no tests).
 # - Skips modules without test files to avoid empty test output.
@@ -429,7 +429,7 @@ test-unit/pkg/coverage: package ## Run unit tests with coverage for pkg modules 
 	@echo "Running pkg unit tests with coverage..."
 	set -euo pipefail
 	rm -f ./gotest-unit-pkg.log
-	PKG_MODULES=$$(find pkg -maxdepth 3 -name "go.mod" -type f -exec dirname {} \; | grep -v "runtime" | grep -v "databasesql" | grep -v "^pkg$$"); \
+	PKG_MODULES=$$(find pkg -maxdepth 4 -name "go.mod" -type f -exec dirname {} \; | grep -v "runtime" | grep -v "databasesql" | grep -v "^pkg$$"); \
 	for moddir in $$PKG_MODULES; do \
 		if ! find "$$moddir" -name "*_test.go" -type f | grep -q .; then \
 			echo "Skipping $$moddir (no tests)..."; \

--- a/pkg/instrumentation/redis/v9/hook_test.go
+++ b/pkg/instrumentation/redis/v9/hook_test.go
@@ -180,7 +180,8 @@ func TestProcessHook_CreatesSpan(t *testing.T) {
 	}
 	assert.Equal(t, "redis", attrMap["db.system.name"])
 	assert.Equal(t, "get", attrMap["db.operation.name"])
-	assert.Equal(t, "localhost:6379", attrMap["network.peer.address"])
+	assert.Equal(t, "localhost", attrMap["server.address"])
+	assert.Equal(t, int64(6379), attrMap["server.port"])
 }
 
 func TestProcessHook_RecordsError(t *testing.T) {


### PR DESCRIPTION
## Description

Increase module search depth for the `test-unit/pkg` target in the Makefile.

Fix a failing unit test for the redis instrumentation hook.

## Motivation

Searching modules only up to depth 3 skips testing `pkg/instrumentation/grpc/{client,server}`, `pkg/instrumentation/nethttp/{client,server}`, and `pkg/instrumentation/redis/v9`

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
