### PR TITLE
feat(tests): store bench results

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -23,4 +23,40 @@ jobs:
       - name: Build otelc
         run: make build
       - name: Run benchmarks
-        run: make benchmark/run BENCH_ITERATIONS=5 BENCH_MAX_OVERHEAD_PCT=150
+        run: make benchmark/run BENCH_ITERATIONS=5 BENCH_MAX_OVERHEAD_PCT=150 BENCH_ACTION_OUTPUT=bench-action.json
+      - name: Upload benchmark-action results
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          name: bench-action
+          path: bench-action.json
+          retention-days: 1
+
+  benchmark-store:
+    name: Store Benchmark Results
+    runs-on: ubuntu-latest
+    needs: benchmark
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - name: Download benchmark-action results
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        with:
+          name: bench-action
+      - name: Store benchmark results in gh-pages
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372  # ratchet:benchmark-action/github-action-benchmark@v1.22.0
+        with:
+          name: otelc Compile-Time Benchmarks
+          tool: customSmallerIsBetter
+          output-file-path: bench-action.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          comment-on-alert: false
+          fail-on-alert: false
+          summary-always: true
+          max-items-in-chart: 100

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ test/apps/*/app.exe
 
 test/bench/scenarios/*/app
 bench.json
+bench-action.json
 
 _tools
 coverage.out

--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,7 @@ check-golden-files: package
 BENCH_HARNESS_DIR := test/bench/cmd/bench
 BENCH_SCENARIOS_DIR := test/bench/scenarios
 BENCH_OUTPUT := bench.json
+BENCH_ACTION_OUTPUT := bench-action.json
 BENCH_ITERATIONS ?= 5
 BENCH_WARMUP ?= 1
 BENCH_MAX_OVERHEAD_PCT ?= -1
@@ -374,9 +375,10 @@ benchmark/run: benchmark
 		-iterations=$(BENCH_ITERATIONS) \
 		-warmup=$(BENCH_WARMUP) \
 		-max-overhead-pct=$(BENCH_MAX_OVERHEAD_PCT) \
-		-output=$(CURDIR)/$(BENCH_OUTPUT)
+		-output=$(CURDIR)/$(BENCH_OUTPUT) \
+		-benchmark-action-output=$(CURDIR)/$(BENCH_ACTION_OUTPUT)
 	@echo ""
-	@echo "Results written to $(BENCH_OUTPUT)"
+	@echo "Results written to $(BENCH_OUTPUT) and $(BENCH_ACTION_OUTPUT)"
 
 ##@ Testing
 # NOTE: Tests require the 'package' target to run first because tool/data/export.go

--- a/test/bench/cmd/bench/main.go
+++ b/test/bench/cmd/bench/main.go
@@ -10,6 +10,10 @@
 // Usage:
 //
 //	bench -otelc=./otelc -scenarios=../../scenarios -iterations=5 -warmup=1 -output=bench.json
+//
+// To additionally emit a benchmark-action compatible file:
+//
+//	bench ... -benchmark-action-output=bench-action.json
 package main
 
 import (
@@ -40,6 +44,16 @@ type ScenarioResult struct {
 	OverheadPct float64 `json:"overhead_pct"`
 }
 
+// benchmarkActionEntry is a single entry in the customSmallerIsBetter JSON
+// format consumed by benchmark-action/github-action-benchmark.
+type benchmarkActionEntry struct {
+	Name  string  `json:"name"`
+	Unit  string  `json:"unit"`
+	Value float64 `json:"value"`
+	Range string  `json:"range,omitempty"`
+	Extra string  `json:"extra,omitempty"`
+}
+
 // buildEnv is the environment used for all build commands.
 // GOGC=off suppresses GC jitter inside the Go toolchain during timed builds.
 var buildEnv = append(os.Environ(), "GOGC=off")
@@ -51,6 +65,7 @@ func main() {
 	warmup := flag.Int("warmup", 1, "Number of discarded warmup builds before timing begins")
 	outputFile := flag.String("output", "bench.json", "Output file path for benchmark results JSON")
 	maxOverheadPct := flag.Float64("max-overhead-pct", -1, "Fail if any scenario's otelc overhead exceeds this percentage relative to the plain baseline (negative = disabled)")
+	benchActionOutput := flag.String("benchmark-action-output", "", "Additional output file in benchmark-action customSmallerIsBetter JSON format (empty = disabled)")
 	flag.Parse()
 
 	otelcAbs, err := filepath.Abs(*otelcBin)
@@ -123,6 +138,18 @@ func main() {
 	}
 
 	log.Printf("results written to %s", *outputFile)
+
+	if *benchActionOutput != "" {
+		entries := toBenchmarkActionEntries(results)
+		actionOut, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			log.Fatalf("marshaling benchmark-action output: %v", err)
+		}
+		if err := os.WriteFile(*benchActionOutput, actionOut, 0o644); err != nil {
+			log.Fatalf("writing benchmark-action output file %s: %v", *benchActionOutput, err)
+		}
+		log.Printf("benchmark-action results written to %s", *benchActionOutput)
+	}
 
 	if len(violations) > 0 {
 		log.Printf("FAIL: overhead threshold of %.1f%% exceeded in %d scenario(s):", *maxOverheadPct, len(violations))
@@ -233,4 +260,33 @@ func trimmedStddev(values []float64) float64 {
 // round3 rounds v to 3 decimal places.
 func round3(v float64) float64 {
 	return math.Round(v*1000) / 1000
+}
+
+// toBenchmarkActionEntries converts a slice of ScenarioResults to the
+// customSmallerIsBetter JSON format required by github-action-benchmark.
+func toBenchmarkActionEntries(results []ScenarioResult) []benchmarkActionEntry {
+	entries := make([]benchmarkActionEntry, 0, len(results)*3)
+	for _, r := range results {
+		entries = append(entries,
+			benchmarkActionEntry{
+				Name:  r.Scenario + " / otelc compile time",
+				Unit:  "s",
+				Value: r.OtelcMean,
+				Range: fmt.Sprintf("± %.3f", r.OtelcRange),
+				Extra: fmt.Sprintf("plain=%.3fs (±%.3f) overhead=%+.1f%%", r.PlainMean, r.PlainRange, r.OverheadPct),
+			},
+			benchmarkActionEntry{
+				Name:  r.Scenario + " / plain compile time",
+				Unit:  "s",
+				Value: r.PlainMean,
+				Range: fmt.Sprintf("± %.3f", r.PlainRange),
+			},
+			benchmarkActionEntry{
+				Name:  r.Scenario + " / overhead",
+				Unit:  "%",
+				Value: r.OverheadPct,
+			},
+		)
+	}
+	return entries
 }


### PR DESCRIPTION
Contributing to https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/351

It stores bench results from `main` branch in `gh-pages` branch ([example](https://github.com/txabman42/opentelemetry-go-compile-instrumentation/blob/gh-pages/dev/bench/data.js)).