### PR TITLE
test: collector drain logs and metrics

### DIFF
--- a/test/testutil/collector.go
+++ b/test/testutil/collector.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-// Collector represents an in-memory OTLP collector for testing
+// Collector represents an in-memory OTLP collector for testing.
 type Collector struct {
 	*httptest.Server
 	mu     sync.Mutex
@@ -27,7 +27,17 @@ func (c *Collector) GetTraces() ptrace.Traces {
 	return c.traces
 }
 
-// StartCollector starts an in-memory OTLP HTTP server that collects traces
+// drainOK reads and discards the request body, then returns 200 OK. Used for
+// OTLP signals the harness accepts but does not record (metrics, logs), so
+// instrumented apps can export them without receiving a 404.
+func drainOK(w http.ResponseWriter, r *http.Request) {
+	_, _ = io.Copy(io.Discard, r.Body)
+	_ = r.Body.Close()
+	w.WriteHeader(http.StatusOK)
+}
+
+// StartCollector starts an in-memory OTLP HTTP server. Traces are recorded and
+// retrievable via GetTraces. Metrics and logs are accepted (200 OK).
 func StartCollector(t *testing.T) *Collector {
 	c := &Collector{traces: ptrace.NewTraces()}
 
@@ -55,6 +65,9 @@ func StartCollector(t *testing.T) *Collector {
 
 		w.WriteHeader(http.StatusOK)
 	})
+
+	mux.HandleFunc("/v1/metrics", drainOK)
+	mux.HandleFunc("/v1/logs", drainOK)
 
 	c.Server = httptest.NewServer(mux)
 	t.Cleanup(c.Close)


### PR DESCRIPTION
Drain logs and metrics in order to avoid 404 errors in the test collector.

Related to some errors I saw checking these [latestlibrun logs](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/actions/runs/26907317513/job/79375646725)

Related to TestK8SClient test cc @amazingakai 