### PR TITLE
test(integration): build once, run multiple times

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,12 +43,11 @@ Use this convention when a testcase exercises call rules that reference wrapper 
 
 Integration tests build real binaries with the `otelc` tool and run them against **in-process** dependencies (e.g. `httptest.Server`, in-process gRPC server, miniredis, testdb driver).
 
-Each test follows the same pattern:
+All test apps are built once in `TestMain` before any test runs (via `otelc go build`). Each test follows the same pattern:
 
-1. Build the test application with compile-time instrumentation.
-2. Start an in-memory OTLP collector.
-3. Run the instrumented binary against a local dependency.
-4. Assert on the exported spans and their semantic conventions.
+1. Start an in-memory OTLP collector.
+2. Run the pre-built instrumented binary against a local dependency.
+3. Assert on the exported spans and their semantic conventions.
 
 ## E2E Tests
 

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -18,10 +18,10 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	appDir := filepath.Join("..", "..", "demo", "app", "basic")
+	t.Parallel()
 
-	testutil.Build(t, appDir, "go", "build", "-a")
-	output := testutil.Run(t, appDir)
+	appDir := filepath.Join("..", "..", "demo", "app", "basic")
+	output := testutil.Run(t, appDir, nil)
 	expect := []string{
 		"Every1",
 		"Every3",

--- a/test/integration/db_client_test.go
+++ b/test/integration/db_client_test.go
@@ -14,170 +14,173 @@ import (
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/test/testutil"
 )
 
-func TestDBClientPing(t *testing.T) {
-	f := testutil.NewTestFixture(t)
+func TestDBClient(t *testing.T) {
+	t.Parallel()
 
-	f.BuildAndRun("dbclient", "-op=ping")
+	t.Run("Ping", func(t *testing.T) {
+		f := testutil.NewTestFixture(t)
 
-	span := f.RequireSingleSpan()
-	require.Equal(t, "PING", span.Name())
-	testutil.RequireDBClientSemconv(t, span,
-		"PING",
-		"ping",
-		"unknown", 0,
-		"testdb",
-	)
-}
+		f.Run("dbclient", "-op=ping")
 
-func TestDBClientExec(t *testing.T) {
-	f := testutil.NewTestFixture(t)
+		span := f.RequireSingleSpan()
+		require.Equal(t, "PING", span.Name())
+		testutil.RequireDBClientSemconv(t, span,
+			"PING",
+			"ping",
+			"unknown", 0,
+			"testdb",
+		)
+	})
 
-	f.BuildAndRun("dbclient", "-op=exec")
+	t.Run("Exec", func(t *testing.T) {
+		f := testutil.NewTestFixture(t)
 
-	span := f.RequireSingleSpan()
-	require.Equal(t, "INSERT", span.Name())
-	testutil.RequireDBClientSemconv(t, span,
-		"INSERT",
-		"INSERT INTO users (name, email) VALUES (?, ?)",
-		"unknown", 0,
-		"testdb",
-	)
-}
+		f.Run("dbclient", "-op=exec")
 
-func TestDBClientQuery(t *testing.T) {
-	f := testutil.NewTestFixture(t)
+		span := f.RequireSingleSpan()
+		require.Equal(t, "INSERT", span.Name())
+		testutil.RequireDBClientSemconv(t, span,
+			"INSERT",
+			"INSERT INTO users (name, email) VALUES (?, ?)",
+			"unknown", 0,
+			"testdb",
+		)
+	})
 
-	f.BuildAndRun("dbclient", "-op=query")
+	t.Run("Query", func(t *testing.T) {
+		f := testutil.NewTestFixture(t)
 
-	span := f.RequireSingleSpan()
-	require.Equal(t, "SELECT", span.Name())
-	testutil.RequireDBClientSemconv(t, span,
-		"SELECT",
-		"SELECT id, name FROM users WHERE name = ?",
-		"unknown", 0,
-		"testdb",
-	)
-}
+		f.Run("dbclient", "-op=query")
 
-func TestDBClientPrepareAndQuery(t *testing.T) {
-	f := testutil.NewTestFixture(t)
+		span := f.RequireSingleSpan()
+		require.Equal(t, "SELECT", span.Name())
+		testutil.RequireDBClientSemconv(t, span,
+			"SELECT",
+			"SELECT id, name FROM users WHERE name = ?",
+			"unknown", 0,
+			"testdb",
+		)
+	})
 
-	f.BuildAndRun("dbclient", "-op=prepare")
+	t.Run("PrepareAndQuery", func(t *testing.T) {
+		f := testutil.NewTestFixture(t)
 
-	// PrepareContext doesn't create a span directly, but stmt.QueryContext does
-	spans := testutil.AllSpans(f.Traces())
-	require.GreaterOrEqual(t, len(spans), 1, "Expected at least 1 span from prepared statement query")
+		f.Run("dbclient", "-op=prepare")
 
-	// Find the query span from stmt.QueryContext
-	stmtSpan := testutil.RequireSpan(t, f.Traces(), testutil.IsClient)
-	require.Equal(t, "SELECT", stmtSpan.Name())
-}
+		// PrepareContext doesn't create a span directly, but stmt.QueryContext does
+		spans := testutil.AllSpans(f.Traces())
+		require.GreaterOrEqual(t, len(spans), 1, "Expected at least 1 span from prepared statement query")
 
-func TestDBClientTransaction(t *testing.T) {
-	f := testutil.NewTestFixture(t)
+		// Find the query span from stmt.QueryContext
+		stmtSpan := testutil.RequireSpan(t, f.Traces(), testutil.IsClient)
+		require.Equal(t, "SELECT", stmtSpan.Name())
+	})
 
-	f.BuildAndRun("dbclient", "-op=tx")
+	t.Run("Transaction", func(t *testing.T) {
+		f := testutil.NewTestFixture(t)
 
-	spans := testutil.AllSpans(f.Traces())
-	// BeginTx -> ExecContext -> Commit = 3 spans
-	require.Equal(t, 3, len(spans), "Expected 3 spans for transaction: begin, exec, commit")
+		f.Run("dbclient", "-op=tx")
 
-	// Verify we have the expected span types
-	beginSpan := testutil.RequireSpan(t, f.Traces(),
-		testutil.IsClient,
-		testutil.HasAttribute("db.operation.name", "START"),
-	)
-	require.Equal(t, "START", beginSpan.Name())
+		spans := testutil.AllSpans(f.Traces())
+		// BeginTx -> ExecContext -> Commit = 3 spans
+		require.Equal(t, 3, len(spans), "Expected 3 spans for transaction: begin, exec, commit")
 
-	execSpan := testutil.RequireSpan(t, f.Traces(),
-		testutil.IsClient,
-		testutil.HasAttribute("db.operation.name", "INSERT"),
-	)
-	require.Equal(t, "INSERT", execSpan.Name())
+		beginSpan := testutil.RequireSpan(t, f.Traces(),
+			testutil.IsClient,
+			testutil.HasAttribute("db.operation.name", "START"),
+		)
+		require.Equal(t, "START", beginSpan.Name())
 
-	commitSpan := testutil.RequireSpan(t, f.Traces(),
-		testutil.IsClient,
-		testutil.HasAttribute("db.operation.name", "COMMIT"),
-	)
-	require.Equal(t, "COMMIT", commitSpan.Name())
-}
+		execSpan := testutil.RequireSpan(t, f.Traces(),
+			testutil.IsClient,
+			testutil.HasAttribute("db.operation.name", "INSERT"),
+		)
+		require.Equal(t, "INSERT", execSpan.Name())
 
-func TestDBClientAll(t *testing.T) {
-	f := testutil.NewTestFixture(t)
+		commitSpan := testutil.RequireSpan(t, f.Traces(),
+			testutil.IsClient,
+			testutil.HasAttribute("db.operation.name", "COMMIT"),
+		)
+		require.Equal(t, "COMMIT", commitSpan.Name())
+	})
 
-	f.BuildAndRun("dbclient",
-		"-driver=testdb",
-		"-dsn=user:pass@tcp(127.0.0.1:3306)/testdb?charset=utf8",
-		"-op=all",
-	)
+	t.Run("All", func(t *testing.T) {
+		f := testutil.NewTestFixture(t)
 
-	// "all" operation produces 7 spans:
-	//   PING (PingContext)
-	//   INSERT (ExecContext)
-	//   SELECT (QueryContext)
-	//   SELECT (Stmt.QueryContext via PrepareContext)
-	//   START (BeginTx)
-	//   INSERT (Tx.ExecContext)
-	//   COMMIT (Tx.Commit)
-	spans := testutil.AllSpans(f.Traces())
-	require.GreaterOrEqual(t, len(spans), 7, "Expected at least 7 spans")
+		f.Run("dbclient",
+			"-driver=testdb",
+			"-dsn=user:pass@tcp(127.0.0.1:3306)/testdb?charset=utf8",
+			"-op=all",
+		)
 
-	// For "testdb" driver, parseDSN returns an error (unknown driver),
-	// so beforeOpenInstrumentation falls back to "unknown" as the endpoint.
-	const serverAddr = "unknown"
+		// "all" operation produces 7 spans:
+		//   PING (PingContext)
+		//   INSERT (ExecContext)
+		//   SELECT (QueryContext)
+		//   SELECT (Stmt.QueryContext via PrepareContext)
+		//   START (BeginTx)
+		//   INSERT (Tx.ExecContext)
+		//   COMMIT (Tx.Commit)
+		spans := testutil.AllSpans(f.Traces())
+		require.GreaterOrEqual(t, len(spans), 7, "Expected at least 7 spans")
 
-	pingSpan := testutil.RequireSpan(t, f.Traces(),
-		testutil.IsClient,
-		testutil.HasAttribute(string(semconv.DBOperationNameKey), "PING"),
-	)
-	testutil.RequireDBClientSemconv(t, pingSpan,
-		"PING",
-		"ping",
-		serverAddr, 0,
-		"testdb",
-	)
+		// For "testdb" driver, parseDSN returns an error (unknown driver),
+		// so beforeOpenInstrumentation falls back to "unknown" as the endpoint.
+		const serverAddr = "unknown"
 
-	execSpan := testutil.RequireSpan(t, f.Traces(),
-		testutil.IsClient,
-		testutil.HasAttribute(string(semconv.DBQueryTextKey), "INSERT INTO users (name, email) VALUES (?, ?)"),
-	)
-	testutil.RequireDBClientSemconv(t, execSpan,
-		"INSERT",
-		"INSERT INTO users (name, email) VALUES (?, ?)",
-		serverAddr, 0,
-		"testdb",
-	)
+		pingSpan := testutil.RequireSpan(t, f.Traces(),
+			testutil.IsClient,
+			testutil.HasAttribute(string(semconv.DBOperationNameKey), "PING"),
+		)
+		testutil.RequireDBClientSemconv(t, pingSpan,
+			"PING",
+			"ping",
+			serverAddr, 0,
+			"testdb",
+		)
 
-	querySpan := testutil.RequireSpan(t, f.Traces(),
-		testutil.IsClient,
-		testutil.HasAttribute(string(semconv.DBQueryTextKey), "SELECT id, name FROM users WHERE name = ?"),
-	)
-	testutil.RequireDBClientSemconv(t, querySpan,
-		"SELECT",
-		"SELECT id, name FROM users WHERE name = ?",
-		serverAddr, 0,
-		"testdb",
-	)
+		execSpan := testutil.RequireSpan(t, f.Traces(),
+			testutil.IsClient,
+			testutil.HasAttribute(string(semconv.DBQueryTextKey), "INSERT INTO users (name, email) VALUES (?, ?)"),
+		)
+		testutil.RequireDBClientSemconv(t, execSpan,
+			"INSERT",
+			"INSERT INTO users (name, email) VALUES (?, ?)",
+			serverAddr, 0,
+			"testdb",
+		)
 
-	beginSpan := testutil.RequireSpan(t, f.Traces(),
-		testutil.IsClient,
-		testutil.HasAttribute(string(semconv.DBOperationNameKey), "START"),
-	)
-	testutil.RequireDBClientSemconv(t, beginSpan,
-		"START",
-		"START TRANSACTION",
-		serverAddr, 0,
-		"testdb",
-	)
+		querySpan := testutil.RequireSpan(t, f.Traces(),
+			testutil.IsClient,
+			testutil.HasAttribute(string(semconv.DBQueryTextKey), "SELECT id, name FROM users WHERE name = ?"),
+		)
+		testutil.RequireDBClientSemconv(t, querySpan,
+			"SELECT",
+			"SELECT id, name FROM users WHERE name = ?",
+			serverAddr, 0,
+			"testdb",
+		)
 
-	commitSpan2 := testutil.RequireSpan(t, f.Traces(),
-		testutil.IsClient,
-		testutil.HasAttribute(string(semconv.DBOperationNameKey), "COMMIT"),
-	)
-	testutil.RequireDBClientSemconv(t, commitSpan2,
-		"COMMIT",
-		"COMMIT",
-		serverAddr, 0,
-		"testdb",
-	)
+		beginSpan := testutil.RequireSpan(t, f.Traces(),
+			testutil.IsClient,
+			testutil.HasAttribute(string(semconv.DBOperationNameKey), "START"),
+		)
+		testutil.RequireDBClientSemconv(t, beginSpan,
+			"START",
+			"START TRANSACTION",
+			serverAddr, 0,
+			"testdb",
+		)
+
+		commitSpan := testutil.RequireSpan(t, f.Traces(),
+			testutil.IsClient,
+			testutil.HasAttribute(string(semconv.DBOperationNameKey), "COMMIT"),
+		)
+		testutil.RequireDBClientSemconv(t, commitSpan,
+			"COMMIT",
+			"COMMIT",
+			serverAddr, 0,
+			"testdb",
+		)
+	})
 }

--- a/test/integration/grpc_client_test.go
+++ b/test/integration/grpc_client_test.go
@@ -39,13 +39,15 @@ func TestGRPCClient(t *testing.T) {
 		},
 	}
 
+	testutil.BuildApp(t, "grpcclient")
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := testutil.NewTestFixture(t)
 			server := StartGRPCServer(t)
 
 			args := append([]string{"-addr=" + server.Addr}, tc.extraArgs...)
-			output := f.BuildAndRun("grpcclient", args...)
+			output := f.Run("grpcclient", args...)
 
 			require.Contains(t, output, tc.expectedOutput)
 			span := f.RequireSingleSpan()

--- a/test/integration/grpc_client_test.go
+++ b/test/integration/grpc_client_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestGRPCClient(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name           string
 		extraArgs      []string
@@ -38,8 +40,6 @@ func TestGRPCClient(t *testing.T) {
 			expectedOutput: "stream response",
 		},
 	}
-
-	testutil.BuildApp(t, "grpcclient")
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/integration/grpc_server_test.go
+++ b/test/integration/grpc_server_test.go
@@ -6,6 +6,7 @@
 package test
 
 import (
+	"fmt"
 	"io"
 	"testing"
 
@@ -17,6 +18,8 @@ import (
 )
 
 func TestGRPCServer(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name     string
 		method   string
@@ -38,16 +41,16 @@ func TestGRPCServer(t *testing.T) {
 		},
 	}
 
-	testutil.BuildApp(t, "grpcserver")
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := testutil.NewTestFixture(t)
+			port := testutil.FreePort(t)
+			addr := fmt.Sprintf("localhost:%d", port)
 
-			f.Start("grpcserver")
-			testutil.WaitForTCP(t, "localhost:50051")
+			f.Start("grpcserver", fmt.Sprintf("-port=%d", port))
+			testutil.WaitForTCP(t, addr)
 
-			client := NewGRPCClient(t, "localhost:50051")
+			client := NewGRPCClient(t, addr)
 			tc.exercise(t, client)
 			testutil.WaitForSpanFlush(t)
 

--- a/test/integration/grpc_server_test.go
+++ b/test/integration/grpc_server_test.go
@@ -38,11 +38,13 @@ func TestGRPCServer(t *testing.T) {
 		},
 	}
 
+	testutil.BuildApp(t, "grpcserver")
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := testutil.NewTestFixture(t)
 
-			f.BuildAndStart("grpcserver")
+			f.Start("grpcserver")
 			testutil.WaitForTCP(t, "localhost:50051")
 
 			client := NewGRPCClient(t, "localhost:50051")

--- a/test/integration/grpc_shutdown_test.go
+++ b/test/integration/grpc_shutdown_test.go
@@ -6,6 +6,7 @@
 package test
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,15 +28,17 @@ func TestGRPCServerTelemetryFlushOnSignal(t *testing.T) {
 	if util.IsWindows() {
 		t.Skip("SIGINT is not supported on windows")
 	}
+	t.Parallel()
 
 	f := testutil.NewTestFixture(t)
-	t.Setenv("OTEL_GO_SIMPLE_SPAN_PROCESSOR", "false")
+	f.SetEnv("OTEL_GO_SIMPLE_SPAN_PROCESSOR", "false")
 
-	f.Build("grpcserver")
-	cmd := startServerProcess(t, "-port=50052")
-	testutil.WaitForTCP(t, "localhost:50052")
+	port := testutil.FreePort(t)
+	addr := fmt.Sprintf("localhost:%d", port)
+	cmd := startServerProcess(t, f.Env(), fmt.Sprintf("-port=%d", port))
+	testutil.WaitForTCP(t, addr)
 
-	client := NewGRPCClient(t, "localhost:50052")
+	client := NewGRPCClient(t, addr)
 	client.SayHello(t, "ShutdownTest")
 
 	require.NoError(t, cmd.Process.Signal(os.Interrupt))
@@ -53,7 +56,7 @@ func TestGRPCServerTelemetryFlushOnSignal(t *testing.T) {
 }
 
 // startServerProcess starts the instrumented grpcserver app and returns the exec.Cmd.
-func startServerProcess(t *testing.T, args ...string) *exec.Cmd {
+func startServerProcess(t *testing.T, env []string, args ...string) *exec.Cmd {
 	t.Helper()
 
 	pwd, err := os.Getwd()
@@ -67,7 +70,7 @@ func startServerProcess(t *testing.T, args ...string) *exec.Cmd {
 
 	cmd := exec.CommandContext(t.Context(), appName, args...)
 	cmd.Dir = appDir
-	cmd.Env = os.Environ()
+	cmd.Env = env
 
 	require.NoError(t, cmd.Start())
 	t.Cleanup(func() {

--- a/test/integration/http_client_test.go
+++ b/test/integration/http_client_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestHTTPClient(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name       string
 		queryParam string
@@ -34,7 +36,7 @@ func TestHTTPClient(t *testing.T) {
 			f := testutil.NewTestFixture(t)
 			server := StartHTTPServerWithResponse(t, 200, `{"message":"Hello"}`)
 
-			f.BuildAndRun("httpclient", "-addr="+server.URL, "-name="+tc.queryParam)
+			f.Run("httpclient", "-addr="+server.URL, "-name="+tc.queryParam)
 
 			span := f.RequireSingleSpan()
 			expectedURL := server.URL + "/hello?name=" + tc.queryParam

--- a/test/integration/http_server_test.go
+++ b/test/integration/http_server_test.go
@@ -16,32 +16,31 @@ import (
 )
 
 func TestHTTPServer(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name   string
 		scheme string
-		port   int
 		path   string
 		method string
 	}{
 		{
 			name:   "basic",
 			scheme: "http",
-			port:   8081,
 			path:   "/hello",
 			method: "GET",
 		},
 	}
 
-	testutil.BuildApp(t, "httpserver")
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := testutil.NewTestFixture(t)
+			port := testutil.FreePort(t)
 
-			f.Start("httpserver", fmt.Sprintf("-port=%d", tc.port))
-			testutil.WaitForTCP(t, fmt.Sprintf("127.0.0.1:%d", tc.port))
+			f.Start("httpserver", fmt.Sprintf("-port=%d", port))
+			testutil.WaitForTCP(t, fmt.Sprintf("127.0.0.1:%d", port))
 
-			url := fmt.Sprintf("%s://127.0.0.1:%d%s?name=test", tc.scheme, tc.port, tc.path)
+			url := fmt.Sprintf("%s://127.0.0.1:%d%s?name=test", tc.scheme, port, tc.path)
 			resp, err := http.Get(url)
 			require.NoError(t, err)
 			defer resp.Body.Close()
@@ -56,7 +55,7 @@ func TestHTTPServer(t *testing.T) {
 				tc.path,
 				tc.scheme,
 				200,
-				int64(tc.port),
+				int64(port),
 				"127.0.0.1",
 				"Go-http-client/1.1",
 				"1.1",

--- a/test/integration/http_server_test.go
+++ b/test/integration/http_server_test.go
@@ -32,11 +32,13 @@ func TestHTTPServer(t *testing.T) {
 		},
 	}
 
+	testutil.BuildApp(t, "httpserver")
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := testutil.NewTestFixture(t)
 
-			f.BuildAndStart("httpserver", fmt.Sprintf("-port=%d", tc.port))
+			f.Start("httpserver", fmt.Sprintf("-port=%d", tc.port))
 			testutil.WaitForTCP(t, fmt.Sprintf("127.0.0.1:%d", tc.port))
 
 			url := fmt.Sprintf("%s://127.0.0.1:%d%s?name=test", tc.scheme, tc.port, tc.path)

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -1,0 +1,83 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/test/testutil"
+)
+
+func TestMain(m *testing.M) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "TestMain: get working dir:", err)
+		os.Exit(1)
+	}
+
+	appsRoot := filepath.Join(pwd, "..", "apps")
+	entries, err := os.ReadDir(appsRoot)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "TestMain: read apps dir:", err)
+		os.Exit(1)
+	}
+
+	appDirs := make([]string, 0, len(entries)+1)
+	for _, e := range entries {
+		if e.IsDir() {
+			appDirs = append(appDirs, filepath.Join(appsRoot, e.Name()))
+		}
+	}
+	// TestBasic builds and runs the basic demo from a different tree.
+	appDirs = append(appDirs, filepath.Join(pwd, "..", "..", "demo", "app", "basic"))
+
+	if err := buildAll(appDirs); err != nil {
+		fmt.Fprintln(os.Stderr, "TestMain: pre-build failed:", err)
+		cleanupAll(appDirs)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	cleanupAll(appDirs)
+	os.Exit(code)
+}
+
+// buildAll runs otelc go build for every appDir concurrently. Returns the
+// first error if any build fails.
+func buildAll(appDirs []string) error {
+	var (
+		wg       sync.WaitGroup
+		errMu    sync.Mutex
+		firstErr error
+	)
+	ctx := context.Background()
+	for _, dir := range appDirs {
+		wg.Add(1)
+		go func(dir string) {
+			defer wg.Done()
+			if err := testutil.BuildAppAt(ctx, dir); err != nil {
+				errMu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				errMu.Unlock()
+			}
+		}(dir)
+	}
+	wg.Wait()
+	return firstErr
+}
+
+func cleanupAll(appDirs []string) {
+	for _, dir := range appDirs {
+		testutil.CleanupAppAt(dir)
+	}
+}

--- a/test/integration/otel_sdk_test.go
+++ b/test/integration/otel_sdk_test.go
@@ -21,6 +21,8 @@ import (
 //   - otel trace SpanFromContext hook (spanFromContextOnExit reads from GLS)
 //   - net/http server instrumentation (creates the span)
 func TestOtelSDKSpanFromContext(t *testing.T) {
+	t.Parallel()
+
 	f := testutil.NewTestFixture(t)
 
 	var output string
@@ -29,7 +31,7 @@ func TestOtelSDKSpanFromContext(t *testing.T) {
 			t.Logf("otelsdk output:\n%s", output)
 		}
 	}()
-	output = f.BuildAndRun("otelsdk")
+	output = f.Run("otelsdk")
 	require.Contains(t, output, "OTEL_SDK_TEST: span valid",
 		"SpanFromContext(context.Background()) should return a valid span from GLS")
 	require.Contains(t, output, "traceID=")

--- a/test/integration/redis_client_test.go
+++ b/test/integration/redis_client_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestRedisClient(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name string
 	}{
@@ -28,7 +30,7 @@ func TestRedisClient(t *testing.T) {
 			f := testutil.NewTestFixture(t)
 			server := StartRedisServer(t)
 
-			output := f.BuildAndRun("redisclient", "-addr="+server.Addr())
+			output := f.Run("redisclient", "-addr="+server.Addr())
 			require.Contains(t, output, "testvalue")
 
 			spans := testutil.AllSpans(f.Traces())

--- a/test/testutil/fixture.go
+++ b/test/testutil/fixture.go
@@ -20,6 +20,11 @@ type TestFixture struct {
 
 	serviceName   string
 	skipCollector bool
+
+	// env holds per-fixture environment overrides (KEY=VALUE form). Applied
+	// when spawning processes via f.Start/f.Run so parallel tests do not
+	// race on os.Environ via t.Setenv.
+	env []string
 }
 
 type TestFixtureOption func(*TestFixture)
@@ -36,9 +41,10 @@ func WithoutCollector() TestFixtureOption {
 	}
 }
 
-// NewTestFixture creates a new test fixture.
-// It automatically starts the collector and sets up OTEL env vars.
-// Tests can override env vars after calling this if needed.
+// NewTestFixture creates a new test fixture. It starts a collector (unless
+// disabled) and configures OTEL env vars that will be applied to processes
+// spawned via this fixture. The env is fixture-local — it does not touch
+// os.Environ, which keeps the fixture safe for use under t.Parallel().
 func NewTestFixture(t *testing.T, opts ...TestFixtureOption) *TestFixture {
 	f := &TestFixture{
 		t:           t,
@@ -53,23 +59,47 @@ func NewTestFixture(t *testing.T, opts ...TestFixtureOption) *TestFixture {
 	require.NoError(t, err)
 	f.appsDir = filepath.Join(pwd, "..", "apps")
 
-	// Start collector unless skipped
 	if !f.skipCollector {
 		f.collector = StartCollector(t)
 
-		// Configure OTEL env vars (can be overridden by test after this)
-		// Clear signal-specific endpoints to ensure OTEL_EXPORTER_OTLP_ENDPOINT takes precedence
-		t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
-		t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
-		t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "")
-		t.Setenv("OTEL_SERVICE_NAME", f.serviceName)
-		t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
-		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", f.collector.URL)
-		t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
-		t.Setenv("OTEL_GO_SIMPLE_SPAN_PROCESSOR", "true")
+		// Clear signal-specific endpoints so OTEL_EXPORTER_OTLP_ENDPOINT wins
+		f.SetEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+		f.SetEnv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
+		f.SetEnv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "")
+		f.SetEnv("OTEL_SERVICE_NAME", f.serviceName)
+		f.SetEnv("OTEL_TRACES_EXPORTER", "otlp")
+		f.SetEnv("OTEL_EXPORTER_OTLP_ENDPOINT", f.collector.URL)
+		f.SetEnv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+		f.SetEnv("OTEL_GO_SIMPLE_SPAN_PROCESSOR", "true")
 	}
 
 	return f
+}
+
+// SetEnv adds (or replaces) an environment override for processes spawned by
+// this fixture. Unlike t.Setenv it does not modify os.Environ, so it is safe
+// under t.Parallel().
+func (f *TestFixture) SetEnv(key, value string) {
+	prefix := key + "="
+	entry := prefix + value
+	for i, e := range f.env {
+		if len(e) >= len(prefix) && e[:len(prefix)] == prefix {
+			f.env[i] = entry
+			return
+		}
+	}
+	f.env = append(f.env, entry)
+}
+
+// Env returns the full environment to pass to a spawned subprocess:
+// os.Environ() merged with the fixture's overrides (overrides win on dup keys
+// because exec.Cmd respects the last occurrence).
+func (f *TestFixture) Env() []string {
+	base := os.Environ()
+	out := make([]string, 0, len(base)+len(f.env))
+	out = append(out, base...)
+	out = append(out, f.env...)
+	return out
 }
 
 // Traces returns the collected traces for assertions.
@@ -87,51 +117,35 @@ func (f *TestFixture) resolveAppPath(appName string) string {
 	return filepath.Join(f.appsDir, appName)
 }
 
-// BuildApp builds a named app from test/apps/ using the parent test's lifetime.
-// Use this in table-driven tests to build once and call Start/Run per subtest.
-func BuildApp(t *testing.T, appName string) {
-	t.Helper()
-	pwd, err := os.Getwd()
-	require.NoError(t, err)
-	Build(t, filepath.Join(pwd, "..", "apps", appName), "go", "build", "-a")
-}
-
-// Build builds a test application from test/apps/ with the instrumentation tool.
-func (f *TestFixture) Build(appName string) {
-	Build(f.t, f.resolveAppPath(appName), "go", "build", "-a")
-}
-
 // Server represents a running server process.
 type Server struct {
 	t       *testing.T
 	appPath string
 }
 
-// Start starts a test application from test/apps/ and waits for it to be ready.
+// Start starts a pre-built test application from test/apps/. The binary is
+// expected to exist (TestMain pre-builds all apps).
 func (f *TestFixture) Start(appName string, args ...string) *Server {
-	fullPath := f.resolveAppPath(appName)
-	Start(f.t, fullPath, args...)
-
-	return &Server{
-		t:       f.t,
-		appPath: appName,
-	}
+	Start(f.t, f.resolveAppPath(appName), f.Env(), args...)
+	return &Server{t: f.t, appPath: appName}
 }
 
-// Run runs a test application from test/apps/ and waits for it to complete.
+// Run runs a pre-built test application and returns its output.
 func (f *TestFixture) Run(appName string, args ...string) string {
-	return Run(f.t, f.resolveAppPath(appName), args...)
+	return Run(f.t, f.resolveAppPath(appName), f.Env(), args...)
 }
 
-// BuildAndStart builds and starts a test application
+// BuildAndStart builds the named app and then starts it. Kept for e2e test
+// backward compatibility — integration tests use pre-built binaries from TestMain.
 func (f *TestFixture) BuildAndStart(appName string, args ...string) *Server {
-	f.Build(appName)
+	Build(f.t, f.resolveAppPath(appName), "go", "build", "-a")
 	return f.Start(appName, args...)
 }
 
-// BuildAndRun builds and runs a test application
+// BuildAndRun builds the named app and runs it, returning its output. Kept for
+// e2e test backward compatibility — integration tests use pre-built binaries.
 func (f *TestFixture) BuildAndRun(appName string, args ...string) string {
-	f.Build(appName)
+	Build(f.t, f.resolveAppPath(appName), "go", "build", "-a")
 	return f.Run(appName, args...)
 }
 

--- a/test/testutil/fixture.go
+++ b/test/testutil/fixture.go
@@ -87,6 +87,15 @@ func (f *TestFixture) resolveAppPath(appName string) string {
 	return filepath.Join(f.appsDir, appName)
 }
 
+// BuildApp builds a named app from test/apps/ using the parent test's lifetime.
+// Use this in table-driven tests to build once and call Start/Run per subtest.
+func BuildApp(t *testing.T, appName string) {
+	t.Helper()
+	pwd, err := os.Getwd()
+	require.NoError(t, err)
+	Build(t, filepath.Join(pwd, "..", "apps", appName), "go", "build", "-a")
+}
+
 // Build builds a test application from test/apps/ with the instrumentation tool.
 func (f *TestFixture) Build(appName string) {
 	Build(f.t, f.resolveAppPath(appName), "go", "build", "-a")

--- a/test/testutil/fixture.go
+++ b/test/testutil/fixture.go
@@ -6,6 +6,7 @@ package testutil
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -83,7 +84,7 @@ func (f *TestFixture) SetEnv(key, value string) {
 	prefix := key + "="
 	entry := prefix + value
 	for i, e := range f.env {
-		if len(e) >= len(prefix) && e[:len(prefix)] == prefix {
+		if strings.HasPrefix(e, prefix) {
 			f.env[i] = entry
 			return
 		}

--- a/test/testutil/infra.go
+++ b/test/testutil/infra.go
@@ -5,6 +5,7 @@ package testutil
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,66 +26,110 @@ const (
 // This infrastructure is used to actually build the application with the otelc
 // instrumentation tool, execute the application and verify the output.
 
-func newCmd(ctx context.Context, dir string, args ...string) *exec.Cmd {
-	path := args[0]
-	args = args[1:]
-	cmd := exec.CommandContext(ctx, path, args...)
+// newCmd builds an exec.Cmd in dir with the given env. If env is nil, the
+// parent process env is used.
+func newCmd(ctx context.Context, dir string, env []string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.Dir = dir
-	cmd.Env = os.Environ()
+	if env == nil {
+		cmd.Env = os.Environ()
+	} else {
+		cmd.Env = env
+	}
 	return cmd
 }
 
-// Build builds the application with the instrumentation tool.
-func Build(t *testing.T, appDir string, args ...string) {
+// otelcPath returns the absolute path to the otelc binary, assuming the
+// caller's working directory is a sibling of the repo's otelc output.
+func otelcPath() (string, error) {
 	binName := otelcBinName
 	if util.IsWindows() {
 		binName += ".exe"
 	}
 	pwd, err := os.Getwd()
-	require.NoError(t, err)
-	otelcPath := filepath.Join(pwd, "..", "..", binName)
-
-	// Use a consistent binary name for all test apps
-	outputName := appBinName
-	if util.IsWindows() {
-		outputName += ".exe"
+	if err != nil {
+		return "", err
 	}
+	return filepath.Join(pwd, "..", "..", binName), nil
+}
 
-	args = append(args, "-o", outputName)
-	args = append([]string{otelcPath}, args...)
+// appOutputName returns the platform-specific name used for built test binaries.
+func appOutputName() string {
+	if util.IsWindows() {
+		return appBinName + ".exe"
+	}
+	return appBinName
+}
 
-	cmd := newCmd(t.Context(), appDir, args...)
+// Build builds the application with the instrumentation tool. The built binary
+// is registered for cleanup via t.Cleanup.
+func Build(t *testing.T, appDir string, args ...string) {
+	t.Helper()
+	otelc, err := otelcPath()
+	require.NoError(t, err)
+
+	output := appOutputName()
+	args = append(args, "-o", output)
+	args = append([]string{otelc}, args...)
+
+	cmd := newCmd(t.Context(), appDir, nil, args...)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 	t.Cleanup(func() {
-		os.Remove(filepath.Join(appDir, outputName))
+		_ = os.Remove(filepath.Join(appDir, output))
 	})
 }
 
-// Run runs the application and returns the output.
-// It waits for the application to complete.
-func Run(t *testing.T, dir string, args ...string) string {
+// BuildAppAt builds the app at the given directory using context ctx. Intended
+// for use from TestMain where no *testing.T is available. The caller is
+// responsible for cleaning up the built binary via CleanupAppAt.
+func BuildAppAt(ctx context.Context, appDir string) error {
+	otelc, err := otelcPath()
+	if err != nil {
+		return fmt.Errorf("locate otelc: %w", err)
+	}
+
+	output := appOutputName()
+	args := []string{otelc, "go", "build", "-a", "-o", output}
+
+	cmd := newCmd(ctx, appDir, nil, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("otelc build in %s: %w\n%s", appDir, err, string(out))
+	}
+	return nil
+}
+
+// CleanupAppAt removes the binary that BuildAppAt produced in appDir.
+func CleanupAppAt(appDir string) {
+	_ = os.Remove(filepath.Join(appDir, appOutputName()))
+}
+
+// Run runs the application and returns the output. It waits for the
+// application to complete. If env is nil, the parent process env is used.
+func Run(t *testing.T, dir string, env []string, args ...string) string {
+	t.Helper()
 	appName := "./" + appBinName
 	if util.IsWindows() {
 		appName += ".exe"
 	}
-	cmd := newCmd(t.Context(), dir, append([]string{appName}, args...)...)
+	cmd := newCmd(t.Context(), dir, env, append([]string{appName}, args...)...)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 	return string(out)
 }
 
-// Start starts the application but does not wait for it to complete.
-// It returns the command and the combined output pipe(stdout and stderr).
-func Start(t *testing.T, dir string, args ...string) {
+// Start starts the application but does not wait for it to complete. If env
+// is nil, the parent process env is used.
+func Start(t *testing.T, dir string, env []string, args ...string) {
+	t.Helper()
 	appName := "./" + appBinName
 	if util.IsWindows() {
 		appName += ".exe"
 	}
-	cmd := newCmd(t.Context(), dir, append([]string{appName}, args...)...)
+	cmd := newCmd(t.Context(), dir, env, append([]string{appName}, args...)...)
 	cmd.Stderr = cmd.Stdout // redirect stderr to stdout for easier debugging
-	err := cmd.Start()
-	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
 	t.Cleanup(func() {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()

--- a/test/testutil/readiness.go
+++ b/test/testutil/readiness.go
@@ -34,3 +34,15 @@ func WaitForSpanFlush(t *testing.T) {
 	t.Helper()
 	time.Sleep(200 * time.Millisecond)
 }
+
+// FreePort returns a port the OS just assigned for "localhost:0". The
+// listener is closed before returning, so the test app can bind to it.
+// There is a tiny race window between close and rebind; acceptable for CI.
+func FreePort(t *testing.T) int {
+	t.Helper()
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	port := lis.Addr().(*net.TCPAddr).Port
+	require.NoError(t, lis.Close())
+	return port
+}


### PR DESCRIPTION
Goal --> reduce integration test times

Lets build once and run it multiple times + integration test parallelization

Related and unblocks https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pull/501

## Benchmark

> Baseline: [run #26338231667](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/actions/runs/26338231667) · This PR: [run #26540418585](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/actions/runs/26540418585)
> _Runner variance applies (different days). All jobs ran on the same runner class._

| Job | Before | After | Δ |
|---|---|---|---|
| Coverage Integration Tests (ubuntu-latest) | 8m 5s | 4m 2s | **-4m 3s (↓ 50%)** |
| Integration Tests (ubuntu-latest / amd64) | 8m 4s | 5m 3s | **-3m 1s (↓ 37%)** |
| Integration Tests (ubuntu-22.04-arm / arm64) | 5m 46s | 3m 28s | **-2m 18s (↓ 40%)** |
| Integration Tests (macos-latest / arm64) | 7m 13s | 4m 13s | **-3m 0s (↓ 42%)** |
| Integration Tests (windows-latest / amd64) | 12m 40s | 8m 5s | **-4m 35s (↓ 36%)** |