### PR TITLE
chore: move contributors section to README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -343,31 +343,3 @@ Any [Maintainer] can merge the PR once the above criteria have been met.
 
 See [RELEASE.md](RELEASE.md) for the full release process, including release
 cadence, tagging conventions, cross-compilation targets, and hotfix guidance.
-
-## Approvers and Maintainers
-
-### Maintainers
-
-- [Huxing Zhang](https://github.com/ralf0131), Alibaba
-- [Kemal Akkoyun](https://github.com/kakkoyun), Datadog
-- [Liu Ziming](https://github.com/123liuziming), Alibaba
-- [Przemyslaw Delewski](https://github.com/pdelewski), Quesma
-- [Romain Marcadier](https://github.com/RomainMuller), Datadog
-
-For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
-
-### Approvers
-
-- [Dario Castañe](https://github.com/darccio), Datadog
-- [Eliott Bouhana](https://github.com/eliottness), Datadog
-- [Haibin Zhang](https://github.com/NameHaibinZhang), Alibaba
-- [Xabier Martinez](https://github.com/txabman42), Cabify
-- [Yi Yang](https://github.com/y1yang0), Alibaba
-
-For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
-
-### Emeritus maintainers
-
-- [Dinesh Gurumurthy](https://github.com/dineshg13)
-
-For more information about the emeritus role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager).

--- a/README.md
+++ b/README.md
@@ -82,3 +82,37 @@ We welcome contributions! See our [contributing guide](CONTRIBUTING.md) and [dev
 
 This project follows the [OpenTelemetry Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md).
 Please also review our [AI usage policy](AI_POLICY.md) if you use AI tools in your workflow.
+
+Here is a list of community roles with current and previous members:
+
+### Maintainers
+
+- [Huxing Zhang](https://github.com/ralf0131), Alibaba
+- [Kemal Akkoyun](https://github.com/kakkoyun), Datadog
+- [Liu Ziming](https://github.com/123liuziming), Alibaba
+- [Przemyslaw Delewski](https://github.com/pdelewski), Quesma
+- [Romain Marcadier](https://github.com/RomainMuller), Datadog
+
+For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
+
+### Approvers
+
+- [Dario Castañe](https://github.com/darccio), Datadog
+- [Eliott Bouhana](https://github.com/eliottness), Datadog
+- [Haibin Zhang](https://github.com/NameHaibinZhang), Alibaba
+- [Xabier Martinez](https://github.com/txabman42), Cabify
+- [Yi Yang](https://github.com/y1yang0), Alibaba
+
+For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
+
+### Emeritus
+
+- [Dinesh Gurumurthy](https://github.com/dineshg13)
+
+For more information about the emeritus role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager).
+
+### Thanks to all of our contributors!
+
+<a href="https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/graphs/contributors">
+  <img alt="Repo contributors" src="https://contrib.rocks/image?repo=open-telemetry/opentelemetry-go-compile-instrumentation" />
+</a>


### PR DESCRIPTION

## Description

Moves contributors section from CONTRIBUTING.md to README.md

## Motivation

To be in sync with other open-telemetry repos and making the existing tooling work.

ref #449 

---

## Checklist

- [ ] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [ ] Code formatted: `make format`
- [ ] Linters pass: `make lint`
- [ ] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
