### PR TITLE
feat(tool): add is_test where.file predicate for test package filtering

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -114,13 +114,22 @@ instrument_sql_exec:
 
 ### `where.file` semantics
 
-- Predicate keys: `has_func`, `has_recv`, `has_struct`, `has_directive`.
+- Predicate keys: `has_func`, `has_recv`, `has_struct`, `has_directive`, `is_test`.
   Combinator keys: `all-of`, `one-of`, `not`.
 - `has_recv` inside `where.file` narrows `has_func` to a specific receiver type.
+- `is_test` is a tri-state boolean that gates on whether the file belongs to a
+  test build — a compilation the Go toolchain produces only under `go test` (a
+  package augmented with its `_test.go` files, an external `xxx_test` package,
+  or the generated test-main runner). `is_test: true` matches only test builds,
+  `is_test: false` only non-test builds, and omitting it applies no filter. It
+  takes effect when building through `otelc go test`; a plain `otelc go build`
+  never produces test builds. Production code in a package whose tests are all
+  external (`package xxx_test`, no in-package `_test.go`) shares a single
+  compile with normal builds, so `is_test` cannot gate that code.
 - Exactly one leaf predicate must be active per `where.file` node;
   compositions are expressed via `all-of` / `one-of` / `not`.
 - During the setup phase, leaf predicates (`has_func`, `has_recv`,
-  `has_struct`) and the `where.file` combinators documented below are
+  `has_struct`, `is_test`) and the `where.file` combinators documented below are
   executed. `has_directive`, and combinators placed at the top level of
   `where` (outside `where.file`), are validated but return a descriptive
   "not yet supported" error at build time.

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -48,8 +48,10 @@ const (
 	testdataDir        = "testdata"
 	goldenDir          = "golden"
 	sourceFileName     = "source.go"
+	sourceTestFileName = "source_test.go"
 	rulesFileName      = "rules.yml"
 	mainGoFileName     = "main.go"
+	mainTestFileName   = "main_test.go"
 	mainPackage        = "main"
 	buildID            = "foo/bar"
 	compiledOutput     = "_pkg_.a"
@@ -79,13 +81,24 @@ func runTest(t *testing.T, testName string) {
 		slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})),
 	)
 
-	sourceFile := filepath.Join(tempDir, mainGoFileName)
-	// Each test case must provide its own source.go in its golden directory.
-	testSpecificSource := filepath.Join(testdataDir, goldenDir, testName, sourceFileName)
-	require.NoError(t, util.CopyFile(testSpecificSource, sourceFile),
-		"missing source.go for test %q at %s", testName, testSpecificSource)
+	// Each test case provides its source as source.go (a normal build) or
+	// source_test.go (a test build — a file the Go toolchain only compiles
+	// under `go test`). The chosen name is preserved into the temp dir so the
+	// compiled unit is genuinely a _test.go file, which is what is_test gates
+	// on. This mirrors setup.isTestBuild: test-ness is a source-set property,
+	// not an import-path suffix.
+	srcName, compiledName := sourceFileName, mainGoFileName
+	if testSrc := filepath.Join(testdataDir, goldenDir, testName, sourceTestFileName); util.PathExists(testSrc) {
+		srcName, compiledName = sourceTestFileName, mainTestFileName
+	}
+	isTest := strings.HasSuffix(compiledName, "_test.go")
 
-	ruleSet := loadRulesYAML(t, testName, sourceFile)
+	sourceFile := filepath.Join(tempDir, compiledName)
+	testSpecificSource := filepath.Join(testdataDir, goldenDir, testName, srcName)
+	require.NoError(t, util.CopyFile(testSpecificSource, sourceFile),
+		"missing %s for test %q at %s", srcName, testName, testSpecificSource)
+
+	ruleSet := loadRulesYAML(t, testName, sourceFile, isTest)
 	writeMatchedJSON(ruleSet)
 
 	testcaseDir := filepath.Join(testdataDir, goldenDir, testName)
@@ -104,7 +117,7 @@ func runTest(t *testing.T, testName string) {
 	verifyGoldenFiles(t, tempDir, testName)
 }
 
-func loadRulesYAML(t *testing.T, testName, sourceFile string) *rule.InstRuleSet {
+func loadRulesYAML(t *testing.T, testName, sourceFile string, isTest bool) *rule.InstRuleSet {
 	data, err := os.ReadFile(filepath.Join(testdataDir, goldenDir, testName, rulesFileName))
 	require.NoError(t, err)
 
@@ -147,7 +160,7 @@ func loadRulesYAML(t *testing.T, testName, sourceFile string) *rule.InstRuleSet 
 			// that setup.preciseMatching would evaluate is applied inline here.
 			// A rule whose file predicate does not match the source is skipped,
 			// exactly as it would be gated out during matching.
-			if !whereFileMatches(t, ruleData, sourceTree) {
+			if !whereFileMatches(t, ruleData, isTest, sourceTree) {
 				continue
 			}
 
@@ -186,7 +199,11 @@ func loadRulesYAML(t *testing.T, testName, sourceFile string) *rule.InstRuleSet 
 // builds the matched rule set by hand (no setup phase), so this keeps fixtures
 // honest: a rule whose file filter does not match is gated out and produces no
 // instrumentation. The caller parses the tree once and shares it across rules.
-func whereFileMatches(t *testing.T, ruleData []byte, tree *dst.File) bool {
+//
+// isTest reports whether the fixture is a test build (its source is a
+// source_test.go file), mirroring setup.isTestBuild; the is_test predicate is
+// evaluated against it.
+func whereFileMatches(t *testing.T, ruleData []byte, isTest bool, tree *dst.File) bool {
 	t.Helper()
 
 	var probe struct {
@@ -197,20 +214,23 @@ func whereFileMatches(t *testing.T, ruleData []byte, tree *dst.File) bool {
 		return true
 	}
 
-	return fileFilterMatches(t, probe.Where.File, tree)
+	return fileFilterMatches(t, probe.Where.File, isTest, tree)
 }
 
 // fileFilterMatches reports whether a where.file predicate matches the parsed
-// source. It covers the predicates exercised by golden fixtures: all-of and
-// one-of composition plus has_func / has_struct leaves. Filter compilation and
-// match semantics are unit-tested in tool/internal/setup; this is a lightweight
-// stand-in for the golden harness only.
+// source. It covers the predicates exercised by golden fixtures: all-of, one-of
+// and not composition, the has_func / has_struct leaves, and is_test. Filter
+// compilation and match semantics are unit-tested in tool/internal/setup; this
+// is a lightweight stand-in for the golden harness only.
+//
+// isTest reports whether the fixture is a test build, against which the is_test
+// predicate is evaluated (mirrors setup.MatchContext.IsTest).
 //
 // Any predicate this evaluator does not model is rejected with t.Fatalf rather
 // than silently treated as a match: setup.buildFile errors on such predicates,
 // so silently matching here would let a fixture certify instrumentation output
 // that production could never produce.
-func fileFilterMatches(t *testing.T, def *rule.FilterDef, tree *dst.File) bool {
+func fileFilterMatches(t *testing.T, def *rule.FilterDef, isTest bool, tree *dst.File) bool {
 	t.Helper()
 	// Mirror setup.buildFile's exclusivity rule: a combinator owns the node, so
 	// combining it with a sibling leaf or another combinator is a build-time
@@ -222,10 +242,18 @@ func fileFilterMatches(t *testing.T, def *rule.FilterDef, tree *dst.File) bool {
 			combinators++
 		}
 	}
-	leaf := def.HasFunc != "" || def.HasRecv != "" || def.HasStruct != "" || def.HasDirective != ""
+	leaf := def.HasFunc != "" || def.HasRecv != "" || def.HasStruct != "" ||
+		def.HasDirective != "" || def.IsTest != nil
 	if combinators > 1 || (combinators == 1 && leaf) {
 		t.Fatalf("golden fixture combines a where.file combinator with sibling "+
 			"predicates (%+v); setup.buildFile rejects this at build time", def)
+	}
+	// Mirror setup.buildFile's has_recv-requires-has_func rule: has_recv on its
+	// own is a build-time error in production, so reject it here too rather than
+	// letting it fall through to a less specific failure.
+	if def.HasRecv != "" && def.HasFunc == "" {
+		t.Fatalf("golden fixture sets where.file.has_recv without has_func (%+v); "+
+			"setup.buildFile rejects this at build time", def)
 	}
 	// Mirror setup.buildFile's presence semantics: a non-nil combinator slice
 	// (including an explicit empty one-of: [] / all-of: []) is present and owns
@@ -233,7 +261,7 @@ func fileFilterMatches(t *testing.T, def *rule.FilterDef, tree *dst.File) bool {
 	// matches vacuously true — the loop is skipped in each case.
 	if def.OneOf != nil {
 		for i := range def.OneOf {
-			if fileFilterMatches(t, &def.OneOf[i], tree) {
+			if fileFilterMatches(t, &def.OneOf[i], isTest, tree) {
 				return true
 			}
 		}
@@ -241,7 +269,7 @@ func fileFilterMatches(t *testing.T, def *rule.FilterDef, tree *dst.File) bool {
 	}
 	if def.AllOf != nil {
 		for i := range def.AllOf {
-			if !fileFilterMatches(t, &def.AllOf[i], tree) {
+			if !fileFilterMatches(t, &def.AllOf[i], isTest, tree) {
 				return false
 			}
 		}
@@ -249,7 +277,7 @@ func fileFilterMatches(t *testing.T, def *rule.FilterDef, tree *dst.File) bool {
 	}
 	// not is unary: it negates its single inner predicate (mirrors setup.Not).
 	if def.Not != nil {
-		return !fileFilterMatches(t, def.Not, tree)
+		return !fileFilterMatches(t, def.Not, isTest, tree)
 	}
 	switch {
 	case def.HasFunc != "":
@@ -257,6 +285,8 @@ func fileFilterMatches(t *testing.T, def *rule.FilterDef, tree *dst.File) bool {
 		return ok
 	case def.HasStruct != "":
 		return ast.FindStructDecl(tree, def.HasStruct) != nil
+	case def.IsTest != nil:
+		return *def.IsTest == isTest
 	default:
 		t.Fatalf("golden fixture uses a where.file predicate the harness cannot "+
 			"evaluate (%+v); extend fileFilterMatches to mirror setup.buildFile", def)

--- a/tool/internal/instrument/testdata/golden/is-test-filter-match/hook.go
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-match/hook.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import (
+	_ "unsafe"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/inst"
+)
+
+// BeforeProcessRequest is injected before ProcessRequest. The is_test: false
+// filter scopes the rule to non-test builds, so this hook is never injected
+// into a test build.
+func BeforeProcessRequest(ctx inst.HookContext, req string) {
+	println("BeforeProcessRequest:", req)
+}
+
+// AfterProcessRequest is injected after ProcessRequest in non-test builds.
+func AfterProcessRequest(ctx inst.HookContext, err error) {}

--- a/tool/internal/instrument/testdata/golden/is-test-filter-match/is_test_filter_match.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-match/is_test_filter_match.main.go.golden
@@ -1,0 +1,149 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import _ "unsafe"
+
+// ProcessRequest is instrumented only in non-test builds. The is_test: false
+// predicate matches this normal build (source.go, no _test.go file); the same
+// rule is gated out of a test build. See is-test-filter-true-match for the
+// is_test: true counterpart.
+func ProcessRequest(req string) (_unnamedRetVal0 error) {
+	//line <generated>:1
+	if hookContext2401870380, _ := OtelBeforeTrampoline_ProcessRequest2401870380(&req); false {
+	} else {
+		defer OtelAfterTrampoline_ProcessRequest2401870380(hookContext2401870380, &_unnamedRetVal0)
+	}
+	//line main.go:11:2
+	println("processing:", req)
+	//line main.go:12:2
+	return nil
+}
+
+//line <generated>:1
+type HookContextImpl2401870380 struct {
+	params      []interface{}
+	returnVals  []interface{}
+	skipCall    bool
+	data        interface{}
+	funcName    string
+	packageName string
+}
+
+func (c *HookContextImpl2401870380) SetSkipCall(skip bool)    { c.skipCall = skip }
+func (c *HookContextImpl2401870380) IsSkipCall() bool         { return c.skipCall }
+func (c *HookContextImpl2401870380) SetData(data interface{}) { c.data = data }
+func (c *HookContextImpl2401870380) GetData() interface{}     { return c.data }
+func (c *HookContextImpl2401870380) GetKeyData(key string) interface{} {
+	if c.data == nil {
+		return nil
+	}
+	return c.data.(map[string]interface{})[key]
+}
+
+func (c *HookContextImpl2401870380) SetKeyData(key string, val interface{}) {
+	if c.data == nil {
+		c.data = make(map[string]interface{})
+	}
+	c.data.(map[string]interface{})[key] = val
+}
+
+func (c *HookContextImpl2401870380) HasKeyData(key string) bool {
+	if c.data == nil {
+		return false
+	}
+	_, ok := c.data.(map[string]interface{})[key]
+	return ok
+}
+
+func (c *HookContextImpl2401870380) GetParam(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.params[0].(*string))
+	}
+	return nil
+}
+
+func (c *HookContextImpl2401870380) SetParam(idx int, val interface{}) {
+	if val == nil {
+		c.params[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.params[0].(*string)) = val.(string)
+	}
+}
+
+func (c *HookContextImpl2401870380) GetReturnVal(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.returnVals[0].(*error))
+	}
+	return nil
+}
+
+func (c *HookContextImpl2401870380) SetReturnVal(idx int, val interface{}) {
+	if val == nil {
+		c.returnVals[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.returnVals[0].(*error)) = val.(error)
+	}
+}
+func (c *HookContextImpl2401870380) GetParamCount() int     { return len(c.params) }
+func (c *HookContextImpl2401870380) GetReturnValCount() int { return len(c.returnVals) }
+func (c *HookContextImpl2401870380) GetFuncName() string    { return c.funcName }
+func (c *HookContextImpl2401870380) GetPackageName() string { return c.packageName }
+
+// Trampoline Template
+func OtelBeforeTrampoline_ProcessRequest2401870380(param0 *string) (hookContext *HookContextImpl2401870380, skipCall bool) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec Before hook", "BeforeProcessRequest")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext = &HookContextImpl2401870380{}
+	hookContext.params = []interface{}{param0}
+	hookContext.funcName = "ProcessRequest"
+	hookContext.packageName = "main"
+	if BeforeProcessRequest != nil {
+		BeforeProcessRequest(hookContext, *param0)
+	}
+	return hookContext, hookContext.skipCall
+}
+
+func OtelAfterTrampoline_ProcessRequest2401870380(hookContext HookContext, arg0 *error) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec After hook", "AfterProcessRequest")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext.(*HookContextImpl2401870380).returnVals = []interface{}{arg0}
+	if AfterProcessRequest != nil {
+		AfterProcessRequest(hookContext, *arg0)
+	}
+}
+
+//go:linkname BeforeProcessRequest testdata/golden/is-test-filter-match.BeforeProcessRequest
+func BeforeProcessRequest(hookContext HookContext, param0 string)
+
+//go:linkname AfterProcessRequest testdata/golden/is-test-filter-match.AfterProcessRequest
+func AfterProcessRequest(hookContext HookContext, arg0 error)

--- a/tool/internal/instrument/testdata/golden/is-test-filter-match/is_test_filter_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-match/is_test_filter_match.otelc.globals.go.golden
@@ -1,0 +1,41 @@
+package main
+
+// Variable Template
+var (
+	OtelGetStackImpl   func() []byte = nil
+	OtelPrintStackImpl func([]byte)  = nil
+)
+
+// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+type HookContext interface {
+	// Set the skip call flag, can be used to skip the original function call
+	SetSkipCall(bool)
+	// Get the skip call flag, can be used to skip the original function call
+	IsSkipCall() bool
+	// Set the data field, can be used to pass information between Before and After hooks
+	SetData(interface{})
+	// Get the data field, can be used to pass information between Before and After hooks
+	GetData() interface{}
+	// Get a value from the data field by key
+	GetKeyData(key string) interface{}
+	// Set a key-value pair in the data field
+	SetKeyData(key string, val interface{})
+	// Check if a key exists in the data field
+	HasKeyData(key string) bool
+	// Number of original function parameters
+	GetParamCount() int
+	// Get the original function parameter at index idx
+	GetParam(idx int) interface{}
+	// Change the original function parameter at index idx
+	SetParam(idx int, val interface{})
+	// Number of original function return values
+	GetReturnValCount() int
+	// Get the original function return value at index idx
+	GetReturnVal(idx int) interface{}
+	// Change the original function return value at index idx
+	SetReturnVal(idx int, val interface{})
+	// Get the original function name
+	GetFuncName() string
+	// Get the package name of the original function
+	GetPackageName() string
+}

--- a/tool/internal/instrument/testdata/golden/is-test-filter-match/rules.yml
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-match/rules.yml
@@ -1,0 +1,11 @@
+instrument_production_only:
+  target: main
+  where:
+    func: ProcessRequest
+    file:
+      is_test: false
+  do:
+    - inject_hooks:
+        before: BeforeProcessRequest
+        after: AfterProcessRequest
+        path: testdata/golden/is-test-filter-match

--- a/tool/internal/instrument/testdata/golden/is-test-filter-match/source.go
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-match/source.go
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+// ProcessRequest is instrumented only in non-test builds. The is_test: false
+// predicate matches this normal build (source.go, no _test.go file); the same
+// rule is gated out of a test build. See is-test-filter-true-match for the
+// is_test: true counterpart.
+func ProcessRequest(req string) error {
+	println("processing:", req)
+	return nil
+}

--- a/tool/internal/instrument/testdata/golden/is-test-filter-no-match/hook.go
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-no-match/hook.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import (
+	_ "unsafe"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/inst"
+)
+
+// BeforeProcessRequest would be injected before ProcessRequest in a test build.
+// The is_test: true filter scopes the rule to test builds; this fixture is a
+// normal build (source.go, no _test.go file), so the rule is gated out and the
+// hook is never injected. It exists only so the rule's inject_hooks path
+// resolves to real sources.
+func BeforeProcessRequest(ctx inst.HookContext, req string) {
+	println("BeforeProcessRequest:", req)
+}
+
+// AfterProcessRequest would be injected after ProcessRequest in a test build.
+func AfterProcessRequest(ctx inst.HookContext, err error) {}

--- a/tool/internal/instrument/testdata/golden/is-test-filter-no-match/is_test_filter_no_match.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-no-match/is_test_filter_no_match.main.go.golden
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+// ProcessRequest is targeted by a test-only rule (is_test: true). This fixture
+// is a normal build — its source is source.go, not a _test.go file — so the
+// rule is gated out and the output stays byte-identical to this source. The
+// matching counterpart is is-test-filter-true-match.
+func ProcessRequest(req string) error {
+	println("processing:", req)
+	return nil
+}

--- a/tool/internal/instrument/testdata/golden/is-test-filter-no-match/rules.yml
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-no-match/rules.yml
@@ -1,0 +1,11 @@
+instrument_test_only:
+  target: main
+  where:
+    func: ProcessRequest
+    file:
+      is_test: true
+  do:
+    - inject_hooks:
+        before: BeforeProcessRequest
+        after: AfterProcessRequest
+        path: testdata/golden/is-test-filter-no-match

--- a/tool/internal/instrument/testdata/golden/is-test-filter-no-match/source.go
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-no-match/source.go
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+// ProcessRequest is targeted by a test-only rule (is_test: true). This fixture
+// is a normal build — its source is source.go, not a _test.go file — so the
+// rule is gated out and the output stays byte-identical to this source. The
+// matching counterpart is is-test-filter-true-match.
+func ProcessRequest(req string) error {
+	println("processing:", req)
+	return nil
+}

--- a/tool/internal/instrument/testdata/golden/is-test-filter-true-match/hook.go
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-true-match/hook.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import (
+	_ "unsafe"
+
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/inst"
+)
+
+// BeforeProcessRequest is injected before ProcessRequest in this test build.
+// The is_test: true filter scopes the rule to test builds (here, a _test.go
+// source set).
+func BeforeProcessRequest(ctx inst.HookContext, req string) {
+	println("BeforeProcessRequest:", req)
+}
+
+// AfterProcessRequest is injected after ProcessRequest in this test build.
+func AfterProcessRequest(ctx inst.HookContext, err error) {}

--- a/tool/internal/instrument/testdata/golden/is-test-filter-true-match/is_test_filter_true_match.main_test.go.golden
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-true-match/is_test_filter_true_match.main_test.go.golden
@@ -1,0 +1,149 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import _ "unsafe"
+
+// ProcessRequest lives in a _test.go file, so the Go toolchain compiles it only
+// as part of `go test`. The is_test: true rule matches that test build and the
+// golden captures the injected trampolines — the positive counterpart to
+// is-test-filter-no-match, where the same rule is gated out of a normal build.
+func ProcessRequest(req string) (_unnamedRetVal0 error) {
+	//line <generated>:1
+	if hookContext2587785677, _ := OtelBeforeTrampoline_ProcessRequest2587785677(&req); false {
+	} else {
+		defer OtelAfterTrampoline_ProcessRequest2587785677(hookContext2587785677, &_unnamedRetVal0)
+	}
+	//line main_test.go:11:2
+	println("processing:", req)
+	//line main_test.go:12:2
+	return nil
+}
+
+//line <generated>:1
+type HookContextImpl2587785677 struct {
+	params      []interface{}
+	returnVals  []interface{}
+	skipCall    bool
+	data        interface{}
+	funcName    string
+	packageName string
+}
+
+func (c *HookContextImpl2587785677) SetSkipCall(skip bool)    { c.skipCall = skip }
+func (c *HookContextImpl2587785677) IsSkipCall() bool         { return c.skipCall }
+func (c *HookContextImpl2587785677) SetData(data interface{}) { c.data = data }
+func (c *HookContextImpl2587785677) GetData() interface{}     { return c.data }
+func (c *HookContextImpl2587785677) GetKeyData(key string) interface{} {
+	if c.data == nil {
+		return nil
+	}
+	return c.data.(map[string]interface{})[key]
+}
+
+func (c *HookContextImpl2587785677) SetKeyData(key string, val interface{}) {
+	if c.data == nil {
+		c.data = make(map[string]interface{})
+	}
+	c.data.(map[string]interface{})[key] = val
+}
+
+func (c *HookContextImpl2587785677) HasKeyData(key string) bool {
+	if c.data == nil {
+		return false
+	}
+	_, ok := c.data.(map[string]interface{})[key]
+	return ok
+}
+
+func (c *HookContextImpl2587785677) GetParam(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.params[0].(*string))
+	}
+	return nil
+}
+
+func (c *HookContextImpl2587785677) SetParam(idx int, val interface{}) {
+	if val == nil {
+		c.params[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.params[0].(*string)) = val.(string)
+	}
+}
+
+func (c *HookContextImpl2587785677) GetReturnVal(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.returnVals[0].(*error))
+	}
+	return nil
+}
+
+func (c *HookContextImpl2587785677) SetReturnVal(idx int, val interface{}) {
+	if val == nil {
+		c.returnVals[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.returnVals[0].(*error)) = val.(error)
+	}
+}
+func (c *HookContextImpl2587785677) GetParamCount() int     { return len(c.params) }
+func (c *HookContextImpl2587785677) GetReturnValCount() int { return len(c.returnVals) }
+func (c *HookContextImpl2587785677) GetFuncName() string    { return c.funcName }
+func (c *HookContextImpl2587785677) GetPackageName() string { return c.packageName }
+
+// Trampoline Template
+func OtelBeforeTrampoline_ProcessRequest2587785677(param0 *string) (hookContext *HookContextImpl2587785677, skipCall bool) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec Before hook", "BeforeProcessRequest")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext = &HookContextImpl2587785677{}
+	hookContext.params = []interface{}{param0}
+	hookContext.funcName = "ProcessRequest"
+	hookContext.packageName = "main"
+	if BeforeProcessRequest != nil {
+		BeforeProcessRequest(hookContext, *param0)
+	}
+	return hookContext, hookContext.skipCall
+}
+
+func OtelAfterTrampoline_ProcessRequest2587785677(hookContext HookContext, arg0 *error) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec After hook", "AfterProcessRequest")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext.(*HookContextImpl2587785677).returnVals = []interface{}{arg0}
+	if AfterProcessRequest != nil {
+		AfterProcessRequest(hookContext, *arg0)
+	}
+}
+
+//go:linkname BeforeProcessRequest testdata/golden/is-test-filter-true-match.BeforeProcessRequest
+func BeforeProcessRequest(hookContext HookContext, param0 string)
+
+//go:linkname AfterProcessRequest testdata/golden/is-test-filter-true-match.AfterProcessRequest
+func AfterProcessRequest(hookContext HookContext, arg0 error)

--- a/tool/internal/instrument/testdata/golden/is-test-filter-true-match/is_test_filter_true_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-true-match/is_test_filter_true_match.otelc.globals.go.golden
@@ -1,0 +1,41 @@
+package main
+
+// Variable Template
+var (
+	OtelGetStackImpl   func() []byte = nil
+	OtelPrintStackImpl func([]byte)  = nil
+)
+
+// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+type HookContext interface {
+	// Set the skip call flag, can be used to skip the original function call
+	SetSkipCall(bool)
+	// Get the skip call flag, can be used to skip the original function call
+	IsSkipCall() bool
+	// Set the data field, can be used to pass information between Before and After hooks
+	SetData(interface{})
+	// Get the data field, can be used to pass information between Before and After hooks
+	GetData() interface{}
+	// Get a value from the data field by key
+	GetKeyData(key string) interface{}
+	// Set a key-value pair in the data field
+	SetKeyData(key string, val interface{})
+	// Check if a key exists in the data field
+	HasKeyData(key string) bool
+	// Number of original function parameters
+	GetParamCount() int
+	// Get the original function parameter at index idx
+	GetParam(idx int) interface{}
+	// Change the original function parameter at index idx
+	SetParam(idx int, val interface{})
+	// Number of original function return values
+	GetReturnValCount() int
+	// Get the original function return value at index idx
+	GetReturnVal(idx int) interface{}
+	// Change the original function return value at index idx
+	SetReturnVal(idx int, val interface{})
+	// Get the original function name
+	GetFuncName() string
+	// Get the package name of the original function
+	GetPackageName() string
+}

--- a/tool/internal/instrument/testdata/golden/is-test-filter-true-match/rules.yml
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-true-match/rules.yml
@@ -1,0 +1,11 @@
+instrument_test_only:
+  target: main
+  where:
+    func: ProcessRequest
+    file:
+      is_test: true
+  do:
+    - inject_hooks:
+        before: BeforeProcessRequest
+        after: AfterProcessRequest
+        path: testdata/golden/is-test-filter-true-match

--- a/tool/internal/instrument/testdata/golden/is-test-filter-true-match/source_test.go
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-true-match/source_test.go
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+// ProcessRequest lives in a _test.go file, so the Go toolchain compiles it only
+// as part of `go test`. The is_test: true rule matches that test build and the
+// golden captures the injected trampolines — the positive counterpart to
+// is-test-filter-no-match, where the same rule is gated out of a normal build.
+func ProcessRequest(req string) error {
+	println("processing:", req)
+	return nil
+}

--- a/tool/internal/rule/base.go
+++ b/tool/internal/rule/base.go
@@ -33,14 +33,29 @@ type InstRule interface {
 // support remains intentionally narrow: simple leaf predicates are supported,
 // while qualifier composition is validated but not yet executed.
 type FilterDef struct {
-	AllOf []FilterDef `json:"all-of,omitempty" yaml:"all-of,omitempty"`
-	OneOf []FilterDef `json:"one-of,omitempty" yaml:"one-of,omitempty"`
-	Not   *FilterDef  `json:"not,omitempty"    yaml:"not,omitempty"`
+	// AllOf, OneOf, and Not are the boolean combinators. Each composes nested
+	// FilterDefs so predicates can be combined. A node may use at most one
+	// combinator, and a combinator may not be mixed with sibling leaf predicates
+	// on the same node; both rules are enforced at build time.
+	AllOf []FilterDef `json:"all-of,omitempty" yaml:"all-of,omitempty"` // match when every nested predicate matches
+	OneOf []FilterDef `json:"one-of,omitempty" yaml:"one-of,omitempty"` // match when at least one nested predicate matches
+	Not   *FilterDef  `json:"not,omitempty"    yaml:"not,omitempty"`    // match when the nested predicate does not match
 
-	HasFunc      string `json:"has_func,omitempty"      yaml:"has_func,omitempty"`
-	HasRecv      string `json:"has_recv,omitempty"      yaml:"has_recv,omitempty"`
-	HasStruct    string `json:"has_struct,omitempty"    yaml:"has_struct,omitempty"`
-	HasDirective string `json:"has_directive,omitempty" yaml:"has_directive,omitempty"`
+	HasFunc      string `json:"has_func,omitempty"      yaml:"has_func,omitempty"`      // match files that declare this function
+	HasRecv      string `json:"has_recv,omitempty"      yaml:"has_recv,omitempty"`      // narrow has_func to this receiver type; requires has_func
+	HasStruct    string `json:"has_struct,omitempty"    yaml:"has_struct,omitempty"`    // match files that declare this struct type
+	HasDirective string `json:"has_directive,omitempty" yaml:"has_directive,omitempty"` // match files carrying this //go: directive (validated, not yet executed)
+
+	// IsTest is a tri-state boolean predicate that selects or excludes test
+	// builds — compilation units the Go toolchain produces only as part of
+	// `go test` (a package augmented with its _test.go files, the external
+	// xxx_test package, or the generated _testmain.go runner). Test-ness is a
+	// property of the compile's source set, not of the import path.
+	//
+	//   is_test: true  → match only test builds
+	//   is_test: false → match only non-test builds
+	//   absent (nil)   → no filtering; the rule applies to every build
+	IsTest *bool `json:"is_test,omitempty" yaml:"is_test,omitempty"`
 }
 
 // WhereDef carries the structured where clause after package selectors have

--- a/tool/internal/setup/filter.go
+++ b/tool/internal/setup/filter.go
@@ -44,9 +44,12 @@ type Filter interface {
 // passed to all filters associated with the rules being evaluated for that
 // file.
 type MatchContext struct {
-	// ImportPath is the Go import path of the package containing the source
-	// file.
-	ImportPath string
+	// IsTest reports whether the source file is part of a test build — a
+	// compilation the Go toolchain produces only while building a test binary
+	// (a package augmented with its _test.go files, an external xxx_test
+	// package, or the generated _testmain.go runner). It is a property of the
+	// whole compile, so it is identical for every file in a given package.
+	IsTest bool
 
 	// SourceFile is the absolute path to the source file being evaluated.
 	SourceFile string
@@ -61,6 +64,7 @@ type MatchContext struct {
 var (
 	_ Filter = (*FuncFilter)(nil)
 	_ Filter = (*StructFilter)(nil)
+	_ Filter = (*IsTestFilter)(nil)
 )
 
 // FuncFilter matches source files that declare the named function or method.
@@ -87,6 +91,24 @@ type StructFilter struct {
 
 func (f *StructFilter) Match(ctx *MatchContext) bool {
 	return ast.FindStructDecl(ctx.AST, f.Struct) != nil
+}
+
+// IsTestFilter selects or excludes test builds — compilations the Go toolchain
+// produces only as part of `go test` (see MatchContext.IsTest).
+//
+// ShouldMatch == true  → match only test builds
+// ShouldMatch == false → match only non-test builds
+//
+// The predicate is tri-state at the schema level: a nil *bool in FilterDef
+// means "unset" (no filtering), while true/false express explicit intent.
+// This filter is only constructed when the field is explicitly set, so
+// ShouldMatch is never ambiguous once an IsTestFilter exists.
+type IsTestFilter struct {
+	ShouldMatch bool
+}
+
+func (f *IsTestFilter) Match(ctx *MatchContext) bool {
+	return f.ShouldMatch == ctx.IsTest
 }
 
 // --- Combinators ---
@@ -181,7 +203,7 @@ func Build(where *rule.WhereDef) (Filter, error) {
 // predicate that sits as a sibling of a combinator on the same node.
 func hasLeafPredicate(def *rule.FilterDef) bool {
 	return def.HasFunc != "" || def.HasRecv != "" ||
-		def.HasStruct != "" || def.HasDirective != ""
+		def.HasStruct != "" || def.HasDirective != "" || def.IsTest != nil
 }
 
 //nolint:nilnil // unreachable default branch is guarded by util.ShouldNotReachHere
@@ -246,6 +268,9 @@ func buildFile(def *rule.FilterDef) (Filter, error) {
 	if def.HasDirective != "" {
 		active++
 	}
+	if def.IsTest != nil {
+		active++
+	}
 
 	if active == 0 {
 		return nil, ex.Newf("where.file has no active predicate")
@@ -261,6 +286,8 @@ func buildFile(def *rule.FilterDef) (Filter, error) {
 		return &StructFilter{Struct: def.HasStruct}, nil
 	case def.HasDirective != "":
 		return nil, ex.Newf("where.file.has_directive is not yet supported")
+	case def.IsTest != nil:
+		return &IsTestFilter{ShouldMatch: *def.IsTest}, nil
 	default:
 		// The active-predicate counter above proves at least one leaf is set;
 		// matching the convention in match.go / instrument.go / trampoline.go,

--- a/tool/internal/setup/filter_test.go
+++ b/tool/internal/setup/filter_test.go
@@ -22,7 +22,6 @@ import (
 func TestMatchContext_EmptyDecls(t *testing.T) {
 	tree := &dst.File{Name: &dst.Ident{Name: "pkg"}, Decls: nil}
 	ctx := &setup.MatchContext{
-		ImportPath: "example.com/pkg",
 		SourceFile: "/tmp/empty.go",
 		AST:        tree,
 	}
@@ -32,6 +31,39 @@ func TestMatchContext_EmptyDecls(t *testing.T) {
 	}
 	if (&setup.StructFilter{Struct: "Missing"}).Match(ctx) {
 		t.Fatal("StructFilter.Match(empty decls) = true, want false")
+	}
+}
+
+func TestIsTestFilter_Match(t *testing.T) {
+	tree := &dst.File{Name: &dst.Ident{Name: "pkg"}, Decls: nil}
+
+	tests := []struct {
+		name        string
+		shouldMatch bool
+		isTest      bool
+		want        bool
+	}{
+		// ShouldMatch: true → match only test builds.
+		{name: "test build matches when ShouldMatch=true", shouldMatch: true, isTest: true, want: true},
+		{name: "non-test build does not match when ShouldMatch=true", shouldMatch: true, isTest: false, want: false},
+		// ShouldMatch: false → match only non-test builds.
+		{name: "non-test build matches when ShouldMatch=false", shouldMatch: false, isTest: false, want: true},
+		{name: "test build does not match when ShouldMatch=false", shouldMatch: false, isTest: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &setup.MatchContext{
+				IsTest:     tt.isTest,
+				SourceFile: "/tmp/source.go",
+				AST:        tree,
+			}
+			f := &setup.IsTestFilter{ShouldMatch: tt.shouldMatch}
+			if got := f.Match(ctx); got != tt.want {
+				t.Fatalf("IsTestFilter{ShouldMatch:%v}.Match({IsTest:%v}) = %v, want %v",
+					tt.shouldMatch, tt.isTest, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -45,7 +77,6 @@ func parseSource(t *testing.T, src string) *setup.MatchContext {
 		t.Fatalf("parseSource: %v", err)
 	}
 	return &setup.MatchContext{
-		ImportPath: "example.com/pkg",
 		SourceFile: "/tmp/source.go",
 		AST:        tree,
 	}
@@ -139,6 +170,52 @@ func TestBuild_StructFilter(t *testing.T) {
 	}
 }
 
+func boolPtr(b bool) *bool { return &b }
+
+func TestBuild_IsTestFilter(t *testing.T) {
+	t.Run("true matches test packages", func(t *testing.T) {
+		where := &rule.WhereDef{File: &rule.FilterDef{IsTest: boolPtr(true)}}
+		f, err := setup.Build(where)
+		if err != nil {
+			t.Fatalf("Build(IsTest=true) error = %v, want nil", err)
+		}
+		itf, ok := f.(*setup.IsTestFilter)
+		if !ok {
+			t.Fatalf("Build(IsTest=true) returned %T, want *setup.IsTestFilter", f)
+		}
+		if !itf.ShouldMatch {
+			t.Errorf("IsTestFilter.ShouldMatch = false, want true")
+		}
+	})
+
+	t.Run("false matches non-test packages", func(t *testing.T) {
+		where := &rule.WhereDef{File: &rule.FilterDef{IsTest: boolPtr(false)}}
+		f, err := setup.Build(where)
+		if err != nil {
+			t.Fatalf("Build(IsTest=false) error = %v, want nil", err)
+		}
+		itf, ok := f.(*setup.IsTestFilter)
+		if !ok {
+			t.Fatalf("Build(IsTest=false) returned %T, want *setup.IsTestFilter", f)
+		}
+		if itf.ShouldMatch {
+			t.Errorf("IsTestFilter.ShouldMatch = true, want false")
+		}
+	})
+
+	t.Run("nil is_test leaves filter nil", func(t *testing.T) {
+		// A nil IsTest must not produce an IsTestFilter — it means "unset".
+		// We exercise this indirectly: a FilterDef with only IsTest==nil has no
+		// active predicate and Build must return an error, not silently
+		// construct a filter that treats nil as false.
+		where := &rule.WhereDef{File: &rule.FilterDef{}}
+		_, err := setup.Build(where)
+		if err == nil {
+			t.Fatal("Build(empty FilterDef) error = nil, want error: nil IsTest must not count as active predicate")
+		}
+	})
+}
+
 func TestBuild_ErrorCases(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -155,6 +232,33 @@ func TestBuild_ErrorCases(t *testing.T) {
 		{
 			name:  "multiple file predicates",
 			where: &rule.WhereDef{File: &rule.FilterDef{HasFunc: "Foo", HasStruct: "Bar"}},
+		},
+		{
+			name:  "is_test combined with another predicate",
+			where: &rule.WhereDef{File: &rule.FilterDef{HasFunc: "Foo", IsTest: boolPtr(true)}},
+		},
+		{
+			// A combinator owns the node: is_test as a sibling must be rejected,
+			// not silently ignored (regression guard for hasLeafPredicate).
+			name: "is_test sibling of all-of",
+			where: &rule.WhereDef{File: &rule.FilterDef{
+				AllOf:  []rule.FilterDef{{HasFunc: "Foo"}},
+				IsTest: boolPtr(true),
+			}},
+		},
+		{
+			name: "is_test sibling of one-of",
+			where: &rule.WhereDef{File: &rule.FilterDef{
+				OneOf:  []rule.FilterDef{{HasFunc: "Foo"}},
+				IsTest: boolPtr(true),
+			}},
+		},
+		{
+			name: "is_test sibling of not",
+			where: &rule.WhereDef{File: &rule.FilterDef{
+				Not:    &rule.FilterDef{HasFunc: "Foo"},
+				IsTest: boolPtr(false),
+			}},
 		},
 		{
 			name:  "where one-of unsupported",
@@ -442,10 +546,11 @@ func TestNot_Match(t *testing.T) {
 }
 
 type filterExpected struct {
-	Type   string `yaml:"type"`
-	Func   string `yaml:"func"`
-	Recv   string `yaml:"recv"`
-	Struct string `yaml:"struct"`
+	Type        string `yaml:"type"`
+	Func        string `yaml:"func"`
+	Recv        string `yaml:"recv"`
+	Struct      string `yaml:"struct"`
+	ShouldMatch *bool  `yaml:"should_match"`
 	// Children describes the expected sub-filters for combinator types
 	// (e.g. AllOf). It is nil for leaf filters.
 	Children []filterExpected `yaml:"children"`
@@ -533,6 +638,31 @@ func assertBuiltFilter(t *testing.T, name string, got setup.Filter, want filterE
 		if structFilter.Struct != want.Struct {
 			t.Fatalf("Build(%q) = %+v, want struct=%q", name, structFilter, want.Struct)
 		}
+	case "IsTestFilter":
+		itf, ok := got.(*setup.IsTestFilter)
+		if !ok {
+			t.Fatalf("Build(%q) = %T, want *setup.IsTestFilter", name, got)
+		}
+		if want.ShouldMatch == nil {
+			t.Fatalf("expected file %q has type IsTestFilter but no should_match field", name)
+		}
+		if itf.ShouldMatch != *want.ShouldMatch {
+			t.Fatalf("Build(%q) IsTestFilter.ShouldMatch = %v, want %v", name, itf.ShouldMatch, *want.ShouldMatch)
+		}
+	case "AllOf", "OneOf", "Not":
+		assertBuiltCombinator(t, name, got, want)
+	default:
+		t.Fatalf("unexpected expected filter type %q", want.Type)
+	}
+}
+
+// assertBuiltCombinator verifies AllOf/OneOf/Not combinator filters and recurses
+// into their children. It is split out of assertBuiltFilter so that neither
+// function exceeds the linter's cognitive-complexity budget.
+func assertBuiltCombinator(t *testing.T, name string, got setup.Filter, want filterExpected) {
+	t.Helper()
+
+	switch want.Type {
 	case "AllOf":
 		allOf, ok := got.(setup.AllOf)
 		if !ok {
@@ -564,7 +694,5 @@ func assertBuiltFilter(t *testing.T, name string, got setup.Filter, want filterE
 			t.Fatalf("Build(%q) Not expects exactly 1 child, got %d", name, len(want.Children))
 		}
 		assertBuiltFilter(t, name, not.Inner, want.Children[0])
-	default:
-		t.Fatalf("unexpected expected filter type %q", want.Type)
 	}
 }

--- a/tool/internal/setup/find.go
+++ b/tool/internal/setup/find.go
@@ -74,7 +74,7 @@ func findCommands(buildPlanLog *os.File) ([]string, error) {
 
 // listBuildPlan lists the build plan by running `go build -a -x -n`
 // and then filtering the commands (cd, cgo, compile) from the build plan log.
-func (sp *SetupPhase) listBuildPlan(ctx context.Context, cmdArgs []string) ([]string, error) {
+func (sp *SetupPhase) listBuildPlan(ctx context.Context, subcommand string, cmdArgs []string) ([]string, error) {
 	const buildPlanLogName = "build-plan.log"
 
 	// Create a build plan log file in the temporary directory
@@ -83,8 +83,16 @@ func (sp *SetupPhase) listBuildPlan(ctx context.Context, cmdArgs []string) ([]st
 		return nil, ex.Wrapf(err, "failed to create build plan log file")
 	}
 	defer buildPlanLog.Close()
-	// The full build command is: "go build/install -a -x -n  {...}"
-	prefix := []string{"build", "-a", "-x", "-n"}
+	// The dry run lists the compile commands the toolchain would issue. `go test`
+	// needs its own plan because only it surfaces the test-augmented, external
+	// test, and test-main compiles that is_test gates on. `go install` shares
+	// `go build`'s compile plan, so it stays on the build verb.
+	planVerb := subcmdBuild
+	if subcommand == subcmdTest {
+		planVerb = subcmdTest
+	}
+	// The full command is: "go build/test -a -x -n {...}"
+	prefix := []string{planVerb, "-a", "-x", "-n"}
 	args := make([]string, 0, len(prefix)+len(cmdArgs))
 	args = append(args, prefix...)
 	args = append(args, cmdArgs...) // args from original build/install or setup command
@@ -196,8 +204,8 @@ func findGoSources(sp *SetupPhase, args []string, cgoObjDirs map[string]string) 
 }
 
 // findDeps finds dependencies by listing the build plan.
-func (sp *SetupPhase) findDeps(ctx context.Context, cmdArgs []string) ([]*Dependency, error) {
-	buildPlan, err := sp.listBuildPlan(ctx, cmdArgs)
+func (sp *SetupPhase) findDeps(ctx context.Context, subcommand string, cmdArgs []string) ([]*Dependency, error) {
+	buildPlan, err := sp.listBuildPlan(ctx, subcommand, cmdArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/tool/internal/setup/find_test.go
+++ b/tool/internal/setup/find_test.go
@@ -281,6 +281,7 @@ func TestListBuildPlan(t *testing.T) {
 
 	tests := []struct {
 		name          string
+		subcommand    string // defaults to "build" when empty
 		buildPlan     string
 		args          []string
 		expected      []string
@@ -353,6 +354,21 @@ echo nothing useful
 			expected:      nil,
 			expectedGoCmd: []string{"build", "-a", "-x", "-n", "./..."},
 		},
+		{
+			// The test subcommand must list a `go test` plan, which surfaces the
+			// test-augmented, external test, and test-main compiles that is_test
+			// gates on. A `go build` plan would never contain them.
+			name:       "test subcommand lists a go test plan",
+			subcommand: "test",
+			buildPlan: `
+.../compile -o /tmp/out.a -buildid abc -p main main.go
+`,
+			args: []string{"./..."},
+			expected: []string{
+				".../compile -o /tmp/out.a -buildid abc -p main main.go",
+			},
+			expectedGoCmd: []string{"test", "-a", "-x", "-n", "./..."},
+		},
 	}
 
 	for _, tt := range tests {
@@ -380,7 +396,11 @@ echo nothing useful
 			}
 
 			sp := newTestSetupPhase()
-			buildPlan, err := sp.listBuildPlan(t.Context(), tt.args)
+			subcommand := tt.subcommand
+			if subcommand == "" {
+				subcommand = "build"
+			}
+			buildPlan, err := sp.listBuildPlan(t.Context(), subcommand, tt.args)
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -221,6 +221,10 @@ func (sp *SetupPhase) preciseMatching(
 		ruleFilters = append(ruleFilters, ruleFilter{rule: r, where: f})
 	}
 
+	// IsTest is a property of the whole compile (every file in a test build
+	// shares it), so compute it once and reuse it across each file's context.
+	isTest := isTestBuild(dep.Sources)
+
 	for _, source := range dep.Sources {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -244,7 +248,7 @@ func (sp *SetupPhase) preciseMatching(
 		// evaluated against that file. All fields are constant for a given
 		// source file, so no updates are needed inside the inner loop.
 		mctx := MatchContext{
-			ImportPath: dep.ImportPath,
+			IsTest:     isTest,
 			SourceFile: source,
 			AST:        tree,
 		}
@@ -261,6 +265,31 @@ func (sp *SetupPhase) preciseMatching(
 		}
 	}
 	return set, nil
+}
+
+// isTestBuild reports whether a compile invocation is part of a `go test` run.
+// The Go toolchain only ever feeds these inputs to the compiler while building
+// a test binary: a package augmented with its in-package _test.go files, the
+// external xxx_test package (whose sources are also _test.go files), and the
+// generated _testmain.go runner. None of them appear in a normal `go build`,
+// so their presence in the source set is the signal. There is no dedicated
+// "is test" compiler flag — verified against the toolchain — so the source set
+// is the only thing to key on.
+//
+// ponytail: known gap, no fix possible at compile granularity. A package whose
+// tests live only in an external xxx_test package (no in-package _test.go) is
+// compiled once and shared between normal and test builds — the toolchain emits
+// no test-only variant of it — so is_test cannot gate that package's production
+// code. The external xxx_test package and any in-package _test.go files are
+// still detected.
+func isTestBuild(sources []string) bool {
+	for _, src := range sources {
+		base := filepath.Base(src)
+		if base == "_testmain.go" || strings.HasSuffix(base, "_test.go") {
+			return true
+		}
+	}
+	return false
 }
 
 // matchOneRule performs precise AST matching for a single rule against a parsed

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -807,6 +807,87 @@ func TestPreciseMatching_WhereFileNot(t *testing.T) {
 	require.NotContains(t, result.FuncRules, noMatchFile)
 }
 
+func TestPreciseMatching_IsTestFilter(t *testing.T) {
+	// A test build is identified by _test.go files in the compile's source set —
+	// what `go test` feeds the compiler — not by the import path. is_test:true
+	// matches every file in such a build, including the production handler.go;
+	// is_test:false matches only non-test builds. Handle lives in handler.go, so
+	// adding handler_test.go to the source set is what flips the build to a test
+	// build without moving the matched function.
+	prodSrc := writeGoSource(t, "handler.go", "package main\n\nfunc Handle() {}\n")
+	testSrc := writeGoSource(t, "handler_test.go",
+		"package main\n\nimport \"testing\"\n\nfunc TestHandle(t *testing.T) { Handle() }\n")
+
+	tests := []struct {
+		name        string
+		shouldMatch bool // where.file.is_test
+		sources     []string
+		wantMatched bool
+	}{
+		{
+			name:        "is_test=true matches a test build",
+			shouldMatch: true,
+			sources:     []string{prodSrc, testSrc},
+			wantMatched: true,
+		},
+		{
+			name:        "is_test=true does not match a non-test build",
+			shouldMatch: true,
+			sources:     []string{prodSrc},
+			wantMatched: false,
+		},
+		{
+			name:        "is_test=false matches a non-test build",
+			shouldMatch: false,
+			sources:     []string{prodSrc},
+			wantMatched: true,
+		},
+		{
+			name:        "is_test=false does not match a test build",
+			shouldMatch: false,
+			sources:     []string{prodSrc, testSrc},
+			wantMatched: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shouldMatch := tt.shouldMatch
+			funcRule := &rule.InstFuncRule{
+				InstBaseRule: rule.InstBaseRule{
+					Name:   "test-is-test-filter",
+					Target: "example.com/svc",
+					Where: &rule.WhereDef{
+						File: &rule.FilterDef{IsTest: &shouldMatch},
+					},
+				},
+				Func:   "Handle",
+				Before: "BeforeHandle",
+				Path:   "example.com/hooks",
+			}
+
+			dep := &Dependency{
+				ImportPath: "example.com/svc",
+				Sources:    tt.sources,
+			}
+
+			sp := newTestSetupPhase()
+			set := rule.NewInstRuleSet(dep.ImportPath)
+
+			result, err := sp.preciseMatching(t.Context(), dep, []rule.InstRule{funcRule}, set)
+			require.NoError(t, err)
+
+			if tt.wantMatched {
+				require.Len(t, result.FuncRules, 1,
+					"is_test=%v with sources %v: expected rule to match", tt.shouldMatch, tt.sources)
+			} else {
+				require.Empty(t, result.FuncRules,
+					"is_test=%v with sources %v: expected rule not to match", tt.shouldMatch, tt.sources)
+			}
+		})
+	}
+}
+
 func TestPreciseMatching_WhereFileFilterBuildError(t *testing.T) {
 	srcFile := writeGoSource(t, "src.go", "package main\n\nfunc Foo() {}\n")
 

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -75,6 +75,47 @@ var flagsWithPathValues = map[string]bool{
 	"-toolexec":      true,
 }
 
+// testFlagsWithValues contains `go test` flags that take a separate value
+// argument. Their values are not packages, so splitBuildTargets skips them when
+// scanning for package targets (e.g. `go test -run TestX ./pkg` — TestX is the
+// value of -run, not a package). `-args` is handled separately by
+// splitBuildTargets, which stops scanning at it.
+//
+//nolint:gochecknoglobals // private lookup table
+var testFlagsWithValues = map[string]bool{
+	"-bench":                true,
+	"-benchtime":            true,
+	"-blockprofile":         true,
+	"-blockprofilerate":     true,
+	"-count":                true,
+	"-coverprofile":         true,
+	"-cpu":                  true,
+	"-cpuprofile":           true,
+	"-fuzz":                 true,
+	"-fuzzminimizetime":     true,
+	"-fuzztime":             true,
+	"-list":                 true,
+	"-memprofile":           true,
+	"-memprofilerate":       true,
+	"-mutexprofile":         true,
+	"-mutexprofilefraction": true,
+	"-outputdir":            true,
+	"-parallel":             true,
+	"-run":                  true,
+	"-shuffle":              true,
+	"-skip":                 true,
+	"-timeout":              true,
+	"-trace":                true,
+	"-vet":                  true,
+}
+
+// Go subcommands that otelc wraps with toolexec instrumentation.
+const (
+	subcmdBuild   = "build"
+	subcmdInstall = "install"
+	subcmdTest    = "test"
+)
+
 const commandLineArgumentsPackage = "command-line-arguments"
 
 // GetBuildPackages loads all packages from the otelc go build/install or otelc setup command arguments.
@@ -144,20 +185,26 @@ func getBuildPackages(ctx context.Context, args []string) ([]*packages.Package, 
 func splitBuildTargets(args []string) ([]string, []string, error) {
 	var pkgs, files []string
 
-	for i := len(args) - 1; i >= 0; i-- {
+	// Scan forward and classify each argument. Packages and flags may interleave:
+	// `go build` conventionally puts flags first, but `go test` is commonly
+	// invoked as `go test ./pkg -run TestX`, so a position-based scan would miss
+	// the package. A flag in separated form consumes the next argument as its
+	// value (e.g. "-o out", "-run TestX"); skipping it keeps the value from being
+	// mistaken for a package. Joined form ("-tags=x") carries its own value.
+	for i := 0; i < len(args); i++ {
 		arg := args[i]
 
-		// If preceded by a flag that takes a path value, this is a flag value
-		// We want to avoid scenarios like "go build -o ./tmp ./app" where tmp also contains Go files,
-		// as it would be treated as a package.
-		if i > 0 && flagsWithPathValues[args[i-1]] {
+		// Everything after `-args` is passed to the test binary, not the go
+		// command, so it can contain neither packages nor go flags.
+		if arg == "-args" {
 			break
 		}
 
-		// If we hit a flag, stop. Packages come after all flags
-		// go build [-o output] [build flags] [packages]
 		if strings.HasPrefix(arg, "-") {
-			break
+			if !strings.Contains(arg, "=") && (flagsWithPathValues[arg] || testFlagsWithValues[arg]) {
+				i++ // skip this flag's separate value
+			}
+			continue
 		}
 
 		if filepath.Ext(arg) == ".go" {
@@ -172,8 +219,8 @@ func splitBuildTargets(args []string) ([]string, []string, error) {
 	}
 
 	if len(files) > 0 {
-		// files are collected in reverse order due to reverse argument traversal.
-		// files[0] is therefore the last .go file from the original CLI args.
+		// All named .go files must live in one directory; compare each against
+		// the first.
 		dir, err := filepath.Abs(filepath.Dir(files[0]))
 		if err != nil {
 			return nil, nil, ex.Wrapf(err, "failed to get absolute path for directory containing files")
@@ -206,8 +253,10 @@ func Setup(ctx context.Context, cmd *cli.Command) error {
 	// Since Setup can be invoked in different contexts (i.e, via `otelc setup` or as part of `otelc go build`),
 	// we need to handle the arguments accordingly. If the command is `go build` or `go install`, we should trim the first argument
 	args := cmd.Args().Slice()
+	subcommand := subcmdBuild
 	if cmd.Name == "go" {
-		args = cmd.Args().Tail() // trim build/install
+		subcommand = cmd.Args().First() // build / install / test
+		args = cmd.Args().Tail()        // trim the subcommand
 	}
 
 	logger := util.LoggerFromContext(ctx)
@@ -230,7 +279,7 @@ func Setup(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	// Find all dependencies of the project being build
-	deps, err := sp.findDeps(ctx, args)
+	deps, err := sp.findDeps(ctx, subcommand, args)
 	if err != nil {
 		return err
 	}
@@ -471,11 +520,15 @@ func GoBuild(ctx context.Context, cmd *cli.Command) error {
 	instrument.CleanupImportTrackingFiles()
 
 	if !cmd.Args().Present() {
-		return ex.Newf("no command provided. Only 'go build' and 'go install' are supported")
+		return ex.Newf("no command provided. Only 'go build', 'go install' and 'go test' are supported")
 	}
 
-	if cmd.Args().First() != "build" && cmd.Args().First() != "install" {
-		return ex.Newf("unsupported command: %s. Only 'go build' and 'go install' are supported", cmd.Args().First())
+	switch cmd.Args().First() {
+	case subcmdBuild, subcmdInstall, subcmdTest:
+		// supported
+	default:
+		return ex.Newf("unsupported command: %s. Only 'go build', 'go install' and 'go test' are supported",
+			cmd.Args().First())
 	}
 
 	defer func() {

--- a/tool/internal/setup/setup_test.go
+++ b/tool/internal/setup/setup_test.go
@@ -13,8 +13,28 @@ import (
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 	"golang.org/x/tools/go/packages"
 )
+
+func TestGoBuild_RejectsUnsupportedSubcommand(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "no subcommand", args: []string{"go"}},
+		{name: "unsupported subcommand run", args: []string{"go", "run", "./..."}},
+		{name: "unsupported subcommand vet", args: []string{"go", "vet", "./..."}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cli.Command{Name: "go", SkipFlagParsing: true, Action: GoBuild}
+			err := cmd.Run(t.Context(), tt.args)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "supported")
+		})
+	}
+}
 
 func TestGetPackages(t *testing.T) {
 	setupTestModule(t, []string{"cmd", "foo/demo"})
@@ -104,11 +124,12 @@ func TestGetPackages(t *testing.T) {
 
 func TestSplitBuildTargets(t *testing.T) {
 	tests := []struct {
-		name        string
-		targets     []string
-		pkgTargets  []string
-		fileTargets []string
-		expectError bool
+		name          string
+		targets       []string
+		pkgTargets    []string
+		fileTargets   []string
+		notPkgTargets []string // must NOT be parsed as packages (e.g. flag values)
+		expectError   bool
 	}{
 		{
 			name:        "all package targets",
@@ -138,6 +159,54 @@ func TestSplitBuildTargets(t *testing.T) {
 			fileTargets: nil,
 			expectError: true,
 		},
+		{
+			name:          "go test -run value is not a package",
+			targets:       []string{"-run", "TestX", "./pkg"},
+			pkgTargets:    []string{"./pkg"},
+			notPkgTargets: []string{"TestX"},
+			expectError:   false,
+		},
+		{
+			name:        "go test joined -count=1 leaves package",
+			targets:     []string{"-count=1", "./pkg"},
+			pkgTargets:  []string{"./pkg"},
+			expectError: false,
+		},
+		{
+			name:          "go test -run value with no package target",
+			targets:       []string{"-run", "TestX"},
+			pkgTargets:    nil,
+			notPkgTargets: []string{"TestX"},
+			expectError:   false,
+		},
+		{
+			name:          "go test package before -run flag",
+			targets:       []string{"./pkg", "-run", "TestX"},
+			pkgTargets:    []string{"./pkg"},
+			notPkgTargets: []string{"TestX"},
+			expectError:   false,
+		},
+		{
+			name:          "go test package before joined -count",
+			targets:       []string{"./...", "-count=1"},
+			pkgTargets:    []string{"./..."},
+			notPkgTargets: []string{"-count=1"},
+			expectError:   false,
+		},
+		{
+			name:          "go test -args tail is not a package",
+			targets:       []string{"./pkg", "-args", "serverarg"},
+			pkgTargets:    []string{"./pkg"},
+			notPkgTargets: []string{"serverarg"},
+			expectError:   false,
+		},
+		{
+			name:          "go test -vet value is not a package",
+			targets:       []string{"-vet", "off", "./pkg"},
+			pkgTargets:    []string{"./pkg"},
+			notPkgTargets: []string{"off"},
+			expectError:   false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -154,6 +223,10 @@ func TestSplitBuildTargets(t *testing.T) {
 				}
 				for _, exp := range tt.fileTargets {
 					assert.Contains(t, fileTargets, exp, "Expected file target %q not found in %v", exp, fileTargets)
+				}
+				for _, notExp := range tt.notPkgTargets {
+					assert.NotContains(t, pkgTargets, notExp,
+						"Flag value %q must not be parsed as a package (got %v)", notExp, pkgTargets)
 				}
 			}
 		})

--- a/tool/internal/setup/testdata/where/err_is_test_with_has_func.yml
+++ b/tool/internal/setup/testdata/where/err_is_test_with_has_func.yml
@@ -1,0 +1,3 @@
+# Error: is_test combined with has_func — explicit composition required
+is_test: true
+has_func: TestMain

--- a/tool/internal/setup/testdata/where/ok_is_test_false.expected
+++ b/tool/internal/setup/testdata/where/ok_is_test_false.expected
@@ -1,0 +1,2 @@
+type: IsTestFilter
+should_match: false

--- a/tool/internal/setup/testdata/where/ok_is_test_false.yml
+++ b/tool/internal/setup/testdata/where/ok_is_test_false.yml
@@ -1,0 +1,1 @@
+is_test: false

--- a/tool/internal/setup/testdata/where/ok_is_test_true.expected
+++ b/tool/internal/setup/testdata/where/ok_is_test_true.expected
@@ -1,0 +1,2 @@
+type: IsTestFilter
+should_match: true

--- a/tool/internal/setup/testdata/where/ok_is_test_true.yml
+++ b/tool/internal/setup/testdata/where/ok_is_test_true.yml
@@ -1,0 +1,1 @@
+is_test: true


### PR DESCRIPTION
Adds `is_test`, a `where.file` boolean predicate that selects or excludes **test builds**, plus the `go test` support needed for it to take effect.

## What `is_test` matches

A test build is a compilation the Go toolchain produces only as part of `go test`: a package augmented with its `_test.go` files, an external `xxx_test` package, or the generated `_testmain.go` runner. The tool detects this from the presence of those sources in the compile's source set, surfaced as `setup.MatchContext.IsTest`.

- `is_test: true` — match only test builds
- `is_test: false` — match only non-test builds
- absent — no filtering

Test-ness is **not** an import-path `.test` suffix. The Go toolchain never passes a `.test` import path to `go tool compile`; that suffix lives in the test binary name and the `TOOLEXEC_IMPORTPATH` annotation, never in the compile's `-p` flag. An earlier suffix-based draft could not match in practice, so detection is keyed on the source set instead.

## `go test` support

`otelc` previously accepted only `go build`/`go install`, whose build plan never contains test packages, so `is_test` could never match. This PR accepts `otelc go test` and lists a `go test -a -x -n` plan, which surfaces the test-augmented, external test, and test-main compiles. `splitBuildTargets` also learns the `go test` value flags so `go test ./pkg -run TestX` resolves the package whether flags precede or follow it; `-args` stops target scanning.

## Commits

1. `feat(tool/rule)`: the `is_test` predicate — `FilterDef.IsTest`, `IsTestFilter`, `MatchContext.IsTest`, and `isTestBuild`. Counted as a leaf in the combinator-exclusivity guard, so it cannot be silently combined with `all-of`/`one-of`/`not`.
2. `test(tool)`: unit + golden coverage — leaf-filter unit tests, `Build` construction, `preciseMatching` end-to-end gating (including a production file matched because its build is a test build, and combinator+`is_test` negatives), YAML round-trip fixtures, and instrumentation goldens (a `source_test.go` fixture instrumented; a no-match fixture byte-identical to its source).
3. `feat(tool)`: `go test` build-plan support and test-flag-aware `splitBuildTargets`.

## Testing

- `go build ./...`
- `go test ./tool/... -race -count=1` — pass
- `make lint` — 0 issues
- Goldens: the match fixtures contain injected trampolines; the no-match golden is byte-identical to its `source.go`.

## Motivation

Rules could not opt into or out of test code, so instrumentation that should (or should not) apply under `go test` had no way to express it. `is_test` expresses it, and `go test` support makes it effective.

Fixes #550
Refs #346

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
