### PR TITLE
refactor: rename rule replacement fields

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -168,20 +168,20 @@ This rule wraps function calls at call sites with instrumentation code. Unlike t
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `function_call` | string | Yes | Qualified function name: `package/path.FunctionName` |
-| `template` | string | No (one of `template`/`append_args` required) | Wrapper template with `{{ . }}` placeholder for the original call. Must produce a Go call expression. |
-| `append_args` | `[]string` | No (one of `template`/`append_args` required) | Go expression strings appended as additional arguments to the matched call |
+| `replace` | string | No (one of `replace`/`append_args` required) | Wrapper template with `{{ . }}` placeholder for the original call. Must produce a Go call expression. |
+| `append_args` | `[]string` | No (one of `replace`/`append_args` required) | Go expression strings appended as additional arguments to the matched call |
 | `variadic_type` | string | No | Element type for the ellipsis IIFE wrapper (e.g. `grpc.DialOption`). Required when any matched call uses `...` spread. |
 | `imports` | map[string]string | No | Additional imports needed for injected code (alias: path). Packages must be in the target module's `go.mod`. |
 
-**`template` and `append_args` are independent and can both be set.** When both are present, `append_args` is applied first (arguments are appended to the call), then `template` wraps the modified call.
+**`replace` and `append_args` are independent and can both be set.** When both are present, `append_args` is applied first (arguments are appended to the call), then `replace` wraps the modified call.
 
-**Template System:**
+**Replacement Template System:**
 
-The `template` field uses Go's standard `text/template` package for code generation. This provides:
+The `replace` field uses Go's standard `text/template` package for code generation. This provides:
 
 - **Placeholder Substitution**: `{{ . }}` is replaced with the original function call's AST node
-- **Type Safety**: The template is compiled at rule creation time and validated
-- **Expression Output**: The template must produce a valid Go expression that evaluates to a call expression (current limitation)
+- **Type Safety**: The replacement template is compiled at rule creation time and validated
+- **Expression Output**: The replacement template must produce a valid Go expression that evaluates to a call expression (current limitation)
 
 Currently supported template features:
 
@@ -231,7 +231,7 @@ Examples:
 wrap_http_get:
   target: myapp/server
   function_call: net/http.Get
-  template: "tracedGet({{ . }})"
+  replace: "tracedGet({{ . }})"
 ```
 
 In the `myapp/server` package, this transforms:
@@ -263,7 +263,7 @@ func fetchData(url string) {
 wrap_redis_get:
   target: myapp/cache
   function_call: github.com/redis/go-redis/v9.Get
-  template: "tracedRedisGet(ctx, {{ . }})"
+  replace: "tracedRedisGet(ctx, {{ . }})"
 ```
 
 In the `myapp/cache` package:
@@ -290,7 +290,7 @@ This example demonstrates the power of the `text/template` system by using an II
 wrap_with_unsafe:
   target: client
   function_call: myapp/utils.Helper
-  template: "(func() (float32, error) { r, e := {{ . }}; _ = unsafe.Sizeof(r); return r, e })()"
+  replace: "(func() (float32, error) { r, e := {{ . }}; _ = unsafe.Sizeof(r); return r, e })()"
 ```
 
 This uses an immediately-invoked function expression (IIFE) to inject logic after the call:
@@ -314,7 +314,7 @@ func process() {
 }
 ```
 
-**Note:** The `unsafe` package must be imported in the target file for this template to work.
+**Note:** The `unsafe` package must be imported in the target file for this replacement to work.
 
 ---
 
@@ -370,9 +370,9 @@ grpc.Dial(addr, func(v ...grpc.DialOption) []grpc.DialOption {
 
 **Important Notes:**
 
-- The `{{ . }}` placeholder in the template represents the original function call.
-- The template must be a valid Go expression that includes the placeholder and produces a call expression (current limitation).
-- Template code can only reference packages and functions that are already imported or defined in the target file.
+- The `{{ . }}` placeholder in `replace` represents the original function call.
+- `replace` must be a valid Go expression that includes the placeholder and produces a call expression (current limitation).
+- Replacement code can only reference packages and functions that are already imported or defined in the target file.
 - Call rules only affect call sites in the target package, not the function definition itself.
 - Multiple calls to the same function will all be wrapped independently.
 - Use the qualified format `package/path.FunctionName` for functions.
@@ -494,7 +494,7 @@ This rule targets a named package-level symbol (variable, constant, function, or
 
 - `kind` (string, optional): Constrains the kind of symbol to match. Valid values: `var`, `const`, or omitted/empty to match any kind. (`func` and `type` are recognized but not currently supported — no action can be applied to them.)
 - `identifier` (string, required): The name of the top-level symbol to match.
-- `value` (string, required): A Go expression to assign as the new value of the matched `var` or `const`. Not valid when `kind` is `func` or `type`.
+- `replace` (string, required): A Go expression to assign as the new value of the matched `var` or `const`. Not valid when `kind` is `func` or `type`.
 - `imports` (map[string]string, optional): Additional imports needed by the injected expression. Same format as [Common Fields](#common-fields).
 
 **Example:**
@@ -504,7 +504,7 @@ assign_default_transport:
   target: net/http
   kind: var
   identifier: DefaultTransport
-  value: |
+  replace: |
     &http.Transport{
       MaxIdleConns:    100,
       MaxConnsPerHost: 100,
@@ -517,6 +517,6 @@ This rule replaces `http.DefaultTransport` in the `net/http` package with a cust
 
 **Notes:**
 
-- `value` must be a valid Go expression (not a statement).
+- `replace` must be a valid Go expression (not a statement).
 - If the matched symbol has multiple names in a single declaration (e.g., `var a, b = ...`), the expression is cloned and assigned to each name.
 - Omitting `kind` matches the first symbol with the given name regardless of kind.

--- a/tool/internal/instrument/apply_call.go
+++ b/tool/internal/instrument/apply_call.go
@@ -162,7 +162,7 @@ func wrapCall(call *dst.CallExpr, r *rule.InstCallRule) error {
 	wrappedCall, ok := wrappedExpr.(*dst.CallExpr)
 	if !ok {
 		return ex.Newf(
-			"replace output must be a call expression (e.g. \"wrapper({{ . }})\") but got %T; see docs/rules.md for supported template patterns",
+			"replace output must be a call expression (e.g. \"wrapper({{ . }})\") but got %T",
 			wrappedExpr,
 		)
 	}

--- a/tool/internal/instrument/apply_call.go
+++ b/tool/internal/instrument/apply_call.go
@@ -14,7 +14,7 @@ import (
 )
 
 // applyCallRule transforms function calls at call sites by wrapping them with
-// instrumentation code according to the provided template.
+// instrumentation code according to the provided replacement template.
 func (ip *InstrumentPhase) applyCallRule(ctx context.Context, r *rule.InstCallRule, root *dst.File) error {
 	modified := false
 	importAliases := collectImportAliases(root)
@@ -42,14 +42,14 @@ func (ip *InstrumentPhase) applyCallRule(ctx context.Context, r *rule.InstCallRu
 			continue
 		}
 
-		if r.Template != "" {
+		if r.Replace != "" {
 			if err = wrapCall(call, r); err != nil {
 				ip.Warn("Failed to wrap call", "error", err)
 				continue
 			}
 		}
 
-		if appended || r.Template != "" {
+		if appended || r.Replace != "" {
 			modified = true
 		}
 	}
@@ -145,24 +145,24 @@ func buildEllipsisIIFE(spreadArg, varType dst.Expr, newArgs []dst.Expr) *dst.Cal
 	}
 }
 
-// wrapCall applies the template transformation to wrap the original call.
+// wrapCall applies the replacement template transformation to wrap the original call.
 func wrapCall(call *dst.CallExpr, r *rule.InstCallRule) error {
-	tmpl, err := newCallTemplate(r.Template)
+	tmpl, err := newCallTemplate(r.Replace)
 	if err != nil {
-		return ex.Wrapf(err, "rule has no compiled template")
+		return ex.Wrapf(err, "rule has no compiled replacement template")
 	}
 
-	// Use the template to compile the wrapped expression
+	// Use the replacement template to compile the wrapped expression.
 	wrappedExpr, err := tmpl.compileExpression(call)
 	if err != nil {
-		return ex.Wrapf(err, "failed to compile template")
+		return ex.Wrapf(err, "failed to compile replacement template")
 	}
 
 	// Verify we got a call expression back
 	wrappedCall, ok := wrappedExpr.(*dst.CallExpr)
 	if !ok {
 		return ex.Newf(
-			"template output must be a call expression (e.g. \"wrapper({{ . }})\") but got %T; see docs/rules.md for supported template patterns",
+			"replace output must be a call expression (e.g. \"wrapper({{ . }})\") but got %T; see docs/rules.md for supported template patterns",
 			wrappedExpr,
 		)
 	}

--- a/tool/internal/instrument/apply_call_test.go
+++ b/tool/internal/instrument/apply_call_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 func TestWrapCall_Success(t *testing.T) {
-	// Create a rule with a simple template
+	// Create a rule with a simple replacement template.
 	r := &rule.InstCallRule{
-		Template: "wrapper({{ . }})",
+		Replace: "wrapper({{ . }})",
 	}
 
 	// Create a call expression
@@ -43,7 +43,7 @@ func TestWrapCall_Success(t *testing.T) {
 
 func TestWrapCall_EmptyTemplate(t *testing.T) {
 	r := &rule.InstCallRule{
-		Template: "", // Empty template
+		Replace: "", // Empty replacement template
 	}
 
 	call := &dst.CallExpr{
@@ -53,13 +53,13 @@ func TestWrapCall_EmptyTemplate(t *testing.T) {
 	err := wrapCall(call, r)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to compile template")
+	assert.Contains(t, err.Error(), "failed to compile replacement template")
 }
 
 func TestWrapCall_TemplateCompilationError(t *testing.T) {
-	// Create a rule with a template that produces invalid Go syntax
+	// Create a rule with a replacement template that produces invalid Go syntax.
 	r := &rule.InstCallRule{
-		Template: "func {{ . }}", // "func" keyword without proper syntax
+		Replace: "func {{ . }}", // "func" keyword without proper syntax
 	}
 
 	call := &dst.CallExpr{
@@ -69,13 +69,13 @@ func TestWrapCall_TemplateCompilationError(t *testing.T) {
 	err := wrapCall(call, r)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to compile template")
+	assert.Contains(t, err.Error(), "failed to compile replacement template")
 }
 
 func TestWrapCall_NonCallExpressionResult(t *testing.T) {
-	// Create a template that produces a non-call expression
+	// Create a replacement template that produces a non-call expression.
 	r := &rule.InstCallRule{
-		Template: "{{ . }}.Field",
+		Replace: "{{ . }}.Field",
 	}
 
 	call := &dst.CallExpr{
@@ -85,7 +85,7 @@ func TestWrapCall_NonCallExpressionResult(t *testing.T) {
 	err := wrapCall(call, r)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "template output must be a call expression")
+	assert.Contains(t, err.Error(), "replace output must be a call expression")
 }
 
 func TestMatchesCallRule_QualifiedCallMatches(t *testing.T) {
@@ -333,10 +333,10 @@ func TestAppendCallArgs_InvalidExpr(t *testing.T) {
 	assert.False(t, modified)
 }
 
-func TestAppendCallArgs_WithTemplate(t *testing.T) {
+func TestAppendCallArgs_WithReplace(t *testing.T) {
 	r := &rule.InstCallRule{
 		AppendArgs: []string{"42"},
-		Template:   "wrapper({{ . }})",
+		Replace:    "wrapper({{ . }})",
 	}
 	call := &dst.CallExpr{
 		Fun:  &dst.Ident{Name: "f"},

--- a/tool/internal/instrument/apply_decl.go
+++ b/tool/internal/instrument/apply_decl.go
@@ -33,7 +33,7 @@ func parseValueExpr(exprSource string) (dst.Expr, error) {
 // applyDeclRule applies a declaration rule to the target file, modifying the
 // matched named declaration (e.g., assigning a new value to a var or const).
 func (ip *InstrumentPhase) applyDeclRule(ctx context.Context, r *rule.InstDeclRule, root *dst.File) error {
-	if r.Value == "" {
+	if r.Replace == "" {
 		return nil
 	}
 
@@ -48,7 +48,7 @@ func (ip *InstrumentPhase) applyDeclRule(ctx context.Context, r *rule.InstDeclRu
 	}
 
 	spec := util.AssertType[*dst.ValueSpec](node)
-	expr, err := parseValueExpr(r.Value)
+	expr, err := parseValueExpr(r.Replace)
 	if err != nil {
 		return err
 	}

--- a/tool/internal/instrument/testdata/golden/call-rule-only/rules.yml
+++ b/tool/internal/instrument/testdata/golden/call-rule-only/rules.yml
@@ -1,4 +1,4 @@
 wrap_sizeof_call:
   target: main
   function_call: unsafe.Sizeof
-  template: "Wrapper({{ . }})"
+  replace: "Wrapper({{ . }})"

--- a/tool/internal/instrument/testdata/golden/call-rule-template-features/rules.yml
+++ b/tool/internal/instrument/testdata/golden/call-rule-template-features/rules.yml
@@ -1,4 +1,4 @@
 wrap_nested_call:
   target: main
   function_call: unsafe.Sizeof
-  template: "(func() uintptr { return {{ . }} })()"
+  replace: "(func() uintptr { return {{ . }} })()"

--- a/tool/internal/instrument/testdata/golden/call-rule-with-import/rules.yml
+++ b/tool/internal/instrument/testdata/golden/call-rule-with-import/rules.yml
@@ -1,6 +1,6 @@
 wrap_sizeof_with_strings:
   target: main
   function_call: unsafe.Sizeof
-  template: "(func() uintptr { fmt.Println(\"Wrapped!\"); return {{ . }} })()"
+  replace: "(func() uintptr { fmt.Println(\"Wrapped!\"); return {{ . }} })()"
   imports:
     fmt: "fmt"

--- a/tool/internal/instrument/testdata/golden/decl-rule-assign-const/rules.yml
+++ b/tool/internal/instrument/testdata/golden/decl-rule-assign-const/rules.yml
@@ -2,4 +2,4 @@ assign_max_retries:
   target: main
   kind: const
   identifier: MaxRetries
-  value: "99"
+  replace: "99"

--- a/tool/internal/instrument/testdata/golden/decl-rule-assign-value/rules.yml
+++ b/tool/internal/instrument/testdata/golden/decl-rule-assign-value/rules.yml
@@ -2,4 +2,4 @@ assign_global_var:
   target: main
   kind: var
   identifier: GlobalVar
-  value: '"replaced"'
+  replace: '"replaced"'

--- a/tool/internal/rule/call_rule.go
+++ b/tool/internal/rule/call_rule.go
@@ -28,7 +28,7 @@ import (
 //	wrap_http_get:
 //		target: "main"
 //		function_call: "net/http.Get"
-//		template: "tracedGet({{ . }})"
+//		replace: "tracedGet({{ . }})"
 //
 // This transforms: http.Get("url")
 // Into: tracedGet(http.Get("url"))
@@ -47,14 +47,14 @@ type InstCallRule struct {
 	// This field is populated during rule creation from FunctionCall.
 	FuncName string `json:"func-name" yaml:"-"`
 
-	// Template is the wrapper code with {{ . }} as placeholder for the original call.
-	// The template must be a valid Go expression.
+	// Replace is the wrapper code with {{ . }} as placeholder for the original call.
+	// The replacement must be a valid Go expression.
 	// Currently the output must be a call expression.
 	//
 	// Examples:
 	//   - "wrapper({{ . }})" wraps the call with wrapper()
 	//   - "(func() { return {{ . }} })()" uses an IIFE
-	Template string `json:"template" yaml:"template"`
+	Replace string `json:"replace" yaml:"replace"`
 
 	// AppendArgs is a list of Go expression strings appended as additional
 	// arguments to the matched call. See docs/rules.md for full semantics.
@@ -85,9 +85,9 @@ type InstCallRule struct {
 //   - "" (empty string)
 var funcNamePattern = regexp.MustCompile(`^(.+)\.([^\d\W]\w*)$`)
 
-// templatePlaceholderPattern matches template placeholder variants:
+// replacePlaceholderPattern matches replacement template placeholder variants:
 // {{ . }}, {{.}}, {{- . -}}, {{ .  }}, etc.
-var templatePlaceholderPattern = regexp.MustCompile(`\{\{-?\s*\.\s*-?\}\}`)
+var replacePlaceholderPattern = regexp.MustCompile(`\{\{-?\s*\.\s*-?\}\}`)
 
 // NewInstCallRule loads and validates an InstCallRule from YAML data.
 func NewInstCallRule(data []byte, name string) (*InstCallRule, error) {
@@ -114,10 +114,10 @@ func NewInstCallRule(data []byte, name string) (*InstCallRule, error) {
 		return nil, ex.Wrapf(err, "invalid call rule %q", name)
 	}
 
-	// Validate template syntax
-	if r.Template != "" {
-		if _, err := fasttemplate.NewTemplate(r.Template, "{{", "}}"); err != nil {
-			return nil, ex.Wrapf(err, "invalid template syntax for rule %q", name)
+	// Validate replacement template syntax
+	if r.Replace != "" {
+		if _, err := fasttemplate.NewTemplate(r.Replace, "{{", "}}"); err != nil {
+			return nil, ex.Wrapf(err, "invalid replace syntax for rule %q", name)
 		}
 	}
 
@@ -130,11 +130,11 @@ func (r *InstCallRule) validate() error {
 		return ex.Newf("function_call cannot be empty")
 	}
 
-	if strings.TrimSpace(r.Template) == "" && len(r.AppendArgs) == 0 {
-		return ex.Newf("at least one of template or append_args must be set")
+	if strings.TrimSpace(r.Replace) == "" && len(r.AppendArgs) == 0 {
+		return ex.Newf("at least one of replace or append_args must be set")
 	}
-	if strings.TrimSpace(r.Template) != "" && !templatePlaceholderPattern.MatchString(r.Template) {
-		return ex.Newf("template must contain {{ . }} placeholder (also accepts {{.}}, {{- . -}}, etc.)")
+	if strings.TrimSpace(r.Replace) != "" && !replacePlaceholderPattern.MatchString(r.Replace) {
+		return ex.Newf("replace must contain {{ . }} placeholder (also accepts {{.}}, {{- . -}}, etc.)")
 	}
 	for i, arg := range r.AppendArgs {
 		if strings.TrimSpace(arg) == "" {

--- a/tool/internal/rule/call_rule_test.go
+++ b/tool/internal/rule/call_rule_test.go
@@ -21,10 +21,10 @@ func TestNewInstCallRule(t *testing.T) {
 		check       func(*testing.T, *InstCallRule)
 	}{
 		{
-			name: "template only",
+			name: "replace only",
 			yaml: `
 function_call: net/http.Get
-template: "wrapper({{ . }})"
+replace: "wrapper({{ . }})"
 `,
 			ruleName: "wrap_http_get",
 			check: func(t *testing.T, r *InstCallRule) {
@@ -32,7 +32,7 @@ template: "wrapper({{ . }})"
 				assert.Equal(t, "net/http.Get", r.FunctionCall)
 				assert.Equal(t, "net/http", r.ImportPath)
 				assert.Equal(t, "Get", r.FuncName)
-				assert.Equal(t, "wrapper({{ . }})", r.Template)
+				assert.Equal(t, "wrapper({{ . }})", r.Replace)
 			},
 		},
 		{
@@ -46,7 +46,7 @@ append_args: ["ctx"]
 				assert.Equal(t, "net/http", r.ImportPath)
 				assert.Equal(t, "Get", r.FuncName)
 				assert.Equal(t, []string{"ctx"}, r.AppendArgs)
-				assert.Empty(t, r.Template)
+				assert.Empty(t, r.Replace)
 			},
 		},
 		{
@@ -63,15 +63,15 @@ variadic_type: "grpc.DialOption"
 			},
 		},
 		{
-			name: "both template and append_args",
+			name: "both replace and append_args",
 			yaml: `
 function_call: net/http.Get
-template: "wrapper({{ . }})"
+replace: "wrapper({{ . }})"
 append_args: ["ctx"]
 `,
 			ruleName: "combined",
 			check: func(t *testing.T, r *InstCallRule) {
-				assert.NotEmpty(t, r.Template)
+				assert.NotEmpty(t, r.Replace)
 				assert.NotEmpty(t, r.AppendArgs)
 			},
 		},
@@ -80,7 +80,7 @@ append_args: ["ctx"]
 			yaml: `
 name: yaml_name
 function_call: net/http.Get
-template: "wrapper({{ . }})"
+replace: "wrapper({{ . }})"
 `,
 			ruleName: "arg_name",
 			check: func(t *testing.T, r *InstCallRule) {
@@ -91,30 +91,30 @@ template: "wrapper({{ . }})"
 			name: "invalid function_call format",
 			yaml: `
 function_call: NoPackagePath
-template: "wrapper({{ . }})"
+replace: "wrapper({{ . }})"
 `,
 			ruleName:    "bad",
 			wantErr:     true,
 			errContains: "invalid function_call format",
 		},
 		{
-			name: "neither template nor append_args",
+			name: "neither replace nor append_args",
 			yaml: `
 function_call: net/http.Get
 `,
 			ruleName:    "bad",
 			wantErr:     true,
-			errContains: "at least one of template or append_args must be set",
+			errContains: "at least one of replace or append_args must be set",
 		},
 		{
-			name: "template without placeholder",
+			name: "replace without placeholder",
 			yaml: `
 function_call: net/http.Get
-template: "noPlaceholder()"
+replace: "noPlaceholder()"
 `,
 			ruleName:    "bad",
 			wantErr:     true,
-			errContains: "template must contain {{ . }} placeholder",
+			errContains: "replace must contain {{ . }} placeholder",
 		},
 		{
 			name: "empty append_args entry",
@@ -137,14 +137,14 @@ append_args: ["   "]
 			errContains: "append_args[0] must be a non-empty string",
 		},
 		{
-			name: "invalid template syntax",
+			name: "invalid replace syntax",
 			yaml: `
 function_call: net/http.Get
-template: "wrapper({{ . }}) {{ unclosed"
+replace: "wrapper({{ . }}) {{ unclosed"
 `,
 			ruleName:    "bad",
 			wantErr:     true,
-			errContains: "invalid template syntax",
+			errContains: "invalid replace syntax",
 		},
 		{
 			name:     "invalid yaml",
@@ -175,7 +175,7 @@ template: "wrapper({{ . }}) {{ unclosed"
 
 func TestInstCallRule_UnmarshalJSON(t *testing.T) {
 	t.Run("populates derived fields", func(t *testing.T) {
-		data := `{"function_call":"net/http.Get","template":"wrapper({{ . }})"}`
+		data := `{"function_call":"net/http.Get","replace":"wrapper({{ . }})"}`
 		var r InstCallRule
 		err := json.Unmarshal([]byte(data), &r)
 		require.NoError(t, err)

--- a/tool/internal/rule/decl_rule.go
+++ b/tool/internal/rule/decl_rule.go
@@ -19,7 +19,7 @@ import (
 //	  target: net/http
 //	  kind: var
 //	  identifier: DefaultTransport
-//	  value: |
+//	  replace: |
 //	    &http.Transport{MaxIdleConns: 100}
 type InstDeclRule struct {
 	InstBaseRule `yaml:",inline"`
@@ -31,9 +31,9 @@ type InstDeclRule struct {
 	// Identifier is the name of the top-level declaration to match.
 	Identifier string `json:"identifier" yaml:"identifier"`
 
-	// Value is a Go expression to assign as the value of the matched
+	// Replace is a Go expression to assign as the value of the matched
 	// var or const declaration.
-	Value string `json:"value" yaml:"value"`
+	Replace string `json:"replace" yaml:"replace"`
 }
 
 // NewInstDeclRule loads and validates an InstDeclRule from YAML data.
@@ -68,11 +68,11 @@ func (r *InstDeclRule) validate() error {
 	if !validDeclKinds[r.Kind] {
 		return ex.Newf("kind %q is invalid; must be one of: func, var, const, type, or empty", r.Kind)
 	}
-	if strings.TrimSpace(r.Value) == "" {
-		return ex.Newf("value cannot be empty")
+	if strings.TrimSpace(r.Replace) == "" {
+		return ex.Newf("replace cannot be empty")
 	}
 	if r.Kind == "func" || r.Kind == "type" {
-		return ex.Newf("value is not valid when kind is %q", r.Kind)
+		return ex.Newf("replace is not valid when kind is %q", r.Kind)
 	}
 	return nil
 }

--- a/tool/internal/rule/decl_rule_test.go
+++ b/tool/internal/rule/decl_rule_test.go
@@ -20,12 +20,12 @@ func TestNewInstDeclRule(t *testing.T) {
 		check       func(*testing.T, *InstDeclRule)
 	}{
 		{
-			name: "var rule with value",
+			name: "var rule with replace",
 			yaml: `
 target: example.com/pkg
 kind: var
 identifier: GlobalVar
-value: '"replaced"'
+replace: '"replaced"'
 `,
 			ruleName: "assign_global_var",
 			check: func(t *testing.T, r *InstDeclRule) {
@@ -33,22 +33,22 @@ value: '"replaced"'
 				assert.Equal(t, "example.com/pkg", r.Target)
 				assert.Equal(t, "var", r.Kind)
 				assert.Equal(t, "GlobalVar", r.Identifier)
-				assert.Equal(t, `"replaced"`, r.Value)
+				assert.Equal(t, `"replaced"`, r.Replace)
 			},
 		},
 		{
-			name: "const rule with value",
+			name: "const rule with replace",
 			yaml: `
 target: example.com/pkg
 kind: const
 identifier: MaxRetries
-value: "42"
+replace: "42"
 `,
 			ruleName: "patch_const",
 			check: func(t *testing.T, r *InstDeclRule) {
 				assert.Equal(t, "const", r.Kind)
 				assert.Equal(t, "MaxRetries", r.Identifier)
-				assert.Equal(t, "42", r.Value)
+				assert.Equal(t, "42", r.Replace)
 			},
 		},
 		{
@@ -57,7 +57,7 @@ value: "42"
 name: yaml_name
 target: example.com/pkg
 identifier: SomeDecl
-value: "42"
+replace: "42"
 `,
 			ruleName: "arg_name",
 			check: func(t *testing.T, r *InstDeclRule) {
@@ -69,7 +69,7 @@ value: "42"
 			yaml: `
 target: example.com/pkg
 identifier: SomeDecl
-value: "42"
+replace: "42"
 `,
 			ruleName: "arg_name",
 			check: func(t *testing.T, r *InstDeclRule) {
@@ -77,28 +77,28 @@ value: "42"
 			},
 		},
 		{
-			name: "empty value",
+			name: "empty replace",
 			yaml: `
 target: example.com/pkg
 identifier: SomeDecl
 `,
 			ruleName:    "bad_rule",
 			wantErr:     true,
-			errContains: "value cannot be empty",
+			errContains: "replace cannot be empty",
 		},
 		{
-			name: "whitespace-only value",
+			name: "whitespace-only replace",
 			yaml: `
 target: example.com/pkg
 identifier: SomeDecl
-value: "   "
+replace: "   "
 `,
 			ruleName:    "bad_rule",
 			wantErr:     true,
-			errContains: "value cannot be empty",
+			errContains: "replace cannot be empty",
 		},
 		{
-			name: "func kind without value",
+			name: "func kind without replace",
 			yaml: `
 target: example.com/pkg
 kind: func
@@ -106,10 +106,10 @@ identifier: MyFunc
 `,
 			ruleName:    "bad_rule",
 			wantErr:     true,
-			errContains: "value cannot be empty",
+			errContains: "replace cannot be empty",
 		},
 		{
-			name: "type kind without value",
+			name: "type kind without replace",
 			yaml: `
 target: example.com/pkg
 kind: type
@@ -117,7 +117,7 @@ identifier: MyType
 `,
 			ruleName:    "bad_rule",
 			wantErr:     true,
-			errContains: "value cannot be empty",
+			errContains: "replace cannot be empty",
 		},
 		{
 			name: "empty identifier",
@@ -151,28 +151,28 @@ identifier: MyDecl
 			errContains: "kind",
 		},
 		{
-			name: "value not allowed with kind func",
+			name: "replace not allowed with kind func",
 			yaml: `
 target: example.com/pkg
 kind: func
 identifier: MyFunc
-value: "someExpr()"
+replace: "someExpr()"
 `,
 			ruleName:    "bad_rule",
 			wantErr:     true,
-			errContains: "value is not valid when kind is",
+			errContains: "replace is not valid when kind is",
 		},
 		{
-			name: "value not allowed with kind type",
+			name: "replace not allowed with kind type",
 			yaml: `
 target: example.com/pkg
 kind: type
 identifier: MyType
-value: "int"
+replace: "int"
 `,
 			ruleName:    "bad_rule",
 			wantErr:     true,
-			errContains: "value is not valid when kind is",
+			errContains: "replace is not valid when kind is",
 		},
 		{
 			name:     "invalid yaml",

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -256,7 +256,7 @@ target: github.com/example/lib
 			yamlContent: `
 target: github.com/example/lib
 identifier: GlobalVar
-value: "replaced"
+replace: "replaced"
 `,
 			ruleName:     "test-decl-rule",
 			expectError:  false,


### PR DESCRIPTION
# Description
Rename `InstDeclRule.Value` and `InstCallRule.Template` fields to `Replace`
## Motivation

<!-- Why is this change needed? What problem does it solve? -->
It's more intuitive. Additionally, consistent naming conveys an intuitive aesthetic.

Fixes #447