### PR TITLE
test(integration/dbclient): update DB client DSN parsing expectations

### DIFF
--- a/test/integration/db_client_test.go
+++ b/test/integration/db_client_test.go
@@ -224,7 +224,7 @@ func TestDBClientDSNParsing(t *testing.T) {
 			dsn:        "sqlserver://sa:password@localhost:1433?database=master",
 			wantAddr:   "localhost",
 			wantPort:   1433,
-			wantDb:     "sa:password@localhost:1433", // Current ParseDbName logic for this format
+			wantDb:     "master",
 		},
 		{
 			name:       "SQLite3 local file",
@@ -232,7 +232,7 @@ func TestDBClientDSNParsing(t *testing.T) {
 			dsn:        "file:test.db?cache=shared",
 			wantAddr:   "sqlite3",
 			wantPort:   0,
-			wantDb:     "", // Current ParseDbName logic returns empty if no '/' is found
+			wantDb:     "test.db",
 		},
 	}
 


### PR DESCRIPTION
This PR updates the test expectations to match the current DSN parsing logic.

#481 was written before #474 merged and expected the previous DSN parsing behavior.

After both PRs merged, the integration test expectations became stale and started failing in CI.

