### PR TITLE
chore: validate instrumentation rule metadata

### DIFF
--- a/tool/internal/setup/rule_metadata_test.go
+++ b/tool/internal/setup/rule_metadata_test.go
@@ -1,0 +1,88 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
+
+	instrule "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/internal/rule"
+)
+
+func TestInstrumentationRuleMetadata(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "pkg", "instrumentation")
+
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".yaml" {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "expected instrumentation rule YAML files")
+
+	for _, file := range files {
+		name, relErr := filepath.Rel(root, file)
+		require.NoError(t, relErr)
+
+		t.Run(name, func(t *testing.T) {
+			content, readErr := os.ReadFile(file)
+			require.NoError(t, readErr)
+
+			rules, parseErr := parseRuleFromYaml(content)
+			require.NoError(t, parseErr)
+			require.NotEmpty(t, rules, "%s: expected at least one rule", file)
+
+			for _, parsedRule := range rules {
+				ruleName := parsedRule.GetName()
+				require.NotEmpty(t, ruleName, "%s: rule name is empty", file)
+				require.NotEmpty(t, parsedRule.GetTarget(), "%s: rule %q target is empty", file, ruleName)
+
+				validateRuleVersion(t, file, ruleName, parsedRule.GetVersion())
+
+				switch rule := parsedRule.(type) {
+				case *instrule.InstFuncRule:
+					require.NotEmpty(t, rule.Path, "%s: rule %q path is empty", file, ruleName)
+				case *instrule.InstFileRule:
+					require.NotEmpty(t, rule.Path, "%s: rule %q path is empty", file, ruleName)
+				}
+			}
+		})
+	}
+}
+
+func validateRuleVersion(t *testing.T, file, ruleName, version string) {
+	t.Helper()
+
+	if version == "" {
+		return
+	}
+
+	parts := strings.Split(version, ",")
+	require.LessOrEqual(t,
+		len(parts),
+		2,
+		"%s: rule %q has invalid version range %q",
+		file,
+		ruleName,
+		version,
+	)
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		require.NotEmpty(t, part, "%s: rule %q has empty version component in %q", file, ruleName, version)
+		require.True(t, semver.IsValid(part), "%s: rule %q has invalid semver version %q", file, ruleName, part)
+	}
+}


### PR DESCRIPTION
## Description

This PR adds a focused test that validates existing instrumentation rule metadata under `pkg/instrumentation`.

The test walks instrumentation YAML files, parses them with the existing rule parser, and checks basic structural metadata such as non-empty rule names, non-empty targets, valid version metadata when present, and non-empty hook/file paths where required.

This does not change runtime behavior. It only validates existing instrumentation rule metadata in tests.

## Motivation

Instrumentation rule metadata is central to how `otelc` matches target packages and injects hooks. Small metadata mistakes in YAML files, such as missing targets or hook paths, can be easy to miss during review.

Adding structural validation improves regression coverage for rule authoring and gives contributors faster feedback when adding or modifying instrumentation rules.

## Testing

- `go test ./tool/...`
- `make format`
- `make lint`
- `make test`

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)