### PR TITLE
fix(instrumentation/grpc): prevent reentrant OTel SDK initialization in BeforeDialContext

### DIFF
--- a/instrumentation/google.golang.org/grpc/client/client_hook.go
+++ b/instrumentation/google.golang.org/grpc/client/client_hook.go
@@ -5,9 +5,7 @@ package client
 
 import (
 	"context"
-	"os"
 	"runtime/debug"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -24,6 +22,7 @@ import (
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/instrumentation/google.golang.org/grpc/internal/otlpfilter"
 	grpcsemconv "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/instrumentation/google.golang.org/grpc/semconv"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/hook"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/runtime"
@@ -143,14 +142,13 @@ func BeforeNewClient(ictx hook.HookContext, target string, opts ...grpc.DialOpti
 		return
 	}
 
-	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-	if endpoint == "" {
-		endpoint = os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+	if target == "" {
+		logger.Debug("BeforeNewClient called with empty target, skipping instrumentation")
+		return
 	}
 
-	// Skip instrumentation for OTLP exporter endpoints to prevent deadlock/infinite recursion
-	if target != "" && strings.Contains(endpoint, target) {
-		logger.Debug("Skipping instrumentation for OTLP exporter endpoint", "target", target, "endpoint", endpoint)
+	if otlpfilter.IsExporterTarget(target) {
+		logger.Debug("Skipping instrumentation for OTLP exporter endpoint", "target", target)
 		return
 	}
 
@@ -180,6 +178,16 @@ func AfterNewClient(ictx hook.HookContext, conn *grpc.ClientConn, err error) {
 func BeforeDialContext(ictx hook.HookContext, ctx context.Context, target string, opts ...grpc.DialOption) {
 	if !clientEnabler.Enable() {
 		logger.Debug("gRPC client instrumentation disabled")
+		return
+	}
+
+	if target == "" {
+		logger.Debug("BeforeDialContext called with empty target, skipping instrumentation")
+		return
+	}
+
+	if otlpfilter.IsExporterTarget(target) {
+		logger.Debug("Skipping instrumentation for OTLP exporter endpoint", "target", target)
 		return
 	}
 
@@ -223,7 +231,7 @@ func newClientStatsHandler() stats.Handler {
 // TagRPC is called at the beginning of an RPC to create a context
 func (h *clientStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	// Skip instrumentation for OTLP exporter endpoints to prevent infinite recursion
-	if grpcsemconv.IsOTELExporterPath(info.FullMethodName) {
+	if otlpfilter.IsExporterPath(info.FullMethodName) {
 		return ctx
 	}
 

--- a/instrumentation/google.golang.org/grpc/client/client_hook_test.go
+++ b/instrumentation/google.golang.org/grpc/client/client_hook_test.go
@@ -74,7 +74,7 @@ func TestBeforeNewClient(t *testing.T) {
 			target:        "",
 			opts:          []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
 			enabledEnv:    true,
-			expectHandler: true,
+			expectHandler: false,
 		},
 		{
 			name:                    "oltp exporter endpoint target",

--- a/instrumentation/google.golang.org/grpc/internal/otlpfilter/otlpfilter.go
+++ b/instrumentation/google.golang.org/grpc/internal/otlpfilter/otlpfilter.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package otlpfilter identifies OTLP exporter gRPC calls that must not be
+// instrumented by the gRPC instrumentation itself.
+package otlpfilter
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	exporterTracePath   = "/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+	exporterMetricsPath = "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+	exporterLogsPath    = "/opentelemetry.proto.collector.logs.v1.LogsService/Export"
+)
+
+var exporterEndpointEnvVars = []string{
+	"OTEL_EXPORTER_OTLP_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+}
+
+// IsExporterPath returns true when fullMethod is an OTLP exporter method.
+func IsExporterPath(fullMethod string) bool {
+	return fullMethod == exporterTracePath ||
+		fullMethod == exporterMetricsPath ||
+		fullMethod == exporterLogsPath
+}
+
+// IsExporterTarget returns true when target matches a configured OTLP exporter endpoint.
+func IsExporterTarget(target string) bool {
+	if target == "" {
+		return false
+	}
+
+	for _, envVar := range exporterEndpointEnvVars {
+		endpoint := os.Getenv(envVar)
+		if endpoint != "" && strings.Contains(endpoint, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/instrumentation/google.golang.org/grpc/internal/otlpfilter/otlpfilter_test.go
+++ b/instrumentation/google.golang.org/grpc/internal/otlpfilter/otlpfilter_test.go
@@ -1,0 +1,111 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otlpfilter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsExporterPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		fullMethod string
+		want       bool
+	}{
+		{
+			name:       "trace exporter",
+			fullMethod: "/opentelemetry.proto.collector.trace.v1.TraceService/Export",
+			want:       true,
+		},
+		{
+			name:       "metrics exporter",
+			fullMethod: "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export",
+			want:       true,
+		},
+		{
+			name:       "logs exporter",
+			fullMethod: "/opentelemetry.proto.collector.logs.v1.LogsService/Export",
+			want:       true,
+		},
+		{
+			name:       "regular RPC",
+			fullMethod: "/grpc.testing.TestService/UnaryCall",
+			want:       false,
+		},
+		{
+			name:       "empty method",
+			fullMethod: "",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsExporterPath(tt.fullMethod))
+		})
+	}
+}
+
+func TestIsExporterTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVar string
+		target string
+		want   bool
+	}{
+		{
+			name:   "global endpoint",
+			envVar: "OTEL_EXPORTER_OTLP_ENDPOINT",
+			target: "localhost:4317",
+			want:   true,
+		},
+		{
+			name:   "traces endpoint",
+			envVar: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+			target: "localhost:4317",
+			want:   true,
+		},
+		{
+			name:   "metrics endpoint",
+			envVar: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+			target: "localhost:4317",
+			want:   true,
+		},
+		{
+			name:   "logs endpoint",
+			envVar: "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+			target: "localhost:4317",
+			want:   true,
+		},
+		{
+			name:   "empty target",
+			envVar: "OTEL_EXPORTER_OTLP_ENDPOINT",
+			target: "",
+			want:   false,
+		},
+		{
+			name:   "target does not match",
+			envVar: "OTEL_EXPORTER_OTLP_ENDPOINT",
+			target: "localhost:50051",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(tt.envVar, "http://localhost:4317")
+
+			assert.Equal(t, tt.want, IsExporterTarget(tt.target))
+		})
+	}
+}
+
+func TestIsExporterTargetChecksAllEndpoints(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:50051")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://localhost:4317")
+
+	assert.True(t, IsExporterTarget("localhost:4317"))
+}

--- a/instrumentation/google.golang.org/grpc/semconv/grpc.go
+++ b/instrumentation/google.golang.org/grpc/semconv/grpc.go
@@ -13,15 +13,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const (
-	// OTELExporterTracePath is the gRPC method for OTLP trace export
-	OTELExporterTracePath = "/opentelemetry.proto.collector.trace.v1.TraceService/Export"
-	// OTELExporterMetricPath is the gRPC method for OTLP metric export
-	OTELExporterMetricPath = "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
-	// OTELExporterLogPath is the gRPC method for OTLP log export
-	OTELExporterLogPath = "/opentelemetry.proto.collector.logs.v1.LogsService/Export"
-)
-
 // ParseFullMethod returns a span name and attributes based on a gRPC's FullMethod.
 // Parsing is consistent with grpc-go implementation.
 // Format: /package.service/method
@@ -131,12 +122,4 @@ func ClientAddrAttrs(addr string) []attribute.KeyValue {
 		attrs = append(attrs, semconv.ClientPort(port))
 	}
 	return attrs
-}
-
-// IsOTELExporterPath returns true if the method is an OpenTelemetry exporter endpoint.
-// These methods should be excluded from instrumentation to prevent infinite recursion.
-func IsOTELExporterPath(fullMethod string) bool {
-	return fullMethod == OTELExporterTracePath ||
-		fullMethod == OTELExporterMetricPath ||
-		fullMethod == OTELExporterLogPath
 }

--- a/instrumentation/google.golang.org/grpc/semconv/grpc_test.go
+++ b/instrumentation/google.golang.org/grpc/semconv/grpc_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	grpc_codes "google.golang.org/grpc/codes"
@@ -268,60 +267,6 @@ func TestClientAddrAttrs(t *testing.T) {
 			if tt.expectedPort > 0 {
 				assert.Contains(t, attrs, semconv.ClientPort(tt.expectedPort))
 			}
-		})
-	}
-}
-
-func TestIsOTELExporterPath(t *testing.T) {
-	tests := []struct {
-		name       string
-		fullMethod string
-		expected   bool
-	}{
-		{
-			name:       "trace exporter path",
-			fullMethod: OTELExporterTracePath,
-			expected:   true,
-		},
-		{
-			name:       "metric exporter path",
-			fullMethod: OTELExporterMetricPath,
-			expected:   true,
-		},
-		{
-			name:       "log exporter path",
-			fullMethod: OTELExporterLogPath,
-			expected:   true,
-		},
-		{
-			name:       "regular method",
-			fullMethod: "/grpc.testing.TestService/UnaryCall",
-			expected:   false,
-		},
-		{
-			name:       "health check",
-			fullMethod: "/grpc.health.v1.Health/Check",
-			expected:   false,
-		},
-		{
-			name:       "empty path",
-			fullMethod: "",
-			expected:   false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := IsOTELExporterPath(tt.fullMethod)
-			require.Equal(
-				t,
-				tt.expected,
-				result,
-				"IsOTELExporterPath(%q) = %v, want %v",
-				tt.fullMethod,
-				result,
-				tt.expected,
-			)
 		})
 	}
 }

--- a/instrumentation/google.golang.org/grpc/server/server_hook.go
+++ b/instrumentation/google.golang.org/grpc/server/server_hook.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 
+	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/instrumentation/google.golang.org/grpc/internal/otlpfilter"
 	grpcsemconv "github.com/open-telemetry/opentelemetry-go-compile-instrumentation/instrumentation/google.golang.org/grpc/semconv"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/hook"
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pkg/runtime"
@@ -175,7 +176,7 @@ func newServerStatsHandler() stats.Handler {
 // TagRPC is called at the beginning of an RPC to create a context
 func (h *serverStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	// Skip instrumentation for OTLP exporter endpoints to prevent infinite recursion
-	if grpcsemconv.IsOTELExporterPath(info.FullMethodName) {
+	if otlpfilter.IsExporterPath(info.FullMethodName) {
 		return ctx
 	}
 


### PR DESCRIPTION
Split from #456.

Prevents a deadlock in applications that use `grpc.DialContext` together with an OTLP gRPC exporter configured via:
```
OTEL_EXPORTER_OTLP_PROTOCOL=grpc
OTEL_EXPORTER_OTLP_ENDPOINT=...
```

The fix skips instrumentation for OTLP exporter targets before gRPC instrumentation is initialized, preventing reentrant OpenTelemetry SDK initialization.

Co-authored-by: shown <yuluo08290126@gmail.com>
