### PR TITLE
fix(bench): clean up runner scratch space after codspeed job

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -33,6 +33,21 @@ jobs:
         with:
           mode: walltime
           run: make benchmark/codspeed BENCH_TIME=5x
+      - name: Cleanup runner scratch space
+        if: always()
+        run: |
+          set -u
+          # Remove workspace artifacts left by the bench's `go build -a` loops.
+          # The Makefile EXIT trap covers the success path; this step covers
+          # cases where the CodSpeed action was cancelled before the trap fires.
+          rm -rf .otelc-build test/bench/scenarios/*/app test/bench/scenarios/*/.otelc-build || true
+          # Remove Go toolchain scratch dirs created under /tmp by our job.
+          # Scoped to files owned by the current user so we don't touch other
+          # SIGs' artifacts; self-hosted runners serialise jobs so concurrent
+          # writes to these paths from another job are not expected.
+          find /tmp -maxdepth 1 -user "$(id -un)" -name 'go-build*' -exec rm -rf {} + 2>/dev/null || true
+          # Log free space so regressions are visible in CI logs.
+          df -h /tmp /
 
   # Fails if any scenario's otelc overhead exceeds 150% of the plain baseline.
   overhead-threshold:

--- a/Makefile
+++ b/Makefile
@@ -356,6 +356,7 @@ BENCH_MAX_OVERHEAD_PCT ?= 150
 
 benchmark/codspeed: build ## Run compile-time benchmarks using Go testing.B (for CodSpeed walltime)
 	cd $(BENCH_DIR) && \
+	trap 'rm -rf $(CURDIR)/$(BENCH_SCENARIOS_DIR)/*/app $(CURDIR)/$(BENCH_SCENARIOS_DIR)/*/.otelc-build $(CURDIR)/.otelc-build' EXIT; \
 	OTELC_BIN=$(CURDIR)/$(BINARY_NAME) \
 	BENCH_SCENARIOS_DIR=$(CURDIR)/$(BENCH_SCENARIOS_DIR) \
 	go test -v -run=^$$ -bench=. -benchtime=$(BENCH_TIME)


### PR DESCRIPTION
## Summary

Addresses [open-telemetry/community#3461](https://github.com/open-telemetry/community/issues/3461).

The shared bare-metal benchmark runner (`oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24`) hit `No space left on device` twice (April and May 2026). The `/tmp` volume was the remaining unsolved vector (Docker overlay growth was addressed separately in [community#3484](https://github.com/open-telemetry/community/pull/3484)).

Our `codspeed` job is one of the contributors: `BenchmarkCompile` runs `go build -a` in a tight loop (`BENCH_TIME=5x`, 3 scenarios × 2 variants) with `GOGC=off`. Each `go build` invocation leaves a `/tmp/go-build*` scratch directory that the Go toolchain only removes on a clean exit. Panics, signals, or a cancelled CodSpeed action strand these.

A container-based approach was considered ([#539](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pull/539)) but rejected by @kakkoyun: "we deliberately don't want to use containers for these benchmarks." This PR follows the maintainer-sanctioned direction of cleaning up after each run.

## Changes

Two complementary layers of defence:

**`Makefile` — EXIT trap in `benchmark/codspeed`**

An `EXIT` trap fires whenever the `go test` process terminates (success, failure, signal). It removes:
- `test/bench/scenarios/*/app` — compiled binaries left by each scenario's `go build -a`
- `test/bench/scenarios/*/.otelc-build/` — otelc working directories created per scenario
- `.otelc-build/` at repo root — any otelc artefacts from the outer build

**`.github/workflows/benchmark.yaml` — `if: always()` post-step**

A workflow step that runs unconditionally after `Run benchmarks`, covering the edge case where the CodSpeed action is cancelled before the trap can fire. It:
- Removes the same workspace paths as the trap
- Removes `/tmp/go-build*` owned by the runner user (scoped to avoid touching other SIGs' files
- Prints Filesystem      Size  Used Avail Use% Mounted on
/dev/disk3s1s1  461G  376G   85G  82% /
/dev/disk3s1s1  461G  376G   85G  82% / so disk-growth regressions are visible in job output

Neither layer touches ,  logs, or any paths not owned by our job.

## Test plan

- [ ]  on this branch once merged to confirm the cleanup step runs and Filesystem      Size  Used Avail Use% Mounted on
/dev/disk3s1s1  461G  376G   85G  82% / shows reclaimed space
- [ ] Confirm CodSpeed walltime numbers are not affected (cleanup runs *after* measurement)

Made with [Cursor](https://cursor.com)
EOF
)