### PR TITLE
fix(testutil): use polling for TCP readiness checks

### DIFF
--- a/test/testutil/readiness.go
+++ b/test/testutil/readiness.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -17,17 +19,14 @@ const (
 // WaitForTCP waits until a TCP connection can be established.
 func WaitForTCP(t *testing.T, addr string) {
 	t.Helper()
-	deadline := time.Now().Add(defaultReadinessTimeout)
-
-	for time.Now().Before(deadline) {
+	require.Eventuallyf(t, func() bool {
 		conn, err := net.DialTimeout("tcp", addr, defaultReadinessInterval)
 		if err == nil {
 			conn.Close()
-			return
+			return true
 		}
-		time.Sleep(defaultReadinessInterval)
-	}
-	t.Fatalf("timeout waiting for TCP readiness at %s", addr)
+		return false
+	}, defaultReadinessTimeout, defaultReadinessInterval, "timeout waiting for TCP readiness at %s", addr)
 }
 
 // WaitForSpanFlush waits for spans to be flushed to collector.


### PR DESCRIPTION
## Description

Replace the manual timeout loop in `WaitForTCP` with `require.Eventuallyf` for polling-based TCP readiness checks.

## Motivation

This simplifies the readiness logic and keeps the polling behavior consistent with other test synchronization helpers.

Follow-up extracted from #488.

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
