### PR TITLE
test: cover latest library build dependency discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL := /bin/bash
         build-demo build-demo-grpc build-demo-http format/go format/yaml lint/go lint/yaml \
         lint/action lint/makefile lint/license-header lint/license-header/fix lint/dockerfile actionlint yamlfmt gotestfmt ratchet ratchet/pin \
         ratchet/update ratchet/check golangci-lint embedmd checkmake hadolint help docs check-embed check-api-sync check-golden-files \
-        test-unit/update-golden test-unit/tool test-unit/pkg test-unit/demo \
+        test-unit/update-golden test-unit/tool test-unit/pkg test-unit/demo test-unit/helper \
         test-unit/coverage test-unit/tool/coverage test-unit/pkg/coverage \
         test-integration/coverage test-e2e/coverage \
         registry-diff registry-check registry-resolve weaver-install tidy/test-apps \
@@ -375,7 +375,7 @@ benchmark/threshold: build ## Enforce absolute otelc overhead ceiling (fails if 
 test: ## Run all tests (unit + integration + e2e)
 test: test-unit test-integration test-e2e
 
-test-unit: test-unit/tool test-unit/pkg test-unit/demo ## Run all unit tests (tool + pkg + demo)
+test-unit: test-unit/tool test-unit/pkg test-unit/demo test-unit/helper ## Run all unit tests (tool + pkg + demo + test helpers)
 
 .ONESHELL:
 test-unit/update-golden: ## Run unit tests and update golden files
@@ -417,6 +417,13 @@ test-unit/pkg: package ## Run unit tests for pkg modules only
 		(cd "$$moddir" && go mod tidy); \
 		go test -C "$$moddir" -v -shuffle=on -timeout=5m -count=1 ./... 2>&1 | tee -a ./gotest-unit-pkg.log; \
 	done
+
+.ONESHELL:
+test-unit/helper: ## Run unit tests for test helper packages
+	@echo "Running test helper unit tests..."
+	set -euo pipefail
+	rm -f ./gotest-unit-helper.log
+	go test -C "test" -v -shuffle=on -timeout=5m -count=1 ./testutil/... 2>&1 | tee ./gotest-unit-helper.log
 
 .ONESHELL:
 test-unit/demo: ## Run unit tests for demo applications

--- a/test/testutil/latestlib_test.go
+++ b/test/testutil/latestlib_test.go
@@ -1,0 +1,92 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoversAnyTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		requirePath string
+		targets     map[string]bool
+		want        bool
+	}{
+		{
+			name:        "exact match",
+			requirePath: "github.com/redis/go-redis/v9",
+			targets: map[string]bool{
+				"github.com/redis/go-redis/v9": true,
+			},
+			want: true,
+		},
+		{
+			name:        "module covers subpackage target",
+			requirePath: "go.opentelemetry.io/otel",
+			targets: map[string]bool{
+				"go.opentelemetry.io/otel/sdk/trace": true,
+			},
+			want: true,
+		},
+		{
+			name:        "prefix false positive",
+			requirePath: "example.com/foo",
+			targets: map[string]bool{
+				"example.com/foobar": true,
+			},
+			want: false,
+		},
+		{
+			name:        "unrelated target",
+			requirePath: "google.golang.org/grpc",
+			targets: map[string]bool{
+				"net/http": true,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, coversAnyTarget(tt.requirePath, tt.targets))
+		})
+	}
+}
+
+func TestDiscoverInstrumentedDeps(t *testing.T) {
+	appDir := t.TempDir()
+	goMod := `module example.com/app
+
+go 1.25.0
+
+require (
+	github.com/redis/go-redis/v9 v9.0.0
+	go.opentelemetry.io/otel v1.0.0
+	example.com/unused v1.0.0 // indirect
+	example.com/local v1.0.0
+)
+
+replace example.com/local => ./local
+`
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, "go.mod"), []byte(goMod), 0o600))
+
+	targets := map[string]bool{
+		"github.com/redis/go-redis/v9":       true,
+		"go.opentelemetry.io/otel/sdk/trace": true,
+		"example.com/unused":                 true,
+		// The local replacement should be ignored even though it is covered by a target.
+		"example.com/local": true,
+	}
+
+	deps := DiscoverInstrumentedDeps(t, appDir, targets)
+	require.ElementsMatch(t, []string{
+		"github.com/redis/go-redis/v9",
+		"go.opentelemetry.io/otel",
+	}, deps)
+}


### PR DESCRIPTION
## Description

This PR adds focused unit coverage for the helper logic used by the LatestLibBuild workflow.

It verifies that instrumentation targets are matched to module dependencies correctly and that indirect or locally replaced dependencies are ignored.

## Motivation

LatestLibBuild tests rely on dependency discovery to decide which instrumented libraries should be upgraded to `@latest`. Covering this logic helps prevent regressions in the compatibility test workflow.

Fixes #525

## Testing

- `go -C test test ./testutil`
- `go -C test test ./...`
- `make format`
- `make lint`
- `make test`

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)