### PR TITLE
fix(testutil): replace fixed sleep with polling for span flushing

### DIFF
--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -21,7 +21,7 @@ func TestGrpc(t *testing.T) {
 
 	f.BuildAndRun("grpcclient", "-addr", "127.0.0.1:50051", "-name", "OpenTelemetry")
 	f.Run("grpcclient", "-addr", "127.0.0.1:50051", "-stream")
-	testutil.WaitForSpanFlush(t)
+	f.WaitForSpanFlush()
 
 	f.RequireTraceCount(2)    // unary + stream
 	f.RequireSpansPerTrace(2) // client + server per trace

--- a/test/integration/grpc_server_test.go
+++ b/test/integration/grpc_server_test.go
@@ -47,7 +47,7 @@ func TestGRPCServer(t *testing.T) {
 
 			client := NewGRPCClient(t, "localhost:50051")
 			tc.exercise(t, client)
-			testutil.WaitForSpanFlush(t)
+			f.WaitForSpanFlush()
 
 			span := f.RequireSingleSpan()
 			testutil.RequireGRPCServerSemconv(t, span, "greeter.Greeter", tc.method, 0)

--- a/test/integration/grpc_shutdown_test.go
+++ b/test/integration/grpc_shutdown_test.go
@@ -40,7 +40,7 @@ func TestGRPCServerTelemetryFlushOnSignal(t *testing.T) {
 
 	require.NoError(t, cmd.Process.Signal(os.Interrupt))
 	waitForProcessExit(t, cmd, 10*time.Second)
-	testutil.WaitForSpanFlush(t)
+	f.WaitForSpanFlush()
 
 	spans := testutil.AllSpans(f.Traces())
 	require.NotEmpty(t, spans, "expected spans to be flushed on SIGINT shutdown")

--- a/test/integration/http_server_test.go
+++ b/test/integration/http_server_test.go
@@ -44,7 +44,7 @@ func TestHTTPServer(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 			require.Equal(t, http.StatusOK, resp.StatusCode)
-			testutil.WaitForSpanFlush(t)
+			f.WaitForSpanFlush()
 
 			span := f.RequireSingleSpan()
 			testutil.RequireHTTPServerSemconv(

--- a/test/testutil/fixture.go
+++ b/test/testutil/fixture.go
@@ -77,6 +77,12 @@ func (f *TestFixture) Traces() ptrace.Traces {
 	return f.collector.GetTraces()
 }
 
+// WaitForSpanFlush waits for at least one span to be flushed to collector.
+func (f *TestFixture) WaitForSpanFlush() {
+	f.t.Helper()
+	WaitForSpanFlush(f.t, f.collector)
+}
+
 // CollectorURL returns the collector endpoint URL.
 func (f *TestFixture) CollectorURL() string {
 	return f.collector.URL
@@ -128,15 +134,28 @@ func (f *TestFixture) BuildAndRun(appName string, args ...string) string {
 
 // RequireTraceCount asserts the expected number of traces were collected.
 func (f *TestFixture) RequireTraceCount(expected int) {
-	stats := AnalyzeTraces(f.t, f.collector.GetTraces())
+	f.t.Helper()
+	require.Eventuallyf(f.t, func() bool {
+		stats := AnalyzeTraces(f.collector.GetTraces())
+		return stats.TraceCount == expected
+	}, defaultReadinessTimeout, defaultReadinessInterval, "Wait for %d traces", expected)
+
+	stats := AnalyzeTraces(f.collector.GetTraces())
+	if stats.TraceCount != expected {
+		LogTraces(f.t, f.collector.GetTraces())
+	}
 	require.Equal(f.t, expected, stats.TraceCount,
 		"Expected %d traces, got %d. %s", expected, stats.TraceCount, stats.String())
 }
 
 // RequireSpansPerTrace asserts each trace has the expected number of spans.
 func (f *TestFixture) RequireSpansPerTrace(expected int) {
-	stats := AnalyzeTraces(f.t, f.collector.GetTraces())
+	f.t.Helper()
+	stats := AnalyzeTraces(f.collector.GetTraces())
 	for traceID, count := range stats.SpansPerTrace {
+		if count != expected {
+			LogTraces(f.t, f.collector.GetTraces())
+		}
 		require.Equal(f.t, expected, count,
 			"Trace %s should have %d spans, got %d", traceID[:16], expected, count)
 	}

--- a/test/testutil/readiness.go
+++ b/test/testutil/readiness.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -17,21 +19,20 @@ const (
 // WaitForTCP waits until a TCP connection can be established.
 func WaitForTCP(t *testing.T, addr string) {
 	t.Helper()
-	deadline := time.Now().Add(defaultReadinessTimeout)
-
-	for time.Now().Before(deadline) {
+	require.Eventuallyf(t, func() bool {
 		conn, err := net.DialTimeout("tcp", addr, defaultReadinessInterval)
 		if err == nil {
 			conn.Close()
-			return
+			return true
 		}
-		time.Sleep(defaultReadinessInterval)
-	}
-	t.Fatalf("timeout waiting for TCP readiness at %s", addr)
+		return false
+	}, defaultReadinessTimeout, defaultReadinessInterval, "timeout waiting for TCP readiness at %s", addr)
 }
 
 // WaitForSpanFlush waits for spans to be flushed to collector.
-func WaitForSpanFlush(t *testing.T) {
+func WaitForSpanFlush(t *testing.T, c *Collector) {
 	t.Helper()
-	time.Sleep(200 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return c != nil && len(AllSpans(c.GetTraces())) > 0
+	}, defaultReadinessTimeout, defaultReadinessInterval, "timeout waiting for spans to be flushed")
 }

--- a/test/testutil/spans.go
+++ b/test/testutil/spans.go
@@ -102,16 +102,23 @@ type TraceStats struct {
 }
 
 // AnalyzeTraces collects trace statistics.
-func AnalyzeTraces(t *testing.T, td ptrace.Traces) TraceStats {
+func AnalyzeTraces(td ptrace.Traces) TraceStats {
 	stats := TraceStats{SpansPerTrace: make(map[string]int)}
 	for _, s := range AllSpans(td) {
-		t.Logf("Span: name=%s, kind=%v, attrs=%v", s.Name(), s.Kind(), Attrs(s))
 		tid := s.TraceID()
 		stats.SpansPerTrace[hex.EncodeToString(tid[:])]++
 		stats.TotalSpans++
 	}
 	stats.TraceCount = len(stats.SpansPerTrace)
 	return stats
+}
+
+// LogTraces logs all collected spans.
+func LogTraces(t *testing.T, td ptrace.Traces) {
+	t.Helper()
+	for _, s := range AllSpans(td) {
+		t.Logf("Span: name=%s, kind=%v, attrs=%v", s.Name(), s.Kind(), Attrs(s))
+	}
 }
 
 // String returns a human-readable representation of trace statistics.


### PR DESCRIPTION
## Description

Replace fixed `time.Sleep` usage in span flushing helpers with polling-based readiness checks using `require.Eventually`.

Also improves trace logging so spans are only logged on assertion failures instead of every successful run.

## Motivation

Fixed sleep-based synchronization can introduce flaky behavior in integration/E2E tests depending on system and CI timing.

This change makes span flushing checks more reliable while also reducing noisy test logs during successful runs.

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
