### PR TITLE
fix(demo): complete db-server service and bump mysql image

### DIFF
--- a/demo/infrastructure/docker-compose/docker-compose.yml
+++ b/demo/infrastructure/docker-compose/docker-compose.yml
@@ -184,7 +184,7 @@ services:
 
   # MySQL - Database backend for DB demo
   mysql:
-    image: mysql:9.6@sha256:e5dc14f6e01c3e577e669337d2855c6d1561b30d8ef2c592e63e4e8a9a52650a
+    image: mysql:9.6@sha256:c5df04bee1a42b74a5841c6409e669cf62126cd0416f00c1cea8ab933b9361b9
     container_name: mysql
     environment:
       - MYSQL_ROOT_PASSWORD=root
@@ -217,6 +217,17 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_SERVICE_NAME=db-server
+      - OTEL_RESOURCE_ATTRIBUTES=service.namespace=demo,service.version=1.0.0
+      - OTEL_LOG_LEVEL=info
+    networks:
+      - observability
+    depends_on:
+      mysql:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+    restart: unless-stopped
+
   # Redis - In-memory data store for Redis demo
   redis:
     image: redis:8-alpine@sha256:2afba59292f25f5d1af200496db41bea2c6c816b059f57ae74703a50a03a27d0


### PR DESCRIPTION
## Description

Updates incomplete db-server service block and bumps mysql image

## Motivation

Currently the db-server service fails to run because it isn't part of `observability` network and does not depend on mysql service.

The mysql image used in demo also seems to be not working, this PR also bumps the mysql image.

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [ ] Linters pass: `make lint`
- [ ] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
