### PR TITLE
fix(setup): implement isSetup() to check for matched.json marker

### DIFF
--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -43,10 +43,12 @@ func (sp *SetupPhase) keepForDebug(srcPath string) {
 	}
 }
 
-// This function can be used to check if the setup has been completed.
+// isSetup reports whether setup has already been completed for the current
+// build by checking for the presence of the matched-rules file written by
+// store() at the end of a successful Setup run.
 func isSetup() bool {
-	// TODO: Implement Task
-	return false
+	_, err := os.Stat(util.GetMatchedRuleFile())
+	return err == nil
 }
 
 // flagsWithPathValues contains flags that accept a value from "go build" command.

--- a/tool/internal/setup/setup_test.go
+++ b/tool/internal/setup/setup_test.go
@@ -226,6 +226,33 @@ func TestSetupGoCache(t *testing.T) {
 	})
 }
 
+func TestIsSetup(t *testing.T) {
+	t.Run("returns false when matched.json does not exist", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv(util.EnvOtelcWorkDir, tempDir)
+		if err := os.MkdirAll(util.GetBuildTempDir(), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if isSetup() {
+			t.Error("isSetup() = true, expected false when matched.json is absent")
+		}
+	})
+
+	t.Run("returns true when matched.json exists", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv(util.EnvOtelcWorkDir, tempDir)
+		if err := os.MkdirAll(util.GetBuildTempDir(), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(util.GetMatchedRuleFile(), []byte("[]"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if !isSetup() {
+			t.Error("isSetup() = false, expected true when matched.json exists")
+		}
+	})
+}
+
 func TestExtractBuildFlags(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Description:                                                                                                                                          
  ## Summary                                                                                                                                          
                                                                                                                                                        
  Fixes the unimplemented `isSetup()` guard in `tool/internal/setup/setup.go`.                                                                        
                                                                                                                                                        
  Resolves #<issue-number>
                                                                                                                                                        
  ## Changes                                                                                                                                          
            
  - Implemented `isSetup()` to check for the presence of `matched.json` (written by `store()` at the end of a successful `Setup` run) instead of always
  returning `false`                                                                                                                                     
  - Added unit tests for both the "not set up" and "already set up" cases
                                                                                                                                                        
  ## Why                                                                                                                                                
        
  Without this fix, the guard at `Setup()` line 149 would never short-circuit, causing setup to re-run on every build once the guard is wired in —      
  resulting in redundant re-initialization.                                                                                                             
                                           
  ## Test Plan                                                                                                                                          
                                                                                                                                                      
  - [ ] `go test ./tool/internal/setup/... -run TestIsSetup` passes
  - [ ] Full setup package tests pass: `go test ./tool/internal/setup/...`                                                                              
  
  Notes from the guidelines:                                                                                                                            
  - No changelog entry needed — this is a bug fix for an internal/unshipped guard with no user-facing behavior change. You can prefix the title with  
  [chore] if reviewers flag it, or ask a maintainer to add the Skip Changelog label.                                                                    
  - The title follows the [component] description format required by the guidelines.    
  #512 