### PR TITLE
fix(tool): fix backup handling for multi-module setups

### DIFF
--- a/tool/cmd/cmd_cleanup.go
+++ b/tool/cmd/cmd_cleanup.go
@@ -16,7 +16,7 @@ var commandCleanup = cli.Command{
 	Name:        "cleanup",
 	Description: "Remove all artifacts created by the setup and build phases",
 	Before:      addLoggerPhaseAttribute,
-	Action: func(ctx context.Context, _ *cli.Command) error {
-		return setup.Cleanup(ctx, true)
+	Action: func(ctx context.Context, cmd *cli.Command) error {
+		return setup.Cleanup(ctx, cmd.Args().Slice(), true)
 	},
 }

--- a/tool/internal/setup/backup.go
+++ b/tool/internal/setup/backup.go
@@ -1,0 +1,122 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
+)
+
+const (
+	backupDir       = "backup"
+	backupStateFile = "backup.json"
+)
+
+func getBackupFiles(ctx context.Context, moduleDirs map[string]bool) ([]string, error) {
+	var files []string
+
+	// Find all go.mod and go.sum files
+	for moduleDir := range moduleDirs {
+		goModFile := filepath.Join(moduleDir, "go.mod")
+		if util.PathExists(goModFile) {
+			files = append(files, goModFile)
+		}
+		goSumFile := filepath.Join(moduleDir, "go.sum")
+		if util.PathExists(goSumFile) {
+			files = append(files, goSumFile)
+		}
+	}
+
+	// Find go.work.sum if go.work exists
+	goWorkCmd := exec.CommandContext(ctx, "go", "env", "GOWORK")
+	goWorkOutput, err := goWorkCmd.Output()
+	if err != nil {
+		return nil, ex.Wrapf(err, "failed to get GOWORK environment variable")
+	}
+	goWorkPath := strings.TrimSpace(string(goWorkOutput))
+	if goWorkPath != "" {
+		goWorkSumPath := filepath.Join(filepath.Dir(goWorkPath), "go.work.sum")
+		if util.PathExists(goWorkSumPath) {
+			files = append(files, goWorkSumPath)
+		}
+	}
+
+	return files, nil
+}
+
+func backupFilePath(path string) string {
+	p := filepath.Clean(path)
+	sum := sha256.Sum256([]byte(p))
+	return filepath.Base(p) + "." + hex.EncodeToString(sum[:])
+}
+
+// backupFiles copies go.mod, go.sum and go.work.sum files to the backup directory
+// and records their paths in a state file for later restoration.
+func backupFiles(ctx context.Context, moduleDirs map[string]bool) error {
+	files, err := getBackupFiles(ctx, moduleDirs)
+	if err != nil {
+		return ex.Wrapf(err, "failed to get backup files")
+	}
+
+	bakDir := util.GetBuildTemp(backupDir)
+	for _, src := range files {
+		dst := filepath.Join(bakDir, backupFilePath(src))
+		err = ex.Join(err, util.CopyFile(src, dst))
+	}
+	if err != nil {
+		return ex.Wrapf(err, "failed to copy backup files")
+	}
+
+	f := util.GetBuildTemp(backupStateFile)
+	file, createErr := os.Create(f)
+	if createErr != nil {
+		return ex.Wrapf(createErr, "failed to create file %s", f)
+	}
+	defer file.Close()
+
+	bs, marshalErr := json.Marshal(files)
+	if marshalErr != nil {
+		return ex.Wrapf(marshalErr, "failed to marshal backup state to JSON")
+	}
+
+	if _, writeErr := file.Write(bs); writeErr != nil {
+		return ex.Wrapf(writeErr, "failed to write JSON to file %s", f)
+	}
+
+	return nil
+}
+
+// restoreBackupFiles reads the backup state file to get the list of original file paths,
+// then copies the backed-up files from the backup directory back to their original locations.
+func restoreBackupFiles() error {
+	f := util.GetBuildTemp(backupStateFile)
+	file, err := os.Open(f)
+	if err != nil {
+		return ex.Wrapf(err, "failed to open backup state file %s", f)
+	}
+	defer file.Close()
+
+	var files []string
+	decoder := json.NewDecoder(file)
+	if err = decoder.Decode(&files); err != nil {
+		return ex.Wrapf(err, "failed to decode backup state JSON from file %s", f)
+	}
+
+	bakDir := util.GetBuildTemp(backupDir)
+	for _, src := range files {
+		dst := filepath.Join(bakDir, backupFilePath(src))
+		err = ex.Join(err, util.CopyFile(dst, src))
+	}
+
+	return err
+}

--- a/tool/internal/setup/backup_test.go
+++ b/tool/internal/setup/backup_test.go
@@ -1,0 +1,177 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+package setup
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBackupFiles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	moduleDir := filepath.Join(tmp, "mod")
+	goMod := filepath.Join(moduleDir, "go.mod")
+	goSum := filepath.Join(moduleDir, "go.sum")
+
+	mustWriteFile(t, goMod, "testmod")
+	mustWriteFile(t, goSum, "testsum")
+
+	goWork := filepath.Join(tmp, "go.work")
+	goWorkSum := filepath.Join(tmp, "go.work.sum")
+
+	mustWriteFile(t, goWork, "testwork")
+	mustWriteFile(t, goWorkSum, "testworksum")
+
+	files, err := getBackupFiles(t.Context(), map[string]bool{
+		moduleDir: true,
+	})
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []string{
+		goMod,
+		goSum,
+		goWorkSum,
+	}, files)
+}
+
+func TestGetBackupFiles_MissingFiles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	files, err := getBackupFiles(t.Context(), map[string]bool{
+		tmp: true,
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, files)
+}
+
+func TestBackupFiles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	file1 := filepath.Join(tmp, "go.mod")
+	file2 := filepath.Join(tmp, "go.sum")
+	const file1Data = "module example.com\n\ngo 1.24.0\n"
+	const file2Data = "testsum"
+
+	mustWriteFile(t, file1, file1Data)
+	mustWriteFile(t, file2, file2Data)
+
+	err := backupFiles(t.Context(), map[string]bool{
+		tmp: true,
+	})
+	require.NoError(t, err)
+
+	backupDir := util.GetBuildTemp(backupDir)
+
+	backup1 := filepath.Join(backupDir, backupFilePath(file1))
+	backup2 := filepath.Join(backupDir, backupFilePath(file2))
+
+	data1, err := os.ReadFile(backup1)
+	require.NoError(t, err)
+	require.Equal(t, file1Data, string(data1))
+
+	data2, err := os.ReadFile(backup2)
+	require.NoError(t, err)
+	require.Equal(t, file2Data, string(data2))
+
+	stateData, err := os.ReadFile(util.GetBuildTemp(backupStateFile))
+	require.NoError(t, err)
+
+	var files []string
+	require.NoError(t, json.Unmarshal(stateData, &files))
+	require.ElementsMatch(t, []string{file1, file2}, files)
+}
+
+func TestRestoreBackupFiles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	type fileCase struct {
+		path     string
+		original string
+		modified string
+	}
+
+	files := []fileCase{
+		{
+			path:     filepath.Join(tmp, "go.work.sum"),
+			original: "// original go.work.sum content",
+			modified: "// modified go.work.sum content",
+		},
+		{
+			path:     filepath.Join(tmp, "pkgA", "go.mod"),
+			original: "module original.pkga.com\n\ngo 1.24.0\n",
+			modified: "module modified.pkga.com\n\ngo 1.24.0\n",
+		},
+		{
+			path:     filepath.Join(tmp, "pkgB", "go.mod"),
+			original: "module original.pkgb.com\n\ngo 1.24.0\n",
+			modified: "module modified.pkgb.com\n\ngo 1.24.0\n",
+		},
+	}
+
+	mustWriteFile(t, filepath.Join(tmp, "go.work"), "go 1.24\n\nuse ./pkgA\nuse ./pkgB")
+	for _, f := range files {
+		mustWriteFile(t, f.path, f.original)
+	}
+
+	backupFiles(t.Context(), map[string]bool{
+		filepath.Join(tmp, "pkgA"): true,
+		filepath.Join(tmp, "pkgB"): true,
+	})
+
+	for _, f := range files {
+		mustWriteFile(t, f.path, f.modified)
+	}
+
+	require.NoError(t, restoreBackupFiles())
+
+	for _, f := range files {
+		data, err := os.ReadFile(f.path)
+		require.NoError(t, err)
+
+		require.Equal(t, f.original, string(data))
+	}
+}
+
+func TestRestoreBackupFiles_MissingStateFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	err := restoreBackupFiles()
+	require.Error(t, err)
+}
+
+func TestRestoreBackupFiles_InvalidStateJSON(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	mustWriteFile(t, util.GetBuildTemp(backupStateFile), "{bad json")
+
+	err := restoreBackupFiles()
+	require.Error(t, err)
+}
+
+func TestRestoreBackupFiles_BackupMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	original := filepath.Join(tmp, "go.mod")
+
+	state, err := json.Marshal([]string{original})
+	require.NoError(t, err)
+
+	mustWriteFile(t, util.GetBuildTemp(backupStateFile), string(state))
+
+	err = restoreBackupFiles()
+	require.Error(t, err)
+}

--- a/tool/internal/setup/cleanup.go
+++ b/tool/internal/setup/cleanup.go
@@ -18,39 +18,32 @@ import (
 // When cleanAll is false, backed-up files are restored and the generated runtime
 // file is removed, but .otelc-build/ is kept for debugging. When cleanAll is
 // true, .otelc-build/ is also removed.
-func Cleanup(ctx context.Context, cleanAll bool) error {
+func Cleanup(ctx context.Context, args []string, cleanAll bool) error {
 	logger := util.LoggerFromContext(ctx)
 
-	backupFiles := []string{"go.mod", "go.sum", "go.work", "go.work.sum"}
-
-	// Restore backed-up files before removing .otelc-build/, since backups
-	// live inside .otelc-build/backup/.
-	// Only restore files that were actually backed up: repos without go.work
-	// or go.sum will not have those files in the backup dir, and attempting
-	// to restore absent files would produce spurious warnings.
-	backupDir := util.GetBuildTemp("backup")
-	if util.PathExists(backupDir) {
-		var toRestore []string
-		for _, f := range backupFiles {
-			if util.PathExists(filepath.Join(backupDir, f)) {
-				toRestore = append(toRestore, f)
-			}
-		}
-		if err := util.RestoreFile(toRestore); err != nil {
-			logger.WarnContext(ctx, "failed to restore backed up files", "error", err)
-		}
+	err := restoreBackupFiles()
+	if err != nil {
+		logger.WarnContext(ctx, "failed to restore backup files", "error", err)
 	}
 
-	// Remove the generated otel runtime bridge file from the current working directory.
-	if err := os.RemoveAll(OtelcRuntimeFile); err != nil {
-		logger.WarnContext(ctx, "failed to remove otel runtime file", "error", err)
+	// Remove otelc.runtime.go from each instrumented package directory.
+	pkgs, pkgErr := getBuildPackages(ctx, args)
+	if pkgErr != nil {
+		logger.DebugContext(ctx, "failed to get build packages", "error", pkgErr)
+	}
+	for _, pkg := range pkgs {
+		path := filepath.Join(pkg.Dir, OtelcRuntimeFile)
+		if err = os.RemoveAll(path); err != nil {
+			logger.DebugContext(ctx, "failed to remove generated file from package",
+				"file", path, "error", err)
+		}
 	}
 
 	if cleanAll {
 		// Remove the entire .otelc-build/ temp directory last.
 		// The extracted instrumentation package lives inside .otelc-build/pkg/,
 		// so this also covers removing it.
-		if err := os.RemoveAll(util.GetBuildTempDir()); err != nil {
+		if err = os.RemoveAll(util.GetBuildTempDir()); err != nil {
 			logger.WarnContext(ctx, "failed to remove build temp dir", "error", err)
 		}
 	} else {

--- a/tool/internal/setup/cleanup_test.go
+++ b/tool/internal/setup/cleanup_test.go
@@ -4,7 +4,7 @@
 package setup
 
 import (
-	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +22,9 @@ func TestCleanup(t *testing.T) {
 			name: "removes all artifacts when they exist",
 			setup: func(t *testing.T, dir string) {
 				t.Helper()
-				mustWriteFile(t, filepath.Join(dir, OtelcRuntimeFile), "dummy")
+				// go.mod is required here, otherwise Cleanup will skip the package and otelc.runtime.go won't be removed.
+				mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.com\n\ngo 1.24.0\n")
+				mustWriteFile(t, filepath.Join(dir, OtelcRuntimeFile), "package main \n\n// dummy runtime file")
 				// The instrumentation package is extracted inside .otelc-build/pkg/,
 				// not at the project root. It is removed as part of .otelc-build/ cleanup.
 				mustWriteFile(t, filepath.Join(dir, util.BuildTempDir, unzippedPkgDir, "a.go"), "dummy")
@@ -45,7 +47,9 @@ func TestCleanup(t *testing.T) {
 			name: "partial cleanup when only runtime file exists",
 			setup: func(t *testing.T, dir string) {
 				t.Helper()
-				mustWriteFile(t, filepath.Join(dir, OtelcRuntimeFile), "dummy")
+				// go.mod is required here, otherwise Cleanup will skip the package and otelc.runtime.go won't be removed.
+				mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.com\n\ngo 1.24.0\n")
+				mustWriteFile(t, filepath.Join(dir, OtelcRuntimeFile), "package main\n\n// dummy runtime file")
 			},
 			expectRemoved: []string{
 				OtelcRuntimeFile,
@@ -72,7 +76,7 @@ func TestCleanup(t *testing.T) {
 
 			tt.setup(t, tmpDir)
 
-			err := Cleanup(context.Background(), true)
+			err := Cleanup(t.Context(), nil, true)
 			if err != nil {
 				t.Fatalf("Cleanup() returned unexpected error: %v", err)
 			}
@@ -94,17 +98,27 @@ func TestCleanupRestoresBackup(t *testing.T) {
 	const originalContent = "module original.com\n\ngo 1.24.0\n"
 	const modifiedContent = "module modified.com\n\ngo 1.24.0\n"
 
-	// Simulate what GoBuild does: write a modified go.mod and a backup of the original.
-	mustWriteFile(t, filepath.Join(tmpDir, "go.mod"), modifiedContent)
-	mustWriteFile(t, filepath.Join(tmpDir, util.BuildTempDir, "backup", "go.mod"), originalContent)
-
-	err := Cleanup(context.Background(), true)
+	goModPath := filepath.Join(tmpDir, "go.mod")
+	backupJSONContent, err := json.Marshal([]string{goModPath})
 	if err != nil {
+		t.Fatalf("failed to marshal backup state to JSON: %v", err)
+	}
+
+	// Simulate what GoBuild does: write a modified go.mod and a backup of the original.
+	mustWriteFile(t, goModPath, modifiedContent)
+	mustWriteFile(
+		t,
+		filepath.Join(tmpDir, util.BuildTempDir, backupDir, backupFilePath(goModPath)),
+		originalContent,
+	)
+	mustWriteFile(t, filepath.Join(tmpDir, util.BuildTempDir, backupStateFile), string(backupJSONContent))
+
+	if err = Cleanup(t.Context(), nil, true); err != nil {
 		t.Fatalf("Cleanup() returned unexpected error: %v", err)
 	}
 
 	// go.mod should be restored to the original content.
-	got, readErr := os.ReadFile(filepath.Join(tmpDir, "go.mod"))
+	got, readErr := os.ReadFile(goModPath)
 	if readErr != nil {
 		t.Fatalf("failed to read go.mod after cleanup: %v", readErr)
 	}
@@ -118,6 +132,67 @@ func TestCleanupRestoresBackup(t *testing.T) {
 	}
 }
 
+func TestCleanupRestoresMultiModBackup(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	type fileCase struct {
+		path     string
+		original string
+		modified string
+	}
+
+	files := []fileCase{
+		{
+			path:     filepath.Join(tmpDir, "go.work.sum"),
+			original: "// original go.work.sum content",
+			modified: "// modified go.work.sum content",
+		},
+		{
+			path:     filepath.Join(tmpDir, "pkgA", "go.mod"),
+			original: "module original.pkga.com\n\ngo 1.24.0\n",
+			modified: "module modified.pkga.com\n\ngo 1.24.0\n",
+		},
+		{
+			path:     filepath.Join(tmpDir, "pkgB", "go.mod"),
+			original: "module original.pkgb.com\n\ngo 1.24.0\n",
+			modified: "module modified.pkgb.com\n\ngo 1.24.0\n",
+		},
+	}
+
+	mustWriteFile(t, filepath.Join(tmpDir, "go.work"), "go 1.24\n\nuse ./pkgA\nuse ./pkgB")
+
+	backupPaths := make([]string, 0, len(files))
+	for _, f := range files {
+		backupPath := filepath.Join(tmpDir, util.BuildTempDir, backupDir, backupFilePath(f.path))
+		backupPaths = append(backupPaths, f.path)
+
+		mustWriteFile(t, f.path, f.modified)
+		mustWriteFile(t, backupPath, f.original)
+	}
+
+	backupJSONContent, err := json.Marshal(backupPaths)
+	if err != nil {
+		t.Fatalf("marshal backup state: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(tmpDir, util.BuildTempDir, backupStateFile), string(backupJSONContent))
+
+	if err = Cleanup(t.Context(), nil, false); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	for _, f := range files {
+		got, readErr := os.ReadFile(f.path)
+		if readErr != nil {
+			t.Fatalf("read %s: %v", f.path, readErr)
+		}
+
+		if string(got) != f.original {
+			t.Errorf("%s content = %q, want %q", f.path, string(got), f.original)
+		}
+	}
+}
+
 func TestCleanupKeepsBuildDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
@@ -125,19 +200,30 @@ func TestCleanupKeepsBuildDir(t *testing.T) {
 	const originalContent = "module original.com\n\ngo 1.24.0\n"
 	const modifiedContent = "module modified.com\n\ngo 1.24.0\n"
 
-	// Simulate a completed build: modified go.mod, backup, runtime file, and build artifacts.
-	mustWriteFile(t, filepath.Join(tmpDir, "go.mod"), modifiedContent)
-	mustWriteFile(t, filepath.Join(tmpDir, util.BuildTempDir, "backup", "go.mod"), originalContent)
-	mustWriteFile(t, filepath.Join(tmpDir, util.BuildTempDir, "matched.json"), "{}")
-	mustWriteFile(t, filepath.Join(tmpDir, OtelcRuntimeFile), "dummy")
+	goModPath := filepath.Join(tmpDir, "go.mod")
+	backupJSONContent, err := json.Marshal([]string{goModPath})
+	if err != nil {
+		t.Fatalf("failed to marshal backup state to JSON: %v", err)
+	}
 
-	err := Cleanup(context.Background(), false)
+	// Simulate a completed build: modified go.mod, backup, runtime file, and build artifacts.
+	mustWriteFile(t, goModPath, modifiedContent)
+	mustWriteFile(
+		t,
+		filepath.Join(tmpDir, util.BuildTempDir, backupDir, backupFilePath(goModPath)),
+		originalContent,
+	)
+	mustWriteFile(t, filepath.Join(tmpDir, util.BuildTempDir, backupStateFile), string(backupJSONContent))
+	mustWriteFile(t, filepath.Join(tmpDir, util.BuildTempDir, "matched.json"), "{}")
+	mustWriteFile(t, filepath.Join(tmpDir, OtelcRuntimeFile), "package main \n\n// dummy runtime file")
+
+	err = Cleanup(t.Context(), nil, false)
 	if err != nil {
 		t.Fatalf("Cleanup(cleanAll=false) returned unexpected error: %v", err)
 	}
 
 	// go.mod should be restored to the original content.
-	got, readErr := os.ReadFile(filepath.Join(tmpDir, "go.mod"))
+	got, readErr := os.ReadFile(goModPath)
 	if readErr != nil {
 		t.Fatalf("failed to read go.mod after cleanup: %v", readErr)
 	}
@@ -161,7 +247,7 @@ func TestCleanupKeepsBuildDirNoArtifacts(t *testing.T) {
 	t.Chdir(tmpDir)
 
 	// No artifacts exist — Cleanup(cleanAll=false) should not panic or fail.
-	err := Cleanup(context.Background(), false)
+	err := Cleanup(t.Context(), nil, false)
 	if err != nil {
 		t.Fatalf("Cleanup(cleanAll=false) returned unexpected error: %v", err)
 	}

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -217,14 +217,6 @@ func Setup(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 
-	// Back up go.mod / go.sum / go.work / go.work.sum before modifying them.
-	// Cleanup() restores from this backup, so the backup must exist before any
-	// modification happens — including when otelc setup is run standalone.
-	backupFiles := []string{"go.mod", "go.sum", "go.work", "go.work.sum"}
-	if err := util.BackupFile(backupFiles); err != nil {
-		logger.DebugContext(ctx, "failed to back up files", "error", err)
-	}
-
 	sp := &SetupPhase{
 		logger:     logger,
 		ruleConfig: cmd.String("rules"),
@@ -284,6 +276,11 @@ func Setup(ctx context.Context, cmd *cli.Command) error {
 			return ex.Wrapf(err, "adding deps for package at %s", pkgDir)
 		}
 		moduleDirs[moduleDir] = true
+	}
+
+	// Backup go.mod, go.sum and go.work.sum files before modifying them
+	if err = backupFiles(ctx, moduleDirs); err != nil {
+		return ex.Wrapf(err, "backing up files")
 	}
 
 	// Sync new dependencies to go.mod or vendor/modules.txt
@@ -482,22 +479,9 @@ func GoBuild(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	defer func() {
-		// Remove otelc.runtime.go from each instrumented package directory.
-		pkgs, pkgErr := getBuildPackages(ctx, cmd.Args().Tail()) // pass args without build/install
-		if pkgErr != nil {
-			logger.DebugContext(ctx, "failed to get build packages", "error", pkgErr)
-		}
-		for _, pkg := range pkgs {
-			path := filepath.Join(pkg.Dir, OtelcRuntimeFile)
-			if removeErr := os.RemoveAll(path); removeErr != nil {
-				logger.DebugContext(ctx, "failed to remove generated file from package",
-					"file", path, "error", removeErr)
-			}
-		}
-
 		// Restore backed-up go.mod/go.sum but keep .otelc-build/ for debugging.
 		// Users can run `otelc cleanup` to remove it explicitly.
-		if cleanErr := Cleanup(ctx, false); cleanErr != nil {
+		if cleanErr := Cleanup(ctx, cmd.Args().Tail(), false); cleanErr != nil {
 			logger.DebugContext(ctx, "cleanup failed", "error", cleanErr)
 		}
 	}()

--- a/tool/util/shared.go
+++ b/tool/util/shared.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
 	"golang.org/x/mod/semver"
 )
 
@@ -63,26 +62,6 @@ func GetBuildTempDir() string {
 // GetBuildTemp returns the path to the build temp directory $BUILD_TEMP/name
 func GetBuildTemp(name string) string {
 	return filepath.Join(GetOtelcWorkDir(), BuildTempDir, name)
-}
-
-func copyBackupFiles(names []string, src, dst string) error {
-	var err error
-	for _, name := range names {
-		srcFile := filepath.Join(src, name)
-		dstFile := filepath.Join(dst, name)
-		err = ex.Join(err, CopyFile(srcFile, dstFile))
-	}
-	return err
-}
-
-// BackupFile backups the source file to $BUILD_TEMP/backup/name.
-func BackupFile(names []string) error {
-	return copyBackupFiles(names, ".", GetBuildTemp("backup"))
-}
-
-// RestoreFile restores the source file from $BUILD_TEMP/backup/name.
-func RestoreFile(names []string) error {
-	return copyBackupFiles(names, GetBuildTemp("backup"), ".")
 }
 
 // GetBuildFlags returns the build flags from OTELC_BUILD_FLAGS environment variable.


### PR DESCRIPTION
## Description
Fixes backup handling for multi-module setups by resolving actual module/workspace file locations instead of assuming they exist in cwd.

Adds a backup state file to track original backup locations.

## Motivation
otelc currently assumes `go.mod`, `go.sum`, `go.work.sum`, and related files are present in cwd, which breaks in multi-module setups.

Fixes #514

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [ ] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
