### PR TITLE
refactor(tool): move version helpers to util package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,8 @@ GOOS ?= $(shell go env GOOS)
 VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
 COMMIT_HASH := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME := $(shell date -u '+%Y-%m-%d')
-LDFLAGS := -X main.Version=$(VERSION) -X main.CommitHash=$(COMMIT_HASH) -X main.BuildTime=$(BUILD_TIME)
+MODULE_PATH = github.com/open-telemetry/opentelemetry-go-compile-instrumentation
+LDFLAGS := -X $(MODULE_PATH)/tool/util.Version=$(VERSION) -X $(MODULE_PATH)/tool/util.CommitHash=$(COMMIT_HASH) -X $(MODULE_PATH)/tool/util.BuildTime=$(BUILD_TIME)
 GO_BUILD_CMD := go build -trimpath -a -ldflags "$(LDFLAGS)"
 ALL_GO_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort)
 EXT :=
@@ -148,7 +149,7 @@ install: package ## Install otelc to $$GOPATH/bin (auto-packages instrumentation
 	@echo "Installing otelc..."
 	@cp $(API_SYNC_SOURCE) $(API_SYNC_TARGET)
 	@go mod tidy
-	go install -ldflags "-X main.Version=$(VERSION) -X main.CommitHash=$(COMMIT_HASH) -X main.BuildTime=$(BUILD_TIME)" ./$(TOOL_DIR)
+	go install -ldflags "-X $(MODULE_PATH)/tool/util.Version=$(VERSION) -X $(MODULE_PATH)/tool/util.CommitHash=$(COMMIT_HASH) -X $(MODULE_PATH)/tool/util.BuildTime=$(BUILD_TIME)" ./$(TOOL_DIR)
 
 .ONESHELL:
 package: ## Package the instrumentation code into binary

--- a/tool/cmd/otelc/cmd_version.go
+++ b/tool/cmd/otelc/cmd_version.go
@@ -11,6 +11,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/ex"
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
 
 //nolint:gochecknoglobals // Implementation of a CLI command
@@ -25,20 +26,20 @@ var commandVersion = cli.Command{
 	},
 	Before: addLoggerPhaseAttribute,
 	Action: func(_ context.Context, cmd *cli.Command) error {
-		_, err := fmt.Fprintf(cmd.Writer, "otelc version %s", Version)
+		_, err := fmt.Fprintf(cmd.Writer, "otelc version %s", util.Version)
 		if err != nil {
 			return ex.Wrapf(err, "failed to print version")
 		}
 
-		if CommitHash != "unknown" {
-			_, err = fmt.Fprintf(cmd.Writer, "+%s", CommitHash)
+		if util.CommitHash != "unknown" {
+			_, err = fmt.Fprintf(cmd.Writer, "+%s", util.CommitHash)
 			if err != nil {
 				return ex.Wrapf(err, "failed to print commit hash")
 			}
 		}
 
-		if BuildTime != "unknown" {
-			_, err = fmt.Fprintf(cmd.Writer, " (%s)", BuildTime)
+		if util.BuildTime != "unknown" {
+			_, err = fmt.Fprintf(cmd.Writer, " (%s)", util.BuildTime)
 			if err != nil {
 				return ex.Wrapf(err, "failed to print build time")
 			}

--- a/tool/util/version.go
+++ b/tool/util/version.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package main
+package util
 
 import (
 	"runtime/debug"


### PR DESCRIPTION
Split from #584.

## Description

Moves version metadata from `tool/cmd/otelc/version.go` to `tool/util/version.go`.

## Motivation

This allows version information to be used outside the `cmd` package, for example from the `setup` package.
