### PR TITLE
chore: support test conventional commit type

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ INSTRUCTIONS:
 PR TITLE FORMAT (required):
   type(scope): description
 
-  Types: feat, fix, docs, chore, refactor, test, release
+  Types: chore, doc, docs, feat, fix, release, refactor, test
   Scopes: tool, pkg, demo, test, docs
 
   Examples:

--- a/.github/tools/conventionalcommit/main.go
+++ b/.github/tools/conventionalcommit/main.go
@@ -33,6 +33,7 @@ var (
 		"fix":      "scope:fix",
 		"release":  "scope:chore",
 		"refactor": "scope:refactor",
+		"test":     "scope:chore",
 	}
 	titleRegexp = regexp.MustCompile(fmt.Sprintf(`^(%s)(?:\(.+\))?!?: .*$`, strings.Join(slices.Collect(maps.Keys(conventionalLabels)), "|")))
 )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,6 +198,7 @@ This repository requires using one of the following commit types:
 - `fix` for bug fixes
 - `release` when cutting a new release
 - `refactor` for code changes that do not add new features or fix bugs
+- `test` for changes to tests or test infrastructure
 
 Please try to keep the commit title concise, yet specific: they are used to derive the release notes
 for this repository. A good litmus test for whether a pull request title is suitable or not is to
@@ -235,6 +236,10 @@ Here are some examples for the various supported commit types:
   - :information_source: What code is being refactored?
   - :white_check_mark: `refactor: remove unused code`
   - :x: `refactor: improve code readability`
+- `test`:
+  - :information_source: What behavior or test coverage is being added?
+  - :white_check_mark: `test: validate exported span output in basic integration test`
+  - :x: `test: improve tests`
 
 [conv-commit]: https://www.conventionalcommits.org/en/v1.0.0/
 


### PR DESCRIPTION
## Description

This PR aligns the pull request template, `CONTRIBUTING.md`, and the repository's PR title checker for conventional commit types.

The PR template already listed `test` as an accepted type, but the title checker did not accept it. This PR makes `test` a supported conventional commit type for test-only changes and documents it consistently.

## Motivation

Test-only PRs are common in this repository. Supporting `test` avoids forcing contributors to classify test-related changes as `chore` and keeps the PR template, contributing guide, and title check behavior consistent.

Fixes #522

## Testing

- `go -C .github/tools/conventionalcommit test ./...`
- `make format`
- `make lint`
- `make test`

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](docs/testing.md)
- [x] Documentation updated (if applicable)