### PR TITLE
fix(util): allow ListFiles to walk hidden root directories

### DIFF
--- a/tool/util/sys.go
+++ b/tool/util/sys.go
@@ -125,7 +125,7 @@ func ListFiles(dir string) ([]string, error) {
 			return ex.Wrap(err)
 		}
 		// Don't list files under hidden directories
-		if strings.HasPrefix(info.Name(), ".") {
+		if path != dir && strings.HasPrefix(info.Name(), ".") {
 			if info.IsDir() {
 				return filepath.SkipDir
 			}

--- a/tool/util/sys_test.go
+++ b/tool/util/sys_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRunCmd(t *testing.T) {
@@ -310,6 +312,22 @@ func TestListFiles_SkipsHiddenDirectories(t *testing.T) {
 	if !foundVisible {
 		t.Fatalf("expected visible file to be returned")
 	}
+}
+
+func TestListFiles_HiddenRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	hiddenDir := filepath.Join(tmpDir, ".hidden")
+	require.NoError(t, os.MkdirAll(hiddenDir, 0o755))
+
+	file := filepath.Join(hiddenDir, "file.txt")
+	require.NoError(t, os.WriteFile(file, []byte("hello"), 0o644))
+
+	files, err := ListFiles(hiddenDir)
+	require.NoError(t, err)
+
+	require.Len(t, files, 1)
+	require.Equal(t, file, files[0])
 }
 
 func TestCopyFile(t *testing.T) {


### PR DESCRIPTION
## Description

`ListFiles` skips hidden directories during traversal by returning `filepath.SkipDir` when a directory name starts with `.`.

When the root directory passed to `ListFiles` is itself hidden, the walk terminates immediately and no files are returned, even though the caller explicitly requested traversal of that directory.

This change preserves the existing behavior for hidden subdirectories while allowing traversal of a hidden root directory passed directly to `ListFiles`.

## Motivation

`ListFiles` currently treats the root directory the same way as nested hidden directories.

As a result, calling `ListFiles` on a hidden directory returns an empty result because the walk is skipped before any files are visited. This behavior is unexpected when the hidden directory is explicitly provided by the caller.

This PR fixes that edge case and adds a regression test covering hidden root directory traversal.

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [ ] Linters pass: `make lint` *(typo check requires Docker)*
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
