### PR TITLE
chore: promote @darccio and @txabman42 to maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,18 @@ Here is a list of community roles with current and previous members:
 
 ### Maintainers
 
+- [Dario Castañe](https://github.com/darccio), Datadog
 - [Huxing Zhang](https://github.com/ralf0131), Alibaba
 - [Kemal Akkoyun](https://github.com/kakkoyun), Datadog
 - [Przemyslaw Delewski](https://github.com/pdelewski), Quesma
+- [Xabier Martinez](https://github.com/txabman42), Cabify
 - [Yi Yang](https://github.com/y1yang0), Alibaba
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 
 ### Approvers
 
-- [Dario Castañe](https://github.com/darccio), Datadog
 - [Haibin Zhang](https://github.com/NameHaibinZhang), Alibaba
-- [Xabier Martinez](https://github.com/txabman42), Cabify
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 


### PR DESCRIPTION
## Description

Promote @darccio and @txabman42 to maintainers

## Motivation

I would like to propose @darccio and @txabman42 to be promoted to maintainers. They showed persistent contributions and sense ownership of the tool and SIG. They helped use to shape the future of the tool, participated weekly discussions for some time now.

---

## Checklist

- [ ] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [ ] Code formatted: `make format`
- [ ] Linters pass: `make lint`
- [ ] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)

cc @jpkrohling @ralf0131 @y1yang0 @pdelewski 