### PR TITLE
chore(infra): group all dependency updates into a single PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,11 +12,10 @@
       "enabled": false
     },
     {
-      "groupName": "all non-major versions",
-      "matchUpdateTypes": ["patch", "minor", "digest"]
-    },
-    {
-      "matchUpdateTypes": ["major"]
+      "groupName": "all dependencies",
+      "groupSlug": "all-deps",
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["patch", "minor", "major", "digest"]
     }
   ],
   "labels": [


### PR DESCRIPTION
Configure Renovate to merge all dependency updates (patch, minor, major, and digest) into one PR instead of creating separate PRs per package or update type.
