### PR TITLE
fix(setup): warn when instrumentation hooks bump consumer versions

### DIFF
--- a/tool/internal/setup/sync.go
+++ b/tool/internal/setup/sync.go
@@ -5,6 +5,8 @@ package setup
 
 import (
 	"context"
+	"fmt"
+	goversion "go/version"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,14 +73,13 @@ func addReplace(modfile *modfile.File, replace *replaceDirective) (bool, error) 
 	return false, nil
 }
 
+// versionSnapshot records go directive and direct dep versions before tidy.
 type versionSnapshot struct {
 	goVersion string
-	deps      map[string]string // direct deps only
+	deps      map[string]string
 }
 
-// snapshotVersions records the go directive and direct dep versions
-// so we can detect what go mod tidy bumped.
-func snapshotVersions(mf *modfile.File) versionSnapshot {
+func snapshotVersion(mf *modfile.File) versionSnapshot {
 	snap := versionSnapshot{
 		deps: make(map[string]string),
 	}
@@ -93,42 +94,25 @@ func snapshotVersions(mf *modfile.File) versionSnapshot {
 	return snap
 }
 
-// warnVersionBumps diffs the go.mod after tidy against the pre-mutation
-// snapshot and logs any version that MVS raised.
-func (sp *SetupPhase) warnVersionBumps(goModPath string, before versionSnapshot, hookModules []string) {
+func (sp *SetupPhase) warnVersion(goModPath string, before versionSnapshot) {
 	after, err := parseGoMod(goModPath)
 	if err != nil {
-		sp.Warn("unable to check for version bumps after go mod tidy", "error", err)
+		sp.Error("unable to check for version bumps after go mod tidy", "error", err)
 		return
 	}
 
-	hooks := strings.Join(hookModules, ", ")
-
-	// go directives are bare ("1.25.0"), semver wants "v" prefix
+	// Go directives use Go toolchain syntax ("1.21"), not module semver.
 	if after.Go != nil && before.goVersion != "" {
-		oldGo := "v" + before.goVersion
-		newGo := "v" + after.Go.Version
-		if semver.IsValid(oldGo) && semver.IsValid(newGo) && semver.Compare(newGo, oldGo) > 0 {
-			sp.Warn("go directive bumped by instrumentation hooks",
-				"from", before.goVersion, "to", after.Go.Version,
-				"hooks", hooks)
+		if goversion.Compare("go"+after.Go.Version, "go"+before.goVersion) > 0 {
+			sp.Warn(fmt.Sprintf("Bumped go version (%s -> %s)", before.goVersion, after.Go.Version))
 		}
 	}
 
 	for _, req := range after.Require {
-		if req.Indirect {
-			continue
-		}
-		oldVer, tracked := before.deps[req.Mod.Path]
-		if !tracked {
-			continue
-		}
-		if semver.IsValid(oldVer) && semver.IsValid(req.Mod.Version) &&
-			semver.Compare(req.Mod.Version, oldVer) > 0 {
-			sp.Warn("dependency version bumped by instrumentation hooks",
-				"module", req.Mod.Path,
-				"from", oldVer, "to", req.Mod.Version,
-				"hooks", hooks)
+		if oldVer, tracked := before.deps[req.Mod.Path]; tracked && !req.Indirect {
+			if semver.Compare(req.Mod.Version, oldVer) > 0 {
+				sp.Warn(fmt.Sprintf("Bumped dependency %s (%s -> %s)", req.Mod.Path, oldVer, req.Mod.Version))
+			}
 		}
 	}
 }
@@ -153,10 +137,8 @@ func (sp *SetupPhase) syncDeps(ctx context.Context, matched []*rule.InstRuleSet,
 		return err
 	}
 
-	// Record pre-mutation versions to detect bumps after tidy.
-	before := snapshotVersions(modfile)
+	before := snapshotVersion(modfile)
 	replaces := make([]*replaceDirective, 0)
-	hookModules := make([]string, 0, len(rules))
 	for _, m := range rules {
 		util.Assert(strings.HasPrefix(m.Path, util.OtelcRoot), "sanity check")
 		oldPath := m.Path
@@ -168,7 +150,6 @@ func (sp *SetupPhase) syncDeps(ctx context.Context, matched []*rule.InstRuleSet,
 			newPath:    newPath,
 			newVersion: "",
 		})
-		hookModules = append(hookModules, oldPath)
 	}
 
 	// Add replace directive for special pkg module
@@ -216,7 +197,8 @@ func (sp *SetupPhase) syncDeps(ctx context.Context, matched []*rule.InstRuleSet,
 		if err != nil {
 			return ex.Wrapf(err, "running go mod tidy in %s", moduleDir)
 		}
-		sp.warnVersionBumps(goModFile, before, hookModules)
+		// Compare after tidy because MVS may raise existing consumer versions.
+		sp.warnVersion(goModFile, before)
 		sp.keepForDebug(goModFile)
 	}
 	return nil

--- a/tool/internal/setup/sync.go
+++ b/tool/internal/setup/sync.go
@@ -94,11 +94,10 @@ func snapshotVersion(mf *modfile.File) versionSnapshot {
 	return snap
 }
 
-func (sp *SetupPhase) warnVersion(goModPath string, before versionSnapshot) {
+func (sp *SetupPhase) warnVersion(goModPath string, before versionSnapshot) error {
 	after, err := parseGoMod(goModPath)
 	if err != nil {
-		sp.Error("unable to check for version bumps after go mod tidy", "error", err)
-		return
+		return ex.Wrapf(err, "unable to check for version bumps after go mod tidy")
 	}
 
 	// Go directives use Go toolchain syntax ("1.21"), not module semver.
@@ -109,12 +108,13 @@ func (sp *SetupPhase) warnVersion(goModPath string, before versionSnapshot) {
 	}
 
 	for _, req := range after.Require {
-		if oldVer, tracked := before.deps[req.Mod.Path]; tracked && !req.Indirect {
+		if oldVer, tracked := before.deps[req.Mod.Path]; tracked {
 			if semver.Compare(req.Mod.Version, oldVer) > 0 {
 				sp.Warn(fmt.Sprintf("Bumped dependency %s (%s -> %s)", req.Mod.Path, oldVer, req.Mod.Version))
 			}
 		}
 	}
+	return nil
 }
 
 func (sp *SetupPhase) syncDeps(ctx context.Context, matched []*rule.InstRuleSet, moduleDir string) error {
@@ -198,7 +198,10 @@ func (sp *SetupPhase) syncDeps(ctx context.Context, matched []*rule.InstRuleSet,
 			return ex.Wrapf(err, "running go mod tidy in %s", moduleDir)
 		}
 		// Compare after tidy because MVS may raise existing consumer versions.
-		sp.warnVersion(goModFile, before)
+		err = sp.warnVersion(goModFile, before)
+		if err != nil {
+			return err
+		}
 		sp.keepForDebug(goModFile)
 	}
 	return nil

--- a/tool/internal/setup/sync.go
+++ b/tool/internal/setup/sync.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/semver"
 
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
@@ -70,6 +71,68 @@ func addReplace(modfile *modfile.File, replace *replaceDirective) (bool, error) 
 	return false, nil
 }
 
+type versionSnapshot struct {
+	goVersion string
+	deps      map[string]string // direct deps only
+}
+
+// snapshotVersions records the go directive and direct dep versions
+// so we can detect what go mod tidy bumped.
+func snapshotVersions(mf *modfile.File) versionSnapshot {
+	snap := versionSnapshot{
+		deps: make(map[string]string),
+	}
+	if mf.Go != nil {
+		snap.goVersion = mf.Go.Version
+	}
+	for _, req := range mf.Require {
+		if !req.Indirect {
+			snap.deps[req.Mod.Path] = req.Mod.Version
+		}
+	}
+	return snap
+}
+
+// warnVersionBumps diffs the go.mod after tidy against the pre-mutation
+// snapshot and logs any version that MVS raised.
+func (sp *SetupPhase) warnVersionBumps(goModPath string, before versionSnapshot, hookModules []string) {
+	after, err := parseGoMod(goModPath)
+	if err != nil {
+		sp.Warn("unable to check for version bumps after go mod tidy", "error", err)
+		return
+	}
+
+	hooks := strings.Join(hookModules, ", ")
+
+	// go directives are bare ("1.25.0"), semver wants "v" prefix
+	if after.Go != nil && before.goVersion != "" {
+		oldGo := "v" + before.goVersion
+		newGo := "v" + after.Go.Version
+		if semver.IsValid(oldGo) && semver.IsValid(newGo) && semver.Compare(newGo, oldGo) > 0 {
+			sp.Warn("go directive bumped by instrumentation hooks",
+				"from", before.goVersion, "to", after.Go.Version,
+				"hooks", hooks)
+		}
+	}
+
+	for _, req := range after.Require {
+		if req.Indirect {
+			continue
+		}
+		oldVer, tracked := before.deps[req.Mod.Path]
+		if !tracked {
+			continue
+		}
+		if semver.IsValid(oldVer) && semver.IsValid(req.Mod.Version) &&
+			semver.Compare(req.Mod.Version, oldVer) > 0 {
+			sp.Warn("dependency version bumped by instrumentation hooks",
+				"module", req.Mod.Path,
+				"from", oldVer, "to", req.Mod.Version,
+				"hooks", hooks)
+		}
+	}
+}
+
 func (sp *SetupPhase) syncDeps(ctx context.Context, matched []*rule.InstRuleSet, moduleDir string) error {
 	rules := make([]*rule.InstFuncRule, 0, len(matched))
 	for _, m := range matched {
@@ -89,7 +152,11 @@ func (sp *SetupPhase) syncDeps(ctx context.Context, matched []*rule.InstRuleSet,
 	if err != nil {
 		return err
 	}
+
+	// Record pre-mutation versions to detect bumps after tidy.
+	before := snapshotVersions(modfile)
 	replaces := make([]*replaceDirective, 0)
+	hookModules := make([]string, 0, len(rules))
 	for _, m := range rules {
 		util.Assert(strings.HasPrefix(m.Path, util.OtelcRoot), "sanity check")
 		oldPath := m.Path
@@ -101,6 +168,7 @@ func (sp *SetupPhase) syncDeps(ctx context.Context, matched []*rule.InstRuleSet,
 			newPath:    newPath,
 			newVersion: "",
 		})
+		hookModules = append(hookModules, oldPath)
 	}
 
 	// Add replace directive for special pkg module
@@ -148,6 +216,7 @@ func (sp *SetupPhase) syncDeps(ctx context.Context, matched []*rule.InstRuleSet,
 		if err != nil {
 			return ex.Wrapf(err, "running go mod tidy in %s", moduleDir)
 		}
+		sp.warnVersionBumps(goModFile, before, hookModules)
 		sp.keepForDebug(goModFile)
 	}
 	return nil

--- a/tool/internal/setup/sync_test.go
+++ b/tool/internal/setup/sync_test.go
@@ -4,6 +4,7 @@
 package setup
 
 import (
+	"bytes"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -224,4 +225,174 @@ go 1.21
 
 	// At minimum, the pkg replace should be added
 	assert.Contains(t, string(content), "replace")
+}
+
+func logCapture() (*SetupPhase, *bytes.Buffer) {
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	return &SetupPhase{logger: slog.New(handler)}, &buf
+}
+
+func TestSnapshotVersions(t *testing.T) {
+	content := `module example.com/app
+
+go 1.22.0
+
+require (
+	go.opentelemetry.io/otel v1.38.0
+	github.com/example/lib v0.9.0
+)
+
+require (
+	github.com/indirect/dep v0.5.0 // indirect
+)
+`
+	mf, err := modfile.Parse("go.mod", []byte(content), nil)
+	require.NoError(t, err)
+
+	snap := snapshotVersions(mf)
+
+	assert.Equal(t, "1.22.0", snap.goVersion)
+	assert.Equal(t, "v1.38.0", snap.deps["go.opentelemetry.io/otel"])
+	assert.Equal(t, "v0.9.0", snap.deps["github.com/example/lib"])
+
+	// indirect deps must not leak into the snapshot
+	_, tracked := snap.deps["github.com/indirect/dep"]
+	assert.False(t, tracked)
+}
+
+func TestSnapshotVersions_MinimalGoMod(t *testing.T) {
+	content := `module example.com/tiny
+
+go 1.21
+`
+	mf, err := modfile.Parse("go.mod", []byte(content), nil)
+	require.NoError(t, err)
+
+	snap := snapshotVersions(mf)
+	assert.Equal(t, "1.21", snap.goVersion)
+	assert.Empty(t, snap.deps)
+}
+
+func TestWarnVersionBumps_GoVersionRaised(t *testing.T) {
+	// go.mod as it looks after tidy bumped 1.22.0 → 1.25.0
+	tempDir := t.TempDir()
+	gomodPath := filepath.Join(tempDir, "go.mod")
+	afterContent := `module example.com/app
+
+go 1.25.0
+
+require (
+	go.opentelemetry.io/otel v1.38.0
+)
+`
+	require.NoError(t, os.WriteFile(gomodPath, []byte(afterContent), 0o644))
+
+	sp, buf := logCapture()
+	before := versionSnapshot{
+		goVersion: "1.22.0",
+		deps: map[string]string{
+			"go.opentelemetry.io/otel": "v1.38.0",
+		},
+	}
+	hooks := []string{"pkg/instrumentation/nethttp/server"}
+
+	sp.warnVersionBumps(gomodPath, before, hooks)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "go directive bumped")
+	assert.Contains(t, logged, "1.22.0")
+	assert.Contains(t, logged, "1.25.0")
+	assert.Contains(t, logged, "nethttp/server")
+}
+
+func TestWarnVersionBumps_DepVersionRaised(t *testing.T) {
+	tempDir := t.TempDir()
+	gomodPath := filepath.Join(tempDir, "go.mod")
+	afterContent := `module example.com/app
+
+go 1.22.0
+
+require (
+	go.opentelemetry.io/otel v1.43.0
+)
+`
+	require.NoError(t, os.WriteFile(gomodPath, []byte(afterContent), 0o644))
+
+	sp, buf := logCapture()
+	before := versionSnapshot{
+		goVersion: "1.22.0",
+		deps: map[string]string{
+			"go.opentelemetry.io/otel": "v1.38.0",
+		},
+	}
+	hooks := []string{"pkg/instrumentation/grpc/client", "pkg/instrumentation/nethttp/server"}
+
+	sp.warnVersionBumps(gomodPath, before, hooks)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "dependency version bumped")
+	assert.Contains(t, logged, "v1.38.0")
+	assert.Contains(t, logged, "v1.43.0")
+	assert.Contains(t, logged, "go.opentelemetry.io/otel")
+	assert.Contains(t, logged, "grpc/client")
+	assert.Contains(t, logged, "nethttp/server")
+}
+
+func TestWarnVersionBumps_NoChange(t *testing.T) {
+	tempDir := t.TempDir()
+	gomodPath := filepath.Join(tempDir, "go.mod")
+	content := `module example.com/app
+
+go 1.22.0
+
+require (
+	go.opentelemetry.io/otel v1.38.0
+)
+`
+	require.NoError(t, os.WriteFile(gomodPath, []byte(content), 0o644))
+
+	sp, buf := logCapture()
+	before := versionSnapshot{
+		goVersion: "1.22.0",
+		deps: map[string]string{
+			"go.opentelemetry.io/otel": "v1.38.0",
+		},
+	}
+
+	sp.warnVersionBumps(gomodPath, before, nil)
+
+	assert.Empty(t, buf.String())
+}
+
+func TestWarnVersionBumps_MissingFile(t *testing.T) {
+	sp, buf := logCapture()
+	before := versionSnapshot{goVersion: "1.22.0", deps: map[string]string{}}
+
+	sp.warnVersionBumps("/nonexistent/go.mod", before, nil)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "unable to check for version bumps")
+}
+
+func TestWarnVersionBumps_EmptyGoVersion(t *testing.T) {
+	// no go directive in the before snapshot — nothing to compare
+	tempDir := t.TempDir()
+	gomodPath := filepath.Join(tempDir, "go.mod")
+	afterContent := `module example.com/app
+
+go 1.25.0
+`
+	require.NoError(t, os.WriteFile(gomodPath, []byte(afterContent), 0o644))
+
+	sp, buf := logCapture()
+	before := versionSnapshot{
+		goVersion: "",
+		deps:      map[string]string{},
+	}
+
+	sp.warnVersionBumps(gomodPath, before, []string{"pkg/instrumentation/basic"})
+
+	assert.Empty(t, buf.String(),
+		"no go-bump warning expected when before.goVersion is empty")
 }

--- a/tool/internal/setup/sync_test.go
+++ b/tool/internal/setup/sync_test.go
@@ -227,12 +227,6 @@ go 1.21
 	assert.Contains(t, string(content), "replace")
 }
 
-func logCapture() (*SetupPhase, *bytes.Buffer) {
-	var buf bytes.Buffer
-	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})
-	return &SetupPhase{logger: slog.New(handler)}, &buf
-}
-
 func warnCapture() (*SetupPhase, *bytes.Buffer) {
 	var buf bytes.Buffer
 	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
@@ -301,7 +295,7 @@ require (
 		},
 	}
 
-	sp.warnVersion(gomodPath, before)
+	require.NoError(t, sp.warnVersion(gomodPath, before))
 
 	logged := buf.String()
 	assert.Contains(t, logged, "Bumped go version")
@@ -323,7 +317,7 @@ go 1.25.0
 		deps:      map[string]string{},
 	}
 
-	sp.warnVersion(gomodPath, before)
+	require.NoError(t, sp.warnVersion(gomodPath, before))
 
 	logged := buf.String()
 	assert.Contains(t, logged, "Bumped go version")
@@ -351,7 +345,7 @@ require (
 		},
 	}
 
-	sp.warnVersion(gomodPath, before)
+	require.NoError(t, sp.warnVersion(gomodPath, before))
 
 	logged := buf.String()
 	assert.Contains(t, logged, "Bumped dependency go.opentelemetry.io/otel")
@@ -379,18 +373,19 @@ require (
 		},
 	}
 
-	sp.warnVersion(gomodPath, before)
+	require.NoError(t, sp.warnVersion(gomodPath, before))
 
 	assert.Empty(t, buf.String())
 }
 
 func TestWarnVersion_MissingFile(t *testing.T) {
-	sp, buf := logCapture()
+	sp, _ := warnCapture()
 	before := versionSnapshot{goVersion: "1.22.0", deps: map[string]string{}}
 
-	sp.warnVersion("/nonexistent/go.mod", before)
+	err := sp.warnVersion("/nonexistent/go.mod", before)
 
-	assert.Contains(t, buf.String(), "unable to check for version bumps")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to check for version bumps")
 }
 
 func TestWarnVersion_EmptyGoVersion(t *testing.T) {
@@ -408,7 +403,7 @@ go 1.25.0
 		deps:      map[string]string{},
 	}
 
-	sp.warnVersion(gomodPath, before)
+	require.NoError(t, sp.warnVersion(gomodPath, before))
 
 	assert.Empty(t, buf.String())
 }

--- a/tool/internal/setup/sync_test.go
+++ b/tool/internal/setup/sync_test.go
@@ -229,11 +229,17 @@ go 1.21
 
 func logCapture() (*SetupPhase, *bytes.Buffer) {
 	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})
+	return &SetupPhase{logger: slog.New(handler)}, &buf
+}
+
+func warnCapture() (*SetupPhase, *bytes.Buffer) {
+	var buf bytes.Buffer
 	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
 	return &SetupPhase{logger: slog.New(handler)}, &buf
 }
 
-func TestSnapshotVersions(t *testing.T) {
+func TestSnapshotVersion(t *testing.T) {
 	content := `module example.com/app
 
 go 1.22.0
@@ -250,7 +256,7 @@ require (
 	mf, err := modfile.Parse("go.mod", []byte(content), nil)
 	require.NoError(t, err)
 
-	snap := snapshotVersions(mf)
+	snap := snapshotVersion(mf)
 
 	assert.Equal(t, "1.22.0", snap.goVersion)
 	assert.Equal(t, "v1.38.0", snap.deps["go.opentelemetry.io/otel"])
@@ -261,7 +267,7 @@ require (
 	assert.False(t, tracked)
 }
 
-func TestSnapshotVersions_MinimalGoMod(t *testing.T) {
+func TestSnapshotVersion_MinimalGoMod(t *testing.T) {
 	content := `module example.com/tiny
 
 go 1.21
@@ -269,13 +275,12 @@ go 1.21
 	mf, err := modfile.Parse("go.mod", []byte(content), nil)
 	require.NoError(t, err)
 
-	snap := snapshotVersions(mf)
+	snap := snapshotVersion(mf)
 	assert.Equal(t, "1.21", snap.goVersion)
 	assert.Empty(t, snap.deps)
 }
 
-func TestWarnVersionBumps_GoVersionRaised(t *testing.T) {
-	// go.mod as it looks after tidy bumped 1.22.0 → 1.25.0
+func TestWarnVersion_GoVersionRaised(t *testing.T) {
 	tempDir := t.TempDir()
 	gomodPath := filepath.Join(tempDir, "go.mod")
 	afterContent := `module example.com/app
@@ -288,25 +293,44 @@ require (
 `
 	require.NoError(t, os.WriteFile(gomodPath, []byte(afterContent), 0o644))
 
-	sp, buf := logCapture()
+	sp, buf := warnCapture()
 	before := versionSnapshot{
 		goVersion: "1.22.0",
 		deps: map[string]string{
 			"go.opentelemetry.io/otel": "v1.38.0",
 		},
 	}
-	hooks := []string{"pkg/instrumentation/nethttp/server"}
 
-	sp.warnVersionBumps(gomodPath, before, hooks)
+	sp.warnVersion(gomodPath, before)
 
 	logged := buf.String()
-	assert.Contains(t, logged, "go directive bumped")
-	assert.Contains(t, logged, "1.22.0")
-	assert.Contains(t, logged, "1.25.0")
-	assert.Contains(t, logged, "nethttp/server")
+	assert.Contains(t, logged, "Bumped go version")
+	assert.Contains(t, logged, "1.22.0 -> 1.25.0")
 }
 
-func TestWarnVersionBumps_DepVersionRaised(t *testing.T) {
+func TestWarnVersion_GoLanguageVersionRaised(t *testing.T) {
+	tempDir := t.TempDir()
+	gomodPath := filepath.Join(tempDir, "go.mod")
+	afterContent := `module example.com/app
+
+go 1.25.0
+`
+	require.NoError(t, os.WriteFile(gomodPath, []byte(afterContent), 0o644))
+
+	sp, buf := warnCapture()
+	before := versionSnapshot{
+		goVersion: "1.21",
+		deps:      map[string]string{},
+	}
+
+	sp.warnVersion(gomodPath, before)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "Bumped go version")
+	assert.Contains(t, logged, "1.21 -> 1.25.0")
+}
+
+func TestWarnVersion_DepVersionRaised(t *testing.T) {
 	tempDir := t.TempDir()
 	gomodPath := filepath.Join(tempDir, "go.mod")
 	afterContent := `module example.com/app
@@ -319,27 +343,22 @@ require (
 `
 	require.NoError(t, os.WriteFile(gomodPath, []byte(afterContent), 0o644))
 
-	sp, buf := logCapture()
+	sp, buf := warnCapture()
 	before := versionSnapshot{
 		goVersion: "1.22.0",
 		deps: map[string]string{
 			"go.opentelemetry.io/otel": "v1.38.0",
 		},
 	}
-	hooks := []string{"pkg/instrumentation/grpc/client", "pkg/instrumentation/nethttp/server"}
 
-	sp.warnVersionBumps(gomodPath, before, hooks)
+	sp.warnVersion(gomodPath, before)
 
 	logged := buf.String()
-	assert.Contains(t, logged, "dependency version bumped")
-	assert.Contains(t, logged, "v1.38.0")
-	assert.Contains(t, logged, "v1.43.0")
-	assert.Contains(t, logged, "go.opentelemetry.io/otel")
-	assert.Contains(t, logged, "grpc/client")
-	assert.Contains(t, logged, "nethttp/server")
+	assert.Contains(t, logged, "Bumped dependency go.opentelemetry.io/otel")
+	assert.Contains(t, logged, "v1.38.0 -> v1.43.0")
 }
 
-func TestWarnVersionBumps_NoChange(t *testing.T) {
+func TestWarnVersion_NoChange(t *testing.T) {
 	tempDir := t.TempDir()
 	gomodPath := filepath.Join(tempDir, "go.mod")
 	content := `module example.com/app
@@ -352,7 +371,7 @@ require (
 `
 	require.NoError(t, os.WriteFile(gomodPath, []byte(content), 0o644))
 
-	sp, buf := logCapture()
+	sp, buf := warnCapture()
 	before := versionSnapshot{
 		goVersion: "1.22.0",
 		deps: map[string]string{
@@ -360,23 +379,21 @@ require (
 		},
 	}
 
-	sp.warnVersionBumps(gomodPath, before, nil)
+	sp.warnVersion(gomodPath, before)
 
 	assert.Empty(t, buf.String())
 }
 
-func TestWarnVersionBumps_MissingFile(t *testing.T) {
+func TestWarnVersion_MissingFile(t *testing.T) {
 	sp, buf := logCapture()
 	before := versionSnapshot{goVersion: "1.22.0", deps: map[string]string{}}
 
-	sp.warnVersionBumps("/nonexistent/go.mod", before, nil)
+	sp.warnVersion("/nonexistent/go.mod", before)
 
-	logged := buf.String()
-	assert.Contains(t, logged, "unable to check for version bumps")
+	assert.Contains(t, buf.String(), "unable to check for version bumps")
 }
 
-func TestWarnVersionBumps_EmptyGoVersion(t *testing.T) {
-	// no go directive in the before snapshot — nothing to compare
+func TestWarnVersion_EmptyGoVersion(t *testing.T) {
 	tempDir := t.TempDir()
 	gomodPath := filepath.Join(tempDir, "go.mod")
 	afterContent := `module example.com/app
@@ -385,14 +402,13 @@ go 1.25.0
 `
 	require.NoError(t, os.WriteFile(gomodPath, []byte(afterContent), 0o644))
 
-	sp, buf := logCapture()
+	sp, buf := warnCapture()
 	before := versionSnapshot{
 		goVersion: "",
 		deps:      map[string]string{},
 	}
 
-	sp.warnVersionBumps(gomodPath, before, []string{"pkg/instrumentation/basic"})
+	sp.warnVersion(gomodPath, before)
 
-	assert.Empty(t, buf.String(),
-		"no go-bump warning expected when before.goVersion is empty")
+	assert.Empty(t, buf.String())
 }

--- a/tool/internal/setup/sync_test.go
+++ b/tool/internal/setup/sync_test.go
@@ -275,9 +275,25 @@ go 1.21
 }
 
 func TestWarnVersion_GoVersionRaised(t *testing.T) {
-	tempDir := t.TempDir()
-	gomodPath := filepath.Join(tempDir, "go.mod")
-	afterContent := `module example.com/app
+	tests := []struct {
+		name      string
+		goVersion string
+	}{
+		{
+			name:      "patch version",
+			goVersion: "1.22.0",
+		},
+		{
+			name:      "language version",
+			goVersion: "1.21",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			gomodPath := filepath.Join(tempDir, "go.mod")
+			afterContent := `module example.com/app
 
 go 1.25.0
 
@@ -285,43 +301,23 @@ require (
 	go.opentelemetry.io/otel v1.38.0
 )
 `
-	require.NoError(t, os.WriteFile(gomodPath, []byte(afterContent), 0o644))
+			require.NoError(t, os.WriteFile(gomodPath, []byte(afterContent), 0o644))
 
-	sp, buf := warnCapture()
-	before := versionSnapshot{
-		goVersion: "1.22.0",
-		deps: map[string]string{
-			"go.opentelemetry.io/otel": "v1.38.0",
-		},
+			sp, buf := warnCapture()
+			before := versionSnapshot{
+				goVersion: test.goVersion,
+				deps: map[string]string{
+					"go.opentelemetry.io/otel": "v1.38.0",
+				},
+			}
+
+			require.NoError(t, sp.warnVersion(gomodPath, before))
+
+			logged := buf.String()
+			assert.Contains(t, logged, "Bumped go version")
+			assert.Contains(t, logged, test.goVersion+" -> 1.25.0")
+		})
 	}
-
-	require.NoError(t, sp.warnVersion(gomodPath, before))
-
-	logged := buf.String()
-	assert.Contains(t, logged, "Bumped go version")
-	assert.Contains(t, logged, "1.22.0 -> 1.25.0")
-}
-
-func TestWarnVersion_GoLanguageVersionRaised(t *testing.T) {
-	tempDir := t.TempDir()
-	gomodPath := filepath.Join(tempDir, "go.mod")
-	afterContent := `module example.com/app
-
-go 1.25.0
-`
-	require.NoError(t, os.WriteFile(gomodPath, []byte(afterContent), 0o644))
-
-	sp, buf := warnCapture()
-	before := versionSnapshot{
-		goVersion: "1.21",
-		deps:      map[string]string{},
-	}
-
-	require.NoError(t, sp.warnVersion(gomodPath, before))
-
-	logged := buf.String()
-	assert.Contains(t, logged, "Bumped go version")
-	assert.Contains(t, logged, "1.21 -> 1.25.0")
 }
 
 func TestWarnVersion_DepVersionRaised(t *testing.T) {


### PR DESCRIPTION
## Problem

The `syncDeps` function silently bumps the consumer's `go` directive and OTel dependency versions during setup. Because `go.mod` is restored by cleanup after a successful build, the user never notices these version changes happened.

## Solution

This implements **Part B** of the proposed fix from #489: before running `go mod tidy`, we snapshot the consumer's `go` directive and direct dependency versions. After tidy, we compare and emit `Warn`-level log messages for every version that was raised.

### Example output

```
WARN go directive bumped by instrumentation hooks from=1.22.0 to=1.25.0
WARN dependency version bumped by instrumentation hooks module=go.opentelemetry.io/otel from=v1.38.0 to=v1.43.0
```

## Changes

### `tool/internal/setup/sync.go`

| Symbol | Purpose |
|--------|---------|
| `versionSnapshot` | Struct holding `goVersion` and `deps map[string]string` |
| `snapshotVersions()` | Captures pre-mutation state from the parsed `modfile.File` |
| `warnVersionBumps()` | Re-parses go.mod post-tidy, compares against snapshot, emits warnings |

**Design decisions:**
- Go directives use bare versions (`1.25.0`) while `semver.Compare` needs a `v` prefix -- we prepend `v` before comparison
- - Only **direct** (non-indirect) dependencies are tracked to avoid noise
- - `warnVersionBumps` is non-fatal: parse errors are logged as warnings, not returned as errors
- - Uses `semver.IsValid` guards to skip malformed versions gracefully
### `tool/internal/setup/sync_test.go`

**6 new tests** covering:
- `TestSnapshotVersions` -- direct deps captured, indirect excluded
- - `TestSnapshotVersions_MinimalGoMod` -- empty deps, go version captured
- - `TestWarnVersionBumps_GoVersionRaised` -- go directive bump produces warning
- - `TestWarnVersionBumps_DepVersionRaised` -- OTel dep bump produces warning
- - `TestWarnVersionBumps_NoChange` -- no warnings when versions match
- - `TestWarnVersionBumps_MissingFile` -- graceful handling of missing go.mod
## What's NOT in this PR

**Part A** (lowering hook module floors from `go 1.25.0` / `otel v1.43.0` to true minimums) is a separate effort requiring CI matrix testing across Go versions.

Fixes #489