### PR TITLE
fix(util): avoid skipping sibling files in ListFiles

### DIFF
--- a/tool/util/sys.go
+++ b/tool/util/sys.go
@@ -103,7 +103,11 @@ func ListFiles(dir string) ([]string, error) {
 		}
 		// Don't list files under hidden directories
 		if strings.HasPrefix(info.Name(), ".") {
-			return filepath.SkipDir
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+
+			return nil
 		}
 		if !info.IsDir() {
 			files = append(files, path)

--- a/tool/util/sys_test.go
+++ b/tool/util/sys_test.go
@@ -230,3 +230,84 @@ func TestGetBuildFlags_Empty(t *testing.T) {
 		t.Errorf("GetBuildFlags() with empty env should return nil, got %v", result)
 	}
 }
+
+func TestListFiles_HiddenFileDoesNotSkipSiblings(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	visible1 := filepath.Join(tmpDir, "visible1.txt")
+	hidden := filepath.Join(tmpDir, ".hidden")
+	visible2 := filepath.Join(tmpDir, "visible2.txt")
+
+	for _, file := range []string{visible1, hidden, visible2} {
+		err := os.WriteFile(file, []byte("test"), 0o644)
+		if err != nil {
+			t.Fatalf("failed to create test file %s: %v", file, err)
+		}
+	}
+
+	files, err := ListFiles(tmpDir)
+	if err != nil {
+		t.Fatalf("ListFiles() error = %v", err)
+	}
+
+	var foundVisible1, foundVisible2 bool
+
+	for _, file := range files {
+		switch filepath.Base(file) {
+		case "visible1.txt":
+			foundVisible1 = true
+		case "visible2.txt":
+			foundVisible2 = true
+		case ".hidden":
+			t.Fatalf("hidden file should not be returned")
+		}
+	}
+
+	if !foundVisible1 || !foundVisible2 {
+		t.Fatalf("expected visible sibling files to be returned, got %v", files)
+	}
+}
+
+func TestListFiles_SkipsHiddenDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	hiddenDir := filepath.Join(tmpDir, ".git")
+	err := os.MkdirAll(hiddenDir, 0o755)
+	if err != nil {
+		t.Fatalf("failed to create hidden directory: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(hiddenDir, "config"), []byte("test"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create hidden file: %v", err)
+	}
+
+	visible := filepath.Join(tmpDir, "visible.txt")
+	err = os.WriteFile(visible, []byte("test"), 0o644)
+	if err != nil {
+		t.Fatalf("failed to create visible file: %v", err)
+	}
+
+	files, err := ListFiles(tmpDir)
+	if err != nil {
+		t.Fatalf("ListFiles() error = %v", err)
+	}
+
+	for _, file := range files {
+		if strings.Contains(file, ".git") {
+			t.Fatalf("hidden directory contents should not be returned: %v", files)
+		}
+	}
+
+	var foundVisible bool
+
+	for _, file := range files {
+		if filepath.Base(file) == "visible.txt" {
+			foundVisible = true
+		}
+	}
+
+	if !foundVisible {
+		t.Fatalf("expected visible file to be returned")
+	}
+}


### PR DESCRIPTION
## Description

Fixes a bug in `ListFiles` where encountering a hidden file (such as `.gitignore`) caused `filepath.SkipDir` to skip the remaining sibling files in the directory.

This change keeps the existing behavior for hidden directories while allowing traversal to continue when hidden files are encountered.

Regression tests were added for both cases.

## Motivation

`filepath.Walk` treats `filepath.SkipDir` differently for files and directories. Returning it for a hidden file causes the remaining entries in the containing directory to be skipped as well.

This could lead to visible sibling files being silently omitted from `ListFiles`.

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
