### PR TITLE
fix(tool): validate OTELC_RULES and --rules rule paths for security

### DIFF
--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -324,7 +324,13 @@ func loadCustomRules(ruleConfig string) ([]rule.InstRule, error) {
 	for path := range ruleFiles {
 		path = strings.TrimSpace(path)
 
-		// Get all rule files from path (file or directory)
+		// Guardrail: keep rules inside working directory unless opt-in is set.
+		if err := util.ValidateRulesPath(path); err != nil {
+			return nil, err
+		}
+
+		// Get all rule files from path (file or directory).
+		// IsPathInside uses filepath.Abs internally which handles path normalization.
 		files, err := ruleFromDir(path)
 		if err != nil {
 			return nil, err
@@ -356,7 +362,20 @@ func (sp *SetupPhase) loadRules() ([]rule.InstRule, error) {
 	rulePath := os.Getenv(util.EnvOtelcRules)
 	if rulePath != "" {
 		sp.Debug("rules source: environment variable %s (%s)", util.EnvOtelcRules, rulePath)
-		content, err := os.ReadFile(filepath.Clean(rulePath))
+
+		// Guardrail: keep rules inside working directory unless opt-in is set.
+		if err := util.ValidateRulesPath(rulePath); err != nil {
+			return nil, err
+		}
+		// Warn if loading from external path (user has opted in).
+		wd := util.GetOtelcWorkDir()
+		if wd != "" && !util.IsPathInside(wd, rulePath) {
+			sp.Warn("loading rules from external path (opt-in)", "path", rulePath)
+		}
+
+		// Path is validated by ValidateRulesPath() call above; safe for use.
+		// #nosec G304
+		content, err := os.ReadFile(rulePath)
 		if err != nil {
 			return nil, ex.Wrapf(err, "failed to read %s from env variable", rulePath)
 		}

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -374,8 +374,7 @@ func (sp *SetupPhase) loadRules() ([]rule.InstRule, error) {
 		}
 
 		// Path is validated by ValidateRulesPath() call above; safe for use.
-		// #nosec G304
-		content, err := os.ReadFile(rulePath)
+		content, err := os.ReadFile(rulePath) //nolint:gosec // validated above
 		if err != nil {
 			return nil, ex.Wrapf(err, "failed to read %s from env variable", rulePath)
 		}

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -367,6 +367,7 @@ func TestRuleFilesFromDir(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Setenv(util.EnvOtelcRules, "")
+	t.Setenv(util.EnvOtelcAllowExternalRules, "1")
 
 	sp := newTestSetupPhase()
 	err = sp.extract()
@@ -393,6 +394,7 @@ func TestMultipleRuleFiles(t *testing.T) {
 	p2 := writeCustomRules(t, "r2.yaml", content2)
 
 	t.Setenv(util.EnvOtelcRules, "")
+	t.Setenv(util.EnvOtelcAllowExternalRules, "1")
 
 	sp := newTestSetupPhase()
 	err := sp.extract()
@@ -435,6 +437,7 @@ func TestLoadDefaultRules(t *testing.T) {
   raw: "_ = 1"`
 	p1 := writeCustomRules(t, "r1.yaml", content1)
 	p2 := writeCustomRules(t, "r2.yaml", content2)
+	t.Setenv(util.EnvOtelcAllowExternalRules, "1")
 	t.Setenv(util.EnvOtelcRules, p1)
 
 	// Prepare setup phase and set custom rules via environment variable and flag
@@ -531,6 +534,39 @@ target: example.com/mypkg
 	// The package name must be set from parsing the source file
 	assert.Equal(t, "mypkg", set.PackageName)
 	assert.False(t, set.IsEmpty(), "rule set must contain the file rule")
+}
+
+func TestLoadRulesEnvValidation(t *testing.T) {
+	// Create a workspace dir and an external dir to simulate outside path
+	workdir := t.TempDir()
+	external := t.TempDir()
+
+	// Point otelc work dir to our workspace
+	t.Setenv(util.EnvOtelcWorkDir, workdir)
+
+	// Write a rule file in the external directory
+	content := "h1:\n  target: main\n  func: Example\n  raw: \"_ = 1\"\n"
+	extPath := filepath.Join(external, "r_ext.yaml")
+	err := os.WriteFile(extPath, []byte(content), 0o644)
+	require.NoError(t, err)
+
+	// Set OTELC_RULES to point to the external file
+	t.Setenv(util.EnvOtelcRules, extPath)
+
+	sp := newTestSetupPhase()
+	// extract is required by other tests before loadRules
+	err = sp.extract()
+	require.NoError(t, err)
+
+	// Without opt-in, loading external rules must fail
+	_, err = sp.loadRules()
+	require.Error(t, err)
+
+	// With opt-in env var, loading should succeed
+	t.Setenv(util.EnvOtelcAllowExternalRules, "1")
+	rules, err := sp.loadRules()
+	require.NoError(t, err)
+	require.NotEmpty(t, rules)
 }
 
 func TestRunMatch_EmptyRules(t *testing.T) {

--- a/tool/util/shared.go
+++ b/tool/util/shared.go
@@ -8,14 +8,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 )
 
 const (
-	EnvOtelcWorkDir    = "OTELC_WORK_DIR"
-	EnvOtelcRules      = "OTELC_RULES"
-	EnvOtelcBuildFlags = "OTELC_BUILD_FLAGS"
+	EnvOtelcWorkDir = "OTELC_WORK_DIR"
+	EnvOtelcRules   = "OTELC_RULES"
+	// EnvOtelcAllowExternalRules when set to "1" allows OTELC_RULES and --rules
+	// to point to files outside the working directory. This is a guardrail for
+	// accidental misconfiguration, not a hard security boundary.
+	EnvOtelcAllowExternalRules = "OTELC_ALLOW_EXTERNAL_RULES"
+	EnvOtelcBuildFlags         = "OTELC_BUILD_FLAGS"
 	// EnvOtelcStats enables per-toolexec timing stats when set to "1".
 	// Set automatically when --stats is used; propagated to child processes.
 	EnvOtelcStats = "OTELC_STATS"
@@ -58,6 +63,49 @@ func GetBuildTempDir() string {
 // GetBuildTemp returns the path to the build temp directory $BUILD_TEMP/name
 func GetBuildTemp(name string) string {
 	return filepath.Join(GetOtelcWorkDir(), BuildTempDir, name)
+}
+
+// IsPathInside returns true when the candidate path is inside the base
+// directory. Both paths are made absolute and cleaned before comparison.
+func IsPathInside(base, candidate string) bool {
+	if base == "" || candidate == "" {
+		return false
+	}
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		return false
+	}
+	absCand, err := filepath.Abs(candidate)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absBase, absCand)
+	if err != nil {
+		return false
+	}
+	// When rel starts with ".." it is outside, otherwise inside (or same).
+	return !strings.HasPrefix(rel, "..")
+}
+
+// ValidateRulesPath checks whether a rules path stays within the working directory
+// unless explicitly opted in. This helps avoid accidental/confused-deputy loading
+// of unintended files in normal developer/CI flows.
+func ValidateRulesPath(path string) error {
+	if path == "" {
+		return nil
+	}
+	wd := GetOtelcWorkDir()
+	if wd == "" {
+		return ex.New("OTELC_WORK_DIR is not set and cannot determine current directory")
+	}
+	// IsPathInside handles absolute path conversion; no need to Clean here.
+	if !IsPathInside(wd, path) {
+		if os.Getenv(EnvOtelcAllowExternalRules) != "1" {
+			return ex.Newf("refusing to load rules from %s; set %s=1 to opt-in",
+				path, EnvOtelcAllowExternalRules)
+		}
+	}
+	return nil
 }
 
 func copyBackupFiles(names []string, src, dst string) error {


### PR DESCRIPTION
## Description

I added path validation before loading rule files so rules must live inside the working directory unless explicitly opted in via `OTELC_ALLOW_EXTERNAL_RULES=1`.

- Added `IsPathInside()` in `util/shared.go`, uses `filepath.Rel` to check containment after resolving absolute paths
- Added `ValidateRulesPath()` as a single shared helper so both the env var path (`loadRules`) and the config file path (`loadCustomRules`) go through the same check, no duplication
- `ValidateRulesPath` returns an explicit error if `OTELC_WORK_DIR` is unset, instead of silently returning false
- Added `#nosec G304` on the `os.ReadFile(rulePath)` call since the path is validated immediately above it
- Updated existing tests that write rules to temp dirs to set `OTELC_ALLOW_EXTERNAL_RULES=1` so they don't break under the new validation
- Fixed test indentation in `TestLoadRulesEnvValidation` and fixed `gofumpt` alignment in the const block

 **Assisted-by: GitHub Copilot** 

## Motivation

Without this, `OTELC_RULES` and `--rules` accept any path on the filesystem, so a misconfigured or tampered env var could silently load rules from anywhere. Defaulting to the working directory with an explicit opt-in should be the right call.

---

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [x] Documentation updated (if applicable)