### PR TITLE
fix(setup): back up module files per module dir in multi-module setups

### DIFF
--- a/tool/internal/setup/cleanup.go
+++ b/tool/internal/setup/cleanup.go
@@ -6,7 +6,6 @@ package setup
 import (
 	"context"
 	"os"
-	"path/filepath"
 
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
@@ -21,22 +20,14 @@ import (
 func Cleanup(ctx context.Context, cleanAll bool) error {
 	logger := util.LoggerFromContext(ctx)
 
-	backupFiles := []string{"go.mod", "go.sum", "go.work", "go.work.sum"}
-
 	// Restore backed-up files before removing .otelc-build/, since backups
 	// live inside .otelc-build/backup/.
-	// Only restore files that were actually backed up: repos without go.work
-	// or go.sum will not have those files in the backup dir, and attempting
-	// to restore absent files would produce spurious warnings.
+	// RestoreAllBackedUpFiles walks the backup tree so that module files in
+	// subdirectories (multi-module setups) are also restored to the correct
+	// original paths.
 	backupDir := util.GetBuildTemp("backup")
 	if util.PathExists(backupDir) {
-		var toRestore []string
-		for _, f := range backupFiles {
-			if util.PathExists(filepath.Join(backupDir, f)) {
-				toRestore = append(toRestore, f)
-			}
-		}
-		if err := util.RestoreFile(toRestore); err != nil {
+		if err := util.RestoreAllBackedUpFiles(); err != nil {
 			logger.WarnContext(ctx, "failed to restore backed up files", "error", err)
 		}
 	}

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -217,24 +217,42 @@ func Setup(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 
-	// Back up go.mod / go.sum / go.work / go.work.sum before modifying them.
-	// Cleanup() restores from this backup, so the backup must exist before any
-	// modification happens — including when otelc setup is run standalone.
-	backupFiles := []string{"go.mod", "go.sum", "go.work", "go.work.sum"}
-	if err := util.BackupFile(backupFiles); err != nil {
-		logger.DebugContext(ctx, "failed to back up files", "error", err)
-	}
-
 	sp := &SetupPhase{
 		logger:     logger,
 		ruleConfig: cmd.String("rules"),
 	}
 
-	// Introduce additional hook code by generating otelc.runtime.go
-	// Use GetPackage to determine the build target directory
+	// Resolve the packages first so we know which module directories will be
+	// modified by syncDeps.  Backup must cover all of them, not just cwd.
 	pkgs, err := getBuildPackages(ctx, args)
 	if err != nil {
 		return err
+	}
+
+	// Back up go.mod / go.sum / go.work / go.work.sum before modifying them.
+	// Cleanup() restores from this backup, so the backup must exist before any
+	// modification happens — including when otelc setup is run standalone.
+	//
+	// Workspace files (go.work, go.work.sum) live at cwd; module files
+	// (go.mod, go.sum) may live in subdirectories for multi-module setups.
+	// BackupFileFromDir preserves the relative path so RestoreAllBackedUpFiles
+	// can reconstruct the original location on restore.
+	if err = util.BackupFile([]string{"go.work", "go.work.sum"}); err != nil {
+		logger.DebugContext(ctx, "failed to back up workspace files", "error", err)
+	}
+	backedModuleDirs := make(map[string]bool)
+	for _, pkg := range pkgs {
+		if pkg.Module == nil {
+			continue
+		}
+		moduleDir := pkg.Module.Dir
+		if backedModuleDirs[moduleDir] {
+			continue
+		}
+		if err = util.BackupFileFromDir([]string{"go.mod", "go.sum"}, moduleDir); err != nil {
+			logger.DebugContext(ctx, "failed to back up module files", "moduleDir", moduleDir, "error", err)
+		}
+		backedModuleDirs[moduleDir] = true
 	}
 
 	// Find all dependencies of the project being build

--- a/tool/util/shared.go
+++ b/tool/util/shared.go
@@ -6,6 +6,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -73,12 +74,64 @@ func copyBackupFiles(names []string, src, dst string) error {
 	return err
 }
 
-// BackupFile backups the source file to $BUILD_TEMP/backup/name.
+// BackupFileFromDir backs up the named files from dir into the backup directory,
+// preserving the path of dir relative to cwd so that multiple module directories
+// can be backed up without filename collisions.
+//
+// Example: if cwd is /project and dir is /project/submodule, then go.mod is
+// stored at .otelc-build/backup/submodule/go.mod and can later be restored to
+// the correct location by RestoreAllBackedUpFiles.
+func BackupFileFromDir(names []string, dir string) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return ex.Wrapf(err, "getting working directory for backup")
+	}
+	rel, err := filepath.Rel(wd, dir)
+	if err != nil {
+		rel = filepath.Base(dir)
+	}
+	dst := GetBuildTemp(filepath.Join("backup", rel))
+	if mkErr := os.MkdirAll(dst, 0o755); mkErr != nil {
+		return ex.Wrapf(mkErr, "creating backup directory %s", dst)
+	}
+	return copyBackupFiles(names, dir, dst)
+}
+
+// BackupFile backs up the named files from the current working directory.
+// Deprecated: prefer BackupFileFromDir with an explicit directory.
 func BackupFile(names []string) error {
-	return copyBackupFiles(names, ".", GetBuildTemp("backup"))
+	wd, err := os.Getwd()
+	if err != nil {
+		return ex.Wrapf(err, "getting working directory for backup")
+	}
+	return BackupFileFromDir(names, wd)
+}
+
+// RestoreAllBackedUpFiles restores every file in the backup directory tree to
+// its original location relative to the current working directory. It is the
+// counterpart to BackupFileFromDir: the relative path recorded at backup time
+// is used to reconstruct the original destination path.
+func RestoreAllBackedUpFiles() error {
+	backupRoot := GetBuildTemp("backup")
+	wd, err := os.Getwd()
+	if err != nil {
+		return ex.Wrapf(err, "getting working directory for restore")
+	}
+	return filepath.WalkDir(backupRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return walkErr
+		}
+		rel, relErr := filepath.Rel(backupRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		orig := filepath.Join(wd, rel)
+		return CopyFile(path, orig)
+	})
 }
 
 // RestoreFile restores the source file from $BUILD_TEMP/backup/name.
+// Deprecated: use RestoreAllBackedUpFiles which handles multi-module setups.
 func RestoreFile(names []string) error {
 	return copyBackupFiles(names, GetBuildTemp("backup"), ".")
 }

--- a/tool/util/shared_test.go
+++ b/tool/util/shared_test.go
@@ -1,0 +1,131 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBackupFileFromDir_SingleModule(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvOtelcWorkDir, tmpDir)
+	if err := os.MkdirAll(GetBuildTempDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a go.mod in the work dir (simulating cwd == module root).
+	gomod := filepath.Join(tmpDir, "go.mod")
+	if err := os.WriteFile(gomod, []byte("module example.com/app\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint:errcheck
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := BackupFileFromDir([]string{"go.mod"}, tmpDir); err != nil {
+		t.Fatalf("BackupFileFromDir: %v", err)
+	}
+
+	// Backup should be at .otelc-build/backup/./go.mod (relative "." from cwd==tmpDir)
+	backed := GetBuildTemp(filepath.Join("backup", ".", "go.mod"))
+	if _, err := os.Stat(backed); os.IsNotExist(err) {
+		t.Fatalf("backup file not found at %s", backed)
+	}
+}
+
+func TestBackupFileFromDir_MultiModule(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvOtelcWorkDir, root)
+	if err := os.MkdirAll(GetBuildTempDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a nested module directory.
+	subDir := filepath.Join(root, "sub", "module")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gomod := filepath.Join(subDir, "go.mod")
+	if err := os.WriteFile(gomod, []byte("module example.com/sub\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint:errcheck
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := BackupFileFromDir([]string{"go.mod"}, subDir); err != nil {
+		t.Fatalf("BackupFileFromDir: %v", err)
+	}
+
+	// Backup must be namespaced under the relative path "sub/module".
+	backed := GetBuildTemp(filepath.Join("backup", "sub", "module", "go.mod"))
+	if _, err := os.Stat(backed); os.IsNotExist(err) {
+		t.Fatalf("backup file not found at %s", backed)
+	}
+}
+
+func TestRestoreAllBackedUpFiles(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvOtelcWorkDir, root)
+	if err := os.MkdirAll(GetBuildTempDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a nested module directory with a go.mod.
+	subDir := filepath.Join(root, "nested")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := "module example.com/nested\n\ngo 1.21\n"
+	gomod := filepath.Join(subDir, "go.mod")
+	if err := os.WriteFile(gomod, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint:errcheck
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	// Back up the module file.
+	if err := BackupFileFromDir([]string{"go.mod"}, subDir); err != nil {
+		t.Fatalf("BackupFileFromDir: %v", err)
+	}
+
+	// Overwrite the original to simulate a modification.
+	if err := os.WriteFile(gomod, []byte("modified content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restore and verify content is back.
+	if err := RestoreAllBackedUpFiles(); err != nil {
+		t.Fatalf("RestoreAllBackedUpFiles: %v", err)
+	}
+
+	data, err := os.ReadFile(gomod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != original {
+		t.Errorf("go.mod content after restore = %q, want %q", string(data), original)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #514

`BackupFile` was copying `go.mod`/`go.sum` from `cwd` only. This breaks multi-module workspaces where `go.mod` files live in subdirectories, because `syncDeps` modifies `go.mod` per module directory, but `Cleanup` would only restore the root `go.mod`.

## Changes

- **`util/shared.go`**: Add `BackupFileFromDir(names, dir)` — backs up files from an explicit directory, namespaced by its relative path from cwd. For example, `sub/module/go.mod` is stored at `.otelc-build/backup/sub/module/go.mod` and restores to the correct location.
- **`util/shared.go`**: Add `RestoreAllBackedUpFiles()` — walks the backup tree and restores each file to its original relative location, replacing the flat `RestoreFile` approach that only worked for single-module projects.
- **`setup.go`**: Move `getBuildPackages()` before the backup so all module dirs are known upfront; back up `go.work`/`go.work.sum` from cwd and `go.mod`/`go.sum` from each discovered module directory.
- **`cleanup.go`**: Use `RestoreAllBackedUpFiles()` instead of the hardcoded flat restore.
- **`util/shared_test.go`**: Unit tests for single-module backup, multi-module backup with nested path, and round-trip restore.

## Test plan

- [x] `TestBackupFileFromDir_SingleModule` — backs up root-level go.mod correctly
- [x] `TestBackupFileFromDir_MultiModule` — backs up nested module go.mod under namespaced path
- [x] `TestRestoreAllBackedUpFiles` — restores modified file back to original content
- [x] All existing tests pass (`go test ./tool/util/ ./tool/internal/setup/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)