### PR TITLE
test(apps/k8sclient): enable parallelization and force immediate deletion of pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,19 +489,19 @@ test-integration: go-protobuf-plugins ## Run integration tests
 test-integration: build build-demo
 	@echo "Running integration tests..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags integration ./integration/... 2>&1 | tee ../gotest-integration.log
+	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags integration ./integration/... 2>&1 | tee ./gotest-integration.log
 
 .ONESHELL:
 test-latestlibbuild: build ## Run LatestLibBuild tests
 	@echo "Running LatestLibBuild tests..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags latestlibbuild ./latestlibbuild/... 2>&1 | tee ../gotest-latestlibbuild.log
+	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags latestlibbuild ./latestlibbuild/... 2>&1 | tee ./gotest-latestlibbuild.log
 
 .ONESHELL:
 test-latestlibrun: build ## Run LatestLibRun tests (bump apps to @latest then run integration suite)
 	@echo "Bumping test apps to @latest..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags latestlibrun ./latestlibrun/... 2>&1 | tee ../gotest-latestlibrun.log
+	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags latestlibrun ./latestlibrun/... 2>&1 | tee ./gotest-latestlibrun.log
 	$(MAKE) tidy/test-apps
 	@echo "Syncing test module with bumped apps..."
 	go -C "test" mod tidy
@@ -513,21 +513,21 @@ test-integration/coverage: ## Run integration tests with coverage report
 test-integration/coverage: build build-demo
 	@echo "Running integration tests with coverage report..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags integration ./integration/... -coverprofile=../coverage-integration.txt -covermode=atomic 2>&1 | tee ../gotest-integration.log
+	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags integration ./integration/... -coverprofile=../coverage-integration.txt -covermode=atomic 2>&1 | tee ./gotest-integration.log
 
 .ONESHELL:
 test-e2e: ## Run e2e tests
 test-e2e: build build-demo
 	@echo "Running e2e tests..."
 	set -euo pipefail
-	cd test && go test -json -v -shuffle=on -timeout=10m -count=1 -tags e2e ./e2e/... 2>&1 | tee ../gotest-e2e.log
+	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags e2e ./e2e/... 2>&1 | tee ./gotest-e2e.log
 
 .ONESHELL:
 test-e2e/coverage: ## Run e2e tests with coverage report
 test-e2e/coverage: build build-demo
 	@echo "Running e2e tests with coverage report..."
 	set -euo pipefail
-	cd test && go test -json -v -shuffle=on -timeout=10m -count=1 -tags e2e ./e2e/... -coverprofile=../coverage-e2e.txt -covermode=atomic 2>&1 | tee ../gotest-e2e.log
+	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags e2e ./e2e/... -coverprofile=../coverage-e2e.txt -covermode=atomic 2>&1 | tee ./gotest-e2e.log
 
 .PHONY: crosslink
 crosslink: $(CROSSLINK) ## Update intra-repository dependencies in all go modules

--- a/test/apps/k8sclient/main.go
+++ b/test/apps/k8sclient/main.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-const eventTimeout = 60 * time.Second
+const eventTimeout = 10 * time.Second
 
 func main() {
 	kubeConfigYaml := os.Getenv("KUBECONFIG_YAML")
@@ -151,7 +151,9 @@ func main() {
 	}
 
 	// delete the pod
-	err = clientset.CoreV1().Pods(corev1.NamespaceDefault).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+	err = clientset.CoreV1().Pods(corev1.NamespaceDefault).Delete(ctx, pod.Name, metav1.DeleteOptions{
+		GracePeriodSeconds: new(int64),
+	})
 	if err != nil {
 		log.Fatalf("Failed to delete pod: %v", err)
 	}

--- a/test/integration/k8s_client_test.go
+++ b/test/integration/k8s_client_test.go
@@ -21,6 +21,9 @@ func TestK8SClient(t *testing.T) {
 		t.Skip("k3s not supported on windows")
 	}
 
+	// Enable parallelization
+	t.Parallel()
+
 	f := testutil.NewTestFixture(t)
 	StartK3sCluster(t, f)
 


### PR DESCRIPTION
## Description

This PR enables `t.Parallel()` for the k8s integration test and forces immediate pod deletion (`GracePeriodSeconds: 0`) to avoid deletion timeouts.

I tested this both locally and in GitHub Actions on my fork:
https://github.com/amazingakai/opentelemetry-go-compile-instrumentation/actions/runs/26896875910

The test appears to be more stable with this approach.

---

## Checklist

* [x] PR title follows [[conventional commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) format
* [x] Code formatted: `make format`
* [x] Linters pass: `make lint`
* [x] Tests pass: `make test`
* [ ] Tests added for new functionality
* [ ] Tests follow [testing guidelines](docs/testing.md)
* [ ] Documentation updated (if applicable)