### PR TITLE
docs: add registry update checklist and guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,9 @@ BEFORE SUBMITTING:
   make lint    # Run all linters
   make test    # Run all tests (unit + integration + e2e)
 
+If your PR adds a new user-facing instrumentation, please also submit a corresponding OpenTelemetry Registry PR:
+https://opentelemetry.io/ecosystem/registry/adding/
+
 For detailed contribution guidelines, see CONTRIBUTING.md
 For available make targets, run: make help
 -->
@@ -48,3 +51,4 @@ Fixes #<!-- issue number -->
 - [ ] Tests added for new functionality
 - [ ] Tests follow [testing guidelines](docs/testing.md)
 - [ ] Documentation updated (if applicable)
+- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))

--- a/docs/instrument-guide.md
+++ b/docs/instrument-guide.md
@@ -206,11 +206,20 @@ To run integration tests:
 make test-integration
 ```
 
-## 4. Verify
+## 4. Register the Instrumentation
+
+If applicable, create a PR to add the instrumentation to the OpenTelemetry registry in the `opentelemetry.io` repository.
+
+Follow the [OpenTelemetry Registry contribution guide](https://opentelemetry.io/ecosystem/registry/adding/).
+
+Not every instrumentation package should be listed. Internal helper packages (for example, `basic`, `runtime`, or packages that only provide implementation details for other instrumentations) generally do not need registry entries.
+
+## 5. Verify
 
 Check that your instrumentation package has the following elements:
 
 - A rule YAML under `instrumentation/<import_path>/.../otelc..yaml` with a correct `target` and version range.
-- Hook implementation under `instrumentation/<import_path>/...`
+- Hook implementation under `instrumentation/<import_path>/...`.
 - Unit tests alongside the hooks for logic-level behavior.
 - Integration tests in `test/integration/` that execute an instrumented binary and validate spans/attributes.
+- If applicable, a PR has been opened to add the instrumentation to the OpenTelemetry registry in the `opentelemetry.io` repository.

--- a/docs/instrument-guide.md
+++ b/docs/instrument-guide.md
@@ -208,7 +208,7 @@ make test-integration
 
 ## 4. Register the Instrumentation
 
-If applicable, create a PR to add the instrumentation to the OpenTelemetry registry in the `opentelemetry.io` repository.
+If your PR adds a new user-facing instrumentation, create a PR to add the instrumentation to the OpenTelemetry registry in the `opentelemetry.io` repository.
 
 Follow the [OpenTelemetry Registry contribution guide](https://opentelemetry.io/ecosystem/registry/adding/).
 


### PR DESCRIPTION
Document the process for registering new user-facing instrumentations in the OpenTelemetry Registry.