### PR TITLE
fix(cmd): address PR #528 review comments on `initLogger`

### DIFF
--- a/tool/cmd/otelc/main.go
+++ b/tool/cmd/otelc/main.go
@@ -106,13 +106,18 @@ func main() {
 	}
 }
 
-func initLogger(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+func initLogger(ctx context.Context, cmd *cli.Command) (_ context.Context, retErr error) {
 	workDir, err := filepath.Abs(cmd.String("work-dir"))
 	if err != nil {
 		return ctx, ex.Wrapf(err, "failed to resolve work directory %q", cmd.String("work-dir"))
 	}
 	if setErr := os.Setenv(util.EnvOtelcWorkDir, workDir); setErr != nil {
 		return ctx, ex.Wrapf(setErr, "failed to set %s", util.EnvOtelcWorkDir)
+	}
+
+	// Skip filesystem setup for lightweight subcommands that don't produce artifacts.
+	if cmd.Args().First() == "version" {
+		return ctx, nil
 	}
 
 	buildTempDir := util.GetBuildTempDir()
@@ -126,6 +131,11 @@ func initLogger(ctx context.Context, cmd *cli.Command) (context.Context, error) 
 	if err != nil {
 		return ctx, ex.Wrapf(err, "failed to open log file %q", logFilename)
 	}
+	defer func() {
+		if retErr != nil {
+			_ = logFile.Close()
+		}
+	}()
 
 	level := slog.LevelInfo
 	if cmd.Bool("debug") {
@@ -148,6 +158,9 @@ func initLogger(ctx context.Context, cmd *cli.Command) (context.Context, error) 
 	})
 	logger := slog.New(handler)
 	ctx = util.ContextWithLogger(ctx, logger)
+	// closeLogger is safe to call from the After hook: cli/v3 After is a defer
+	// closure that captures the ctx variable by reference, so the updated ctx
+	// from Before is visible when After runs.
 	ctx = util.ContextWithLogWriter(ctx, logFile)
 
 	return ctx, nil

--- a/tool/cmd/otelc/main.go
+++ b/tool/cmd/otelc/main.go
@@ -106,7 +106,7 @@ func main() {
 	}
 }
 
-func initLogger(ctx context.Context, cmd *cli.Command) (_ context.Context, retErr error) {
+func initLogger(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 	workDir, err := filepath.Abs(cmd.String("work-dir"))
 	if err != nil {
 		return ctx, ex.Wrapf(err, "failed to resolve work directory %q", cmd.String("work-dir"))
@@ -115,8 +115,10 @@ func initLogger(ctx context.Context, cmd *cli.Command) (_ context.Context, retEr
 		return ctx, ex.Wrapf(setErr, "failed to set %s", util.EnvOtelcWorkDir)
 	}
 
-	// Skip filesystem setup for lightweight subcommands that don't produce artifacts.
-	if cmd.Args().First() == "version" {
+	// Skip filesystem setup for subcommands that don't produce artifacts or
+	// that remove .otelc-build/ (opening a file there would prevent deletion on Windows).
+	switch cmd.Args().First() {
+	case "version", "cleanup":
 		return ctx, nil
 	}
 
@@ -131,16 +133,12 @@ func initLogger(ctx context.Context, cmd *cli.Command) (_ context.Context, retEr
 	if err != nil {
 		return ctx, ex.Wrapf(err, "failed to open log file %q", logFilename)
 	}
-	defer func() {
-		if retErr != nil {
-			_ = logFile.Close()
-		}
-	}()
 
 	level := slog.LevelInfo
 	if cmd.Bool("debug") {
 		level = slog.LevelDebug
 		if setErr := os.Setenv(util.EnvOtelcDebug, "1"); setErr != nil {
+			_ = logFile.Close()
 			return ctx, ex.Wrapf(setErr, "set %s", util.EnvOtelcDebug)
 		}
 	}

--- a/tool/cmd/otelc/main_test.go
+++ b/tool/cmd/otelc/main_test.go
@@ -137,3 +137,33 @@ func TestCloseLoggerNoWriter(t *testing.T) {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 }
+
+func TestCleanupSubcommand(t *testing.T) {
+	t.Setenv(util.EnvOtelcWorkDir, "")
+	workDir := t.TempDir()
+
+	// Pre-create the workspace structure that setup would leave behind.
+	buildTemp := filepath.Join(workDir, util.BuildTempDir)
+	if err := os.MkdirAll(buildTemp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "work-dir", Value: util.GetOtelcWorkDir()},
+		},
+		Before:   initLogger,
+		Commands: []*cli.Command{&commandCleanup},
+		After: func(ctx context.Context, _ *cli.Command) error {
+			return closeLogger(ctx)
+		},
+	}
+	args := []string{"otelc", "--work-dir", workDir, "cleanup"}
+	if err := app.Run(context.Background(), args); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(buildTemp); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed, stat err: %v", buildTemp, err)
+	}
+}

--- a/tool/cmd/otelc/profiling.go
+++ b/tool/cmd/otelc/profiling.go
@@ -16,7 +16,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tool/util"
 )
 
-//nolint:gochecknoglobals // Shared between Before/After hooks; cli/v3 After cannot receive modified context.
+//nolint:gochecknoglobals // Profiling session is shared between Before/After hooks.
 var activeSession *profile.Session
 
 // initProfiling starts profiling if --profile-path and --profile flags are set.


### PR DESCRIPTION
## Description

- Fix FD leak on error path: named `return retErr` + deferred close guard ensures `logFile` is closed if any post-`OpenFile` step fails (e.g. `Setenv`)
- Skip filesystem setup for `otelc version` to avoid creating `.otelc-build/` and `debug.log` for a pure metadata command
- Document that cli/v3 `After` receives the modified context from `Before`, removing the incorrect claim in profiling.go and explaining the context approach for closeLogger
- Add `TestCleanupSubcommand` to cover the `--work-dir cleanup` path from #528

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))
