### PR TITLE
chore(tests): upgrade codspeed version

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Build otelc
         run: make build
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@db35df748deb45fdef0960669f57d627c1956c30  # ratchet:CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd  # ratchet:CodSpeedHQ/action@v4.15.1
         with:
           mode: walltime
           run: make benchmark/codspeed BENCH_TIME=5x


### PR DESCRIPTION
Bumping codspeed version. Ubuntu made some changes related to the the ring buffer overflow and codspeed ebpf code failed handling them. Fixed in this [release](https://github.com/CodSpeedHQ/action/releases/tag/v4.15.1).