### PR TITLE
fix(instrument): correct applyCallAppendArgs match accounting

### DIFF
--- a/tool/internal/instrument/apply_call.go
+++ b/tool/internal/instrument/apply_call.go
@@ -120,7 +120,7 @@ func (ip *InstrumentPhase) applyCallAppendArgs(
 		}
 	}
 
-	return true
+	return len(matchingCalls) > 0
 }
 
 // appendCallArgs appends the expressions from r.AppendArgs to the call's argument list.

--- a/tool/internal/instrument/apply_call_test.go
+++ b/tool/internal/instrument/apply_call_test.go
@@ -445,3 +445,29 @@ func TestMatchesCallRule_ImportAliasFromGopkgIn(t *testing.T) {
 
 	assert.True(t, matches)
 }
+
+func TestApplyCallAppendArgs_NoMatchReturnsFalse(t *testing.T) {
+	// A file with no matching calls should cause applyCallAppendArgs to
+	// return false so the assertion in applyCallRule can detect unmatched rules.
+	file := makeCallFile(&dst.CallExpr{
+		Fun: &dst.SelectorExpr{
+			X:   &dst.Ident{Name: "fmt", Path: "fmt"},
+			Sel: &dst.Ident{Name: "Println"},
+		},
+		Args: []dst.Expr{&dst.BasicLit{Kind: token.STRING, Value: `"hello"`}},
+	})
+
+	r := &rule.InstCallRule{
+		InstBaseRule: rule.InstBaseRule{Name: "no_match"},
+		FunctionCall: "net/http.Get",
+		ImportPath:   "net/http",
+		FuncName:     "Get",
+		AppendArgs:   []string{"ctx"},
+	}
+
+	ip := newTestPhase()
+	importAliases := collectImportAliases(file)
+	result := ip.applyCallAppendArgs(r, file, importAliases)
+
+	assert.False(t, result, "applyCallAppendArgs must return false when no calls match")
+}


### PR DESCRIPTION
## Description

`applyCallAppendArgs` returns `true` when `AppendArgs` is set, regardless of whether any calls actually matched. This means the `util.Assert` in `applyCallRule` never fires for append-only rules that match nothing.

Changed `return true` to `return len(matchingCalls) > 0`. Added a test that verifies the function returns false when AppendArgs is set but no calls match in the AST.

## Motivation

`applyCallReplace` already handles this correctly — it returns `false` when `len(replacements) == 0`. This just makes `applyCallAppendArgs` consistent.

Fixes #485 

---

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [ ] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)