### PR TITLE
fix(tools/conventionalcommit): use GetLogin instead of GetLocation for repo owner

### DIFF
--- a/.github/tools/conventionalcommit/main.go
+++ b/.github/tools/conventionalcommit/main.go
@@ -157,7 +157,7 @@ func cleanupOldComments(ctx context.Context, client *github.Client, pr *github.P
 
 	return func() {
 		repo := pr.GetBase().GetRepo()
-		prOwner := repo.GetOwner().GetLocation()
+		prOwner := repo.GetOwner().GetLogin()
 		prRepo := repo.GetName()
 		for _, comment := range oldComments {
 			client.Issues.DeleteComment(ctx, prOwner, prRepo, comment.GetID())
@@ -169,7 +169,7 @@ func findExistingToolComments(ctx context.Context, client *github.Client, pr *gi
 	opts := &github.IssueListCommentsOptions{}
 
 	repo := pr.GetBase().GetRepo()
-	prOwner := repo.GetOwner().GetLocation()
+	prOwner := repo.GetOwner().GetLogin()
 	prRepo := repo.GetName()
 	prNumber := pr.GetNumber()
 


### PR DESCRIPTION

cleanupOldComments and findExistingToolComments were calling repo.GetOwner().GetLocation() to obtain the repository owner's identifier. GetLocation() returns the user's profile location string (e.g. city, country), not their GitHub login name, so the API calls to DeleteComment and ListComments were being made with an incorrect owner value.

Replace both call sites with GetLogin(), which is already used correctly in createReviewComment for the same purpose.

Fixes #547

Assisted-by: Antigravity (Google DeepMind)

<!--
Thank you for contributing to OpenTelemetry Go Compile Instrumentation!

INSTRUCTIONS:
1. Fill in the description and motivation sections below
2. Complete the checklist before submitting
3. Ensure PR title follows conventional commits format (enforced by CI)

PR TITLE FORMAT (required):
  type(scope): description

  Types: chore, doc, docs, feat, fix, release, refactor, test
  Scopes: tool, pkg, demo, test, docs

  Examples:
  - feat(pkg): add gRPC client instrumentation
  - fix(tool): resolve hook signature matching issue
  - docs(api): update instrumenter interface documentation
  - refactor(pkg): simplify attribute extractor composition

BEFORE SUBMITTING:
  make format  # Format Go code and YAML files
  make lint    # Run all linters
  make test    # Run all tests (unit + integration + e2e)

For detailed contribution guidelines, see CONTRIBUTING.md
For available make targets, run: make help
-->

## Description

<!-- What changes does this PR introduce? -->

## Motivation

<!-- Why is this change needed? What problem does it solve? -->

Fixes #<!-- issue number -->

---

## Checklist

- [ ] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [ ] Code formatted: `make format`
- [ ] Linters pass: `make lint`
- [ ] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
