### PR TITLE
fix(instrumentation): prevent reentrant OTel SDK initialization

### DIFF
--- a/pkg/instrumentation/grpc/client/client_hook.go
+++ b/pkg/instrumentation/grpc/client/client_hook.go
@@ -40,11 +40,12 @@ type int64Hist interface {
 }
 
 var (
-	logger     = shared.Logger()
-	tracer     trace.Tracer
-	propagator propagation.TextMapPropagator
-	meter      metric.Meter
-	initOnce   sync.Once
+	logger       = shared.Logger()
+	tracer       trace.Tracer
+	propagator   propagation.TextMapPropagator
+	meter        metric.Meter
+	initOnce     sync.Once
+	initializing atomic.Bool
 
 	// Metrics
 	clientDuration        rpcconv.ClientDuration
@@ -71,7 +72,14 @@ func moduleVersion() string {
 }
 
 func initInstrumentation() {
+	// If we're already in the process of initializing, return immediately to avoid deadlock
+	if initializing.Load() {
+		return
+	}
 	initOnce.Do(func() {
+		initializing.Store(true)
+		defer initializing.Store(false)
+
 		version := moduleVersion()
 		if err := shared.SetupOTelSDK("go.opentelemetry.io/compile-instrumentation/grpc/client", version); err != nil {
 			logger.Error("failed to setup OTel SDK", "error", err)

--- a/pkg/instrumentation/grpc/client/client_hook.go
+++ b/pkg/instrumentation/grpc/client/client_hook.go
@@ -5,7 +5,9 @@ package client
 
 import (
 	"context"
+	"os"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,12 +42,11 @@ type int64Hist interface {
 }
 
 var (
-	logger       = shared.Logger()
-	tracer       trace.Tracer
-	propagator   propagation.TextMapPropagator
-	meter        metric.Meter
-	initOnce     sync.Once
-	initializing atomic.Bool
+	logger     = shared.Logger()
+	tracer     trace.Tracer
+	propagator propagation.TextMapPropagator
+	meter      metric.Meter
+	initOnce   sync.Once
 
 	// Metrics
 	clientDuration        rpcconv.ClientDuration
@@ -72,14 +73,7 @@ func moduleVersion() string {
 }
 
 func initInstrumentation() {
-	// If we're already in the process of initializing, return immediately to avoid deadlock
-	if initializing.Load() {
-		return
-	}
 	initOnce.Do(func() {
-		initializing.Store(true)
-		defer initializing.Store(false)
-
 		version := moduleVersion()
 		if err := shared.SetupOTelSDK("go.opentelemetry.io/compile-instrumentation/grpc/client", version); err != nil {
 			logger.Error("failed to setup OTel SDK", "error", err)
@@ -143,6 +137,17 @@ var clientEnabler = grpcClientEnabler{}
 func BeforeNewClient(ictx inst.HookContext, target string, opts ...grpc.DialOption) {
 	if !clientEnabler.Enable() {
 		logger.Debug("gRPC client instrumentation disabled")
+		return
+	}
+
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if endpoint == "" {
+		endpoint = os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+	}
+
+	// Skip instrumentation for OTLP exporter endpoints to prevent deadlock/infinite recursion
+	if strings.Contains(endpoint, target) {
+		logger.Debug("Skipping instrumentation for OTLP exporter endpoint", "target", target, "endpoint", endpoint)
 		return
 	}
 

--- a/pkg/instrumentation/grpc/client/client_hook.go
+++ b/pkg/instrumentation/grpc/client/client_hook.go
@@ -146,7 +146,7 @@ func BeforeNewClient(ictx inst.HookContext, target string, opts ...grpc.DialOpti
 	}
 
 	// Skip instrumentation for OTLP exporter endpoints to prevent deadlock/infinite recursion
-	if strings.Contains(endpoint, target) {
+	if target != "" && strings.Contains(endpoint, target) {
 		logger.Debug("Skipping instrumentation for OTLP exporter endpoint", "target", target, "endpoint", endpoint)
 		return
 	}

--- a/pkg/instrumentation/grpc/client/client_hook_test.go
+++ b/pkg/instrumentation/grpc/client/client_hook_test.go
@@ -32,11 +32,12 @@ func TestBeforeNewClient(t *testing.T) {
 	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
 
 	tests := []struct {
-		name          string
-		target        string
-		opts          []grpc.DialOption
-		enabledEnv    bool
-		expectHandler bool
+		name                    string
+		target                  string
+		opts                    []grpc.DialOption
+		enabledEnv              bool
+		expectHandler           bool
+		oltpExporterEndpointKey string
 	}{
 		{
 			name:          "no options",
@@ -75,6 +76,22 @@ func TestBeforeNewClient(t *testing.T) {
 			enabledEnv:    true,
 			expectHandler: true,
 		},
+		{
+			name:                    "oltp exporter endpoint target",
+			target:                  "localhost:4317",
+			opts:                    []grpc.DialOption{},
+			enabledEnv:              true,
+			expectHandler:           false,
+			oltpExporterEndpointKey: "OTEL_EXPORTER_OTLP_ENDPOINT",
+		},
+		{
+			name:                    "oltp exporter traces endpoint target",
+			target:                  "localhost:4317",
+			opts:                    []grpc.DialOption{},
+			enabledEnv:              true,
+			expectHandler:           false,
+			oltpExporterEndpointKey: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		},
 	}
 
 	for _, tt := range tests {
@@ -83,6 +100,10 @@ func TestBeforeNewClient(t *testing.T) {
 				t.Setenv("OTEL_GO_ENABLED_INSTRUMENTATIONS", "grpc")
 			} else {
 				t.Setenv("OTEL_GO_DISABLED_INSTRUMENTATIONS", "grpc")
+			}
+
+			if tt.oltpExporterEndpointKey != "" {
+				t.Setenv(tt.oltpExporterEndpointKey, tt.target)
 			}
 
 			ictx := insttest.NewMockHookContext(tt.target, tt.opts)

--- a/pkg/instrumentation/shared/otel_setup.go
+++ b/pkg/instrumentation/shared/otel_setup.go
@@ -7,13 +7,9 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"sync/atomic"
 )
 
-var (
-	setupOnce    sync.Once
-	initializing atomic.Bool
-)
+var setupOnce sync.Once
 
 // SetupOTelSDK initializes the OpenTelemetry SDK if not already initialized.
 // This function is idempotent and safe to call multiple times.
@@ -51,14 +47,7 @@ var (
 //	    logger.Error("failed to setup OTel SDK", "error", err)
 //	}
 func SetupOTelSDK(instrumentationName, instrumentationVersion string) error {
-	// If we're already in the process of initializing, return immediately to avoid deadlock
-	if initializing.Load() {
-		return nil
-	}
 	setupOnce.Do(func() {
-		initializing.Store(true)
-		defer initializing.Store(false)
-
 		// Initialize OpenTelemetry SDK with defensive error handling
 		Initialize(Config{
 			ServiceName:            "otelc-instrumentation",

--- a/pkg/instrumentation/shared/otel_setup.go
+++ b/pkg/instrumentation/shared/otel_setup.go
@@ -7,9 +7,13 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
-var setupOnce sync.Once
+var (
+	setupOnce    sync.Once
+	initializing atomic.Bool
+)
 
 // SetupOTelSDK initializes the OpenTelemetry SDK if not already initialized.
 // This function is idempotent and safe to call multiple times.
@@ -47,7 +51,14 @@ var setupOnce sync.Once
 //	    logger.Error("failed to setup OTel SDK", "error", err)
 //	}
 func SetupOTelSDK(instrumentationName, instrumentationVersion string) error {
+	// If we're already in the process of initializing, return immediately to avoid deadlock
+	if initializing.Load() {
+		return nil
+	}
 	setupOnce.Do(func() {
+		initializing.Store(true)
+		defer initializing.Store(false)
+
 		// Initialize OpenTelemetry SDK with defensive error handling
 		Initialize(Config{
 			ServiceName:            "otelc-instrumentation",


### PR DESCRIPTION
When a project depends on golang.google.org/grpc and OTEL_EXPORTER_OTLP_PROTOCOL is set to grpc, initializing the exporters (autoexport.NewSpanExporter/NewMetricReader) inside initInstrumentation/SetupOTelSDK calls grpc.NewClient.

This invokes BeforeNewClient gRPC instrumentation hook which calls initInstrumentation/SetupOTelSDK again. Since initInstrumentation/SetupOTelSDK use sync.Once, this recursive call causes a deadlock.