### PR TITLE
fix(testutil): improve RequireSpan failure diagnostics

### DIFF
--- a/test/testutil/spans.go
+++ b/test/testutil/spans.go
@@ -65,7 +65,8 @@ func HasAttributeContaining(key, substr string) SpanMatcher {
 
 // RequireSpan finds a span matching all matchers or fails.
 func RequireSpan(t *testing.T, td ptrace.Traces, matchers ...SpanMatcher) ptrace.Span {
-	for _, s := range AllSpans(td) {
+	allSpans := AllSpans(td)
+	for _, s := range allSpans {
 		match := true
 		for _, m := range matchers {
 			if !m(s) {
@@ -77,7 +78,20 @@ func RequireSpan(t *testing.T, td ptrace.Traces, matchers ...SpanMatcher) ptrace
 			return s
 		}
 	}
-	require.Fail(t, "No span found matching criteria")
+
+	var sb strings.Builder
+	sb.WriteString("No span found matching criteria\n")
+	if len(allSpans) == 0 {
+		sb.WriteString("Collected 0 spans")
+	} else {
+		fmt.Fprintf(&sb, "Collected %d span(s):\n", len(allSpans))
+		for _, s := range allSpans {
+			fmt.Fprintf(&sb, "  - Name: %s, Kind: %v, Attrs: %v\n",
+				s.Name(), s.Kind(), Attrs(s))
+		}
+	}
+
+	require.Fail(t, sb.String())
 	return ptrace.NewSpan()
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to OpenTelemetry Go Compile Instrumentation!

INSTRUCTIONS:
1. Fill in the description and motivation sections below
2. Complete the checklist before submitting
3. Ensure PR title follows conventional commits format (enforced by CI)

PR TITLE FORMAT (required):
  type(scope): description

  Types: feat, fix, docs, chore, refactor, test, release
  Scopes: tool, pkg, demo, test, docs

  Examples:
  - feat(pkg): add gRPC client instrumentation
  - fix(tool): resolve hook signature matching issue
  - docs(api): update instrumenter interface documentation
  - refactor(pkg): simplify attribute extractor composition

BEFORE SUBMITTING:
  make format  # Format Go code and YAML files
  make lint    # Run all linters
  make test    # Run all tests (unit + integration + e2e)

For detailed contribution guidelines, see CONTRIBUTING.md
For available make targets, run: make help
-->

## Description

Improve `RequireSpan` failure output by listing collected spans when no matcher succeeds.

This makes integration and E2E test failures easier to debug without changing the existing matching behavior.

## Motivation

`RequireSpan` currently fails with a generic `No span found matching criteria` message, which makes debugging failing integration tests difficult.

This change adds lightweight contextual information to the failure output so contributors can quickly inspect which spans were actually collected during the test run.

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
