### PR TITLE
chore: promote @NameHaibinZhang to the maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,19 +89,14 @@ Here is a list of community roles with current and previous members:
 ### Maintainers
 
 - [Dario Castañe](https://github.com/darccio), Datadog
+- [Haibin Zhang](https://github.com/NameHaibinZhang), Alibaba
 - [Huxing Zhang](https://github.com/ralf0131), Alibaba
 - [Kemal Akkoyun](https://github.com/kakkoyun), Datadog
 - [Przemyslaw Delewski](https://github.com/pdelewski), Quesma
 - [Xabier Martinez](https://github.com/txabman42), Cabify
 - [Yi Yang](https://github.com/y1yang0), Alibaba
 
-For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
-
 ### Approvers
-
-- [Haibin Zhang](https://github.com/NameHaibinZhang), Alibaba
-
-For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 
 ### Emeritus
 
@@ -110,10 +105,7 @@ For more information about the approver role, see the [community repository](htt
 - [Liu Ziming](https://github.com/123liuziming), Maintainer
 - [Romain Marcadier](https://github.com/RomainMuller), Maintainer
 
-For more information about the emeritus role, see the
-[community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager).
-
-For more information about the emeritus role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager).
+For more information about these roles, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md).
 
 ### Thanks to all of our contributors!
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ Here is a list of community roles with current and previous members:
 - [Xabier Martinez](https://github.com/txabman42), Cabify
 - [Yi Yang](https://github.com/y1yang0), Alibaba
 
+For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
+
 ### Approvers
+
+For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 
 ### Emeritus
 
@@ -105,7 +109,8 @@ Here is a list of community roles with current and previous members:
 - [Liu Ziming](https://github.com/123liuziming), Maintainer
 - [Romain Marcadier](https://github.com/RomainMuller), Maintainer
 
-For more information about these roles, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md).
+For more information about the emeritus role, see the
+[community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager).
 
 ### Thanks to all of our contributors!
 


### PR DESCRIPTION
I'd like to formally nominate [@Haibin Zhang](https://cloud-native.slack.com/team/U083LAJ16PQ) as a maintainer for opentelemetry-go-compile-instrumentation.

He is a core developer of our go-compile auto-instrumentation and has been making steady contributions: [CommitList](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/commits?author=NameHaibinZhang).

He’s a regular attendee at our weekly meetings (though he tends to listen more due to the language barrier). As part of the team led by [@Huxing Zhang](https://cloud-native.slack.com/team/U057HUSENSG), he and I have been working closely to build cloud-based Golang observability.

Looking ahead, he is committed to contributing to the auto-instrumentation plugins long-term and will bring a lot of valuable insights to improve the tool module.

Would love to hear your thoughts on adding him to the maintainers list!