### PR TITLE
fix(tool): preserve permissions and handle close errors in CopyFile

### DIFF
--- a/tool/util/sys.go
+++ b/tool/util/sys.go
@@ -63,30 +63,53 @@ func IsUnix() bool {
 }
 
 func CopyFile(src, dst string) error {
-	_, err := os.Stat(filepath.Dir(dst))
-	if os.IsNotExist(err) {
-		err = os.MkdirAll(filepath.Dir(dst), 0o755)
-		if err != nil {
-			return ex.Wrap(err)
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return ex.Wrapf(err, "failed to stat source file %q", src)
+	}
+
+	dstInfo, err := os.Stat(dst)
+	if err == nil {
+		// Avoid self-copy which would otherwise truncate the file.
+		if os.SameFile(srcInfo, dstInfo) {
+			return nil
 		}
+	} else if !os.IsNotExist(err) {
+		return ex.Wrapf(err, "failed to stat destination file %q", dst)
+	}
+
+	err = os.MkdirAll(filepath.Dir(dst), 0o755)
+	if err != nil {
+		return ex.Wrapf(err, "failed to create directory for file %q", dst)
 	}
 
 	srcFile, err := os.Open(src)
 	if err != nil {
-		return ex.Wrap(err)
+		return ex.Wrapf(err, "failed to open source file %q", src)
 	}
 	defer srcFile.Close()
 
 	dstFile, err := os.Create(dst)
 	if err != nil {
-		return ex.Wrap(err)
+		return ex.Wrapf(err, "failed to create destination file %q", dst)
 	}
-	defer dstFile.Close()
 
 	_, err = io.Copy(dstFile, srcFile)
 	if err != nil {
-		return ex.Wrap(err)
+		_ = dstFile.Close()
+		return ex.Wrapf(err, "failed to copy file from %q to %q", src, dst)
 	}
+
+	err = dstFile.Close()
+	if err != nil {
+		return ex.Wrapf(err, "failed to close destination file %q", dst)
+	}
+
+	err = os.Chmod(dst, srcInfo.Mode().Perm())
+	if err != nil {
+		return ex.Wrapf(err, "failed to change permissions for file %q", dst)
+	}
+
 	return nil
 }
 

--- a/tool/util/sys_test.go
+++ b/tool/util/sys_test.go
@@ -311,3 +311,118 @@ func TestListFiles_SkipsHiddenDirectories(t *testing.T) {
 		t.Fatalf("expected visible file to be returned")
 	}
 }
+
+func TestCopyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	src := filepath.Join(tmpDir, "src.txt")
+	dst := filepath.Join(tmpDir, "dst.txt")
+	content := []byte("hello world")
+
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatalf("failed to write src: %v", err)
+	}
+
+	if err := CopyFile(src, dst); err != nil {
+		t.Fatalf("CopyFile failed: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read dst: %v", err)
+	}
+
+	if string(got) != string(content) {
+		t.Errorf("got content %q, want %q", string(got), string(content))
+	}
+}
+
+func TestCopyFileNestedDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	src := filepath.Join(tmpDir, "src_nested.txt")
+	dst := filepath.Join(tmpDir, "a", "b", "c", "dst_nested.txt")
+	content := []byte("nested hello")
+
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatalf("failed to write src: %v", err)
+	}
+
+	if err := CopyFile(src, dst); err != nil {
+		t.Fatalf("CopyFile failed: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read dst: %v", err)
+	}
+
+	if string(got) != string(content) {
+		t.Errorf("got content %q, want %q", string(got), string(content))
+	}
+}
+
+func TestCopyFilePreservesPermissions(t *testing.T) {
+	if IsWindows() {
+		t.Skip("Skipping permission test on Windows")
+	}
+
+	tmpDir := t.TempDir()
+
+	src := filepath.Join(tmpDir, "src_perms.txt")
+	dst := filepath.Join(tmpDir, "dst_perms.txt")
+
+	if err := os.WriteFile(src, []byte("perms"), 0o700); err != nil {
+		t.Fatalf("failed to write src: %v", err)
+	}
+
+	if err := CopyFile(src, dst); err != nil {
+		t.Fatalf("CopyFile failed: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("failed to stat dst: %v", err)
+	}
+
+	if info.Mode().Perm() != 0o700 {
+		t.Errorf("got perm %o, want %o", info.Mode().Perm(), 0o700)
+	}
+}
+
+func TestCopyFileSourceDoesNotExist(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	err := CopyFile(
+		filepath.Join(tmpDir, "nonexistent"),
+		filepath.Join(tmpDir, "out"),
+	)
+
+	if err == nil {
+		t.Error("expected error for nonexistent source")
+	}
+}
+
+func TestCopyFileSameFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	src := filepath.Join(tmpDir, "same.txt")
+	content := []byte("hello")
+
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatalf("failed to write src: %v", err)
+	}
+
+	if err := CopyFile(src, src); err != nil {
+		t.Fatalf("CopyFile failed: %v", err)
+	}
+
+	got, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("failed to read src: %v", err)
+	}
+
+	if string(got) != string(content) {
+		t.Errorf("got %q, want %q", got, content)
+	}
+}


### PR DESCRIPTION
## Description

This PR improves `CopyFile` in `tool/util/sys.go` by:
- Preserving source file permissions on the copied file.
- Returning destination file `Close()` errors instead of ignoring them.
- Preventing accidental self-copy operations from modifying the source file.

It also adds unit tests covering:
- Successful file copies.
- Copying to nested directories.
- Permission preservation.
- Copying a file onto itself.
- Missing source file handling.

## Motivation

`CopyFile` currently creates destination files with default permissions and ignores errors returned by `Close()`. It can also unintentionally modify a file when the source and destination refer to the same file.

This change makes file copying more robust and adds test coverage for these behaviors.


---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
