### PR TITLE
feat(tool): add root module rule target

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -284,6 +284,11 @@ Rules:
 
 - `target: main` — matches the compile-time package named `main`.
 - `target: test_main` — not currently supported; reserved for future work.
+- `target: $root` — matches the root module of the build and every package
+  below it. If a build spans multiple modules, it matches the union of all
+  resolved roots. The setup phase expands this selector through the normal glob
+  target matcher, so rules do not need to hardcode the application's module
+  path.
 - An empty or whitespace-only `target` is rejected at load time: `target` is
   the sole package selector, so a rule without one can never match.
 

--- a/tool/internal/pkgload/pkgload.go
+++ b/tool/internal/pkgload/pkgload.go
@@ -7,6 +7,7 @@ package pkgload
 import (
 	"context"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/tools/go/packages"
 
@@ -23,16 +24,50 @@ func LoadPackages(
 	buildFlags []string,
 	patterns ...string,
 ) ([]*packages.Package, error) {
+	dir, buildFlags, err := loadDirFromBuildFlags(buildFlags)
+	if err != nil {
+		return nil, err
+	}
 	cfg := &packages.Config{
 		Mode:       mode,
 		Context:    ctx,
 		BuildFlags: buildFlags,
+		Dir:        dir,
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {
 		return nil, ex.Wrapf(err, "loading packages %v", patterns)
 	}
 	return pkgs, nil
+}
+
+func loadDirFromBuildFlags(buildFlags []string) (string, []string, error) {
+	var dir string
+	filtered := make([]string, 0, len(buildFlags))
+	for i := 0; i < len(buildFlags); i++ {
+		flag := buildFlags[i]
+
+		switch {
+		case flag == "-C":
+			if i+1 >= len(buildFlags) {
+				return "", nil, ex.New("missing value for -C")
+			}
+			dir = buildFlags[i+1]
+			i++
+		case strings.HasPrefix(flag, "-C="):
+			dir = strings.TrimPrefix(flag, "-C=")
+		default:
+			filtered = append(filtered, flag)
+		}
+	}
+	if dir == "" {
+		return "", filtered, nil
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", nil, ex.Wrapf(err, "resolving -C directory %s", dir)
+	}
+	return absDir, filtered, nil
 }
 
 // ResolvePackageName returns the declared package name for an import path.
@@ -117,19 +152,19 @@ func PackageDir(pkg *packages.Package) string {
 	return ""
 }
 
-// resolveModuleDir returns the module directory for a given package directory.
-func resolveModuleDir(ctx context.Context, pkgDir string) (string, error) {
+// ResolveModule returns the module for a given package directory.
+func ResolveModule(ctx context.Context, pkgDir string) (*packages.Module, error) {
 	pkgs, err := LoadPackages(ctx, packages.NeedModule, nil, pkgDir)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if len(pkgs) == 0 {
-		return "", ex.Newf("no packages found for directory: %s", pkgDir)
+		return nil, ex.Newf("no packages found for directory: %s", pkgDir)
 	}
 
 	pkg := pkgs[0]
 	if pkg.Module == nil || pkg.Module.Dir == "" || len(pkg.Errors) > 0 {
-		return "", ex.Newf(
+		return nil, ex.Newf(
 			"failed to load module information for package in directory %s: module=%v, errors=%v",
 			pkgDir,
 			pkg.Module,
@@ -137,7 +172,16 @@ func resolveModuleDir(ctx context.Context, pkgDir string) (string, error) {
 		)
 	}
 
-	return pkg.Module.Dir, nil
+	return pkg.Module, nil
+}
+
+// ResolveModuleDir returns the module directory for a given package directory.
+func ResolveModuleDir(ctx context.Context, pkgDir string) (string, error) {
+	mod, err := ResolveModule(ctx, pkgDir)
+	if err != nil {
+		return "", err
+	}
+	return mod.Dir, nil
 }
 
 func FindModuleDirs(ctx context.Context, pkgs []*packages.Package) (map[string]bool, error) {
@@ -161,7 +205,7 @@ func FindModuleDirs(ctx context.Context, pkgs []*packages.Package) (map[string]b
 		if pkg.Module != nil {
 			moduleDir = pkg.Module.Dir
 		} else {
-			modDir, err := resolveModuleDir(ctx, pkgDir)
+			modDir, err := ResolveModuleDir(ctx, pkgDir)
 			if err != nil {
 				return nil, ex.Wrapf(err, "finding module dir for package %s", pkg.PkgPath)
 			}

--- a/tool/internal/pkgload/pkgload_test.go
+++ b/tool/internal/pkgload/pkgload_test.go
@@ -21,6 +21,31 @@ func TestLoadPackages(t *testing.T) {
 	assert.Equal(t, "fmt", pkgs[0].PkgPath)
 }
 
+func TestLoadPackagesWithChangeDirectoryFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	appDir := filepath.Join(tmpDir, "app")
+	require.NoError(t, os.MkdirAll(appDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(appDir, "go.mod"),
+		[]byte("module example.com/app\n\ngo 1.21\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(appDir, "main.go"),
+		[]byte("package main\n\nfunc main() {}\n"),
+		0o644,
+	))
+	t.Chdir(tmpDir)
+
+	for _, buildFlags := range [][]string{{"-C", "app"}, {"-C=app"}} {
+		pkgs, err := LoadPackages(t.Context(), packages.NeedName|packages.NeedModule, buildFlags, ".")
+		require.NoError(t, err)
+		require.Len(t, pkgs, 1)
+		require.NotNil(t, pkgs[0].Module)
+		assert.Equal(t, "example.com/app", pkgs[0].Module.Path)
+	}
+}
+
 func TestResolvePackageName(t *testing.T) {
 	tests := []struct {
 		importPath string
@@ -265,7 +290,7 @@ func TestResolveModuleDir(t *testing.T) {
 			t.Chdir(workDir)
 
 			ctx := t.Context()
-			moduleDir, err := resolveModuleDir(ctx, workDir)
+			mod, err := ResolveModule(ctx, workDir)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -273,12 +298,16 @@ func TestResolveModuleDir(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			require.Equal(t, "example.com/test", mod.Path)
 
 			expectedDir := tmpDir
 			if tt.expectedDir != "." {
 				expectedDir = tt.expectedDir
 			}
 
+			require.Equal(t, expectedDir, mod.Dir)
+			moduleDir, err := ResolveModuleDir(ctx, workDir)
+			require.NoError(t, err)
 			require.Equal(t, expectedDir, moduleDir)
 		})
 	}

--- a/tool/internal/rule/target_glob.go
+++ b/tool/internal/rule/target_glob.go
@@ -16,6 +16,15 @@ import (
 // import path that keeps the fast map-lookup matching path.
 const globMeta = "*?[{"
 
+// TargetRoot selects the root module of the build. The setup phase expands it
+// to a concrete module glob before matching rules.
+const TargetRoot = "$root"
+
+// IsRootTarget reports whether target is the root-module selector.
+func IsRootTarget(target string) bool {
+	return target == TargetRoot
+}
+
 // IsGlobTarget reports whether target uses glob syntax and therefore must be
 // matched against every dependency import path rather than looked up by exact
 // key. An empty target is not a glob.
@@ -32,6 +41,9 @@ func IsGlobTarget(target string) bool {
 // before it reaches ValidateTarget; a non-glob target is a literal import path
 // and is always valid.
 func ValidateTarget(target string) error {
+	if strings.Contains(strings.ToLower(target), TargetRoot) && target != TargetRoot {
+		return ex.Newf("target %q must be exactly %q", target, TargetRoot)
+	}
 	if !IsGlobTarget(target) {
 		return nil
 	}

--- a/tool/internal/rule/target_glob_test.go
+++ b/tool/internal/rule/target_glob_test.go
@@ -32,6 +32,25 @@ func TestIsGlobTarget(t *testing.T) {
 	}
 }
 
+func TestIsRootTarget(t *testing.T) {
+	tests := []struct {
+		target string
+		want   bool
+	}{
+		{rule.TargetRoot, true},
+		{"example.com/svc", false},
+		{"", false},
+		{"$root/**", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			if got := rule.IsRootTarget(tt.target); got != tt.want {
+				t.Errorf("IsRootTarget(%q) = %v, want %v", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateTarget(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -41,6 +60,7 @@ func TestValidateTarget(t *testing.T) {
 		// Exact targets are never glob-validated.
 		{name: "exact path", target: "example.com/svc"},
 		{name: "empty path", target: ""},
+		{name: "root target", target: "$root"},
 
 		// Valid glob patterns.
 		{name: "single segment star", target: "example.com/svc/*"},
@@ -62,6 +82,9 @@ func TestValidateTarget(t *testing.T) {
 		// doublestar.ValidatePattern. A semantically reversed range like "[z-a]"
 		// is not an error; it simply never matches, consistent with glob.
 		{name: "unclosed bracket", target: "example.com/svc/[ab", wantErr: true},
+		{name: "root target with suffix", target: "$root/**", wantErr: true},
+		{name: "root target with trailing space", target: "$root ", wantErr: true},
+		{name: "root target wrong case", target: "$ROOT", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -134,6 +134,43 @@ func matchVersion(dependency *Dependency, rule rule.InstRule) bool {
 	return util.VersionInRange(dependency.Version, rule.GetVersion())
 }
 
+type targetRule struct {
+	target string
+	rule   rule.InstRule
+}
+
+func (sp *SetupPhase) matchGlobRules(
+	dep *Dependency,
+	relevantRules []rule.InstRule,
+	globRules []targetRule,
+) []rule.InstRule {
+	var matched []rule.InstRule
+	var seen map[rule.InstRule]bool
+	for _, gr := range globRules {
+		if !rule.MatchGlobTarget(gr.target, dep.ImportPath) {
+			continue
+		}
+		if matched == nil {
+			matched = make([]rule.InstRule, 0, len(relevantRules)+1)
+			matched = append(matched, relevantRules...)
+			seen = make(map[rule.InstRule]bool, len(relevantRules)+1)
+			for _, r := range relevantRules {
+				seen[r] = true
+			}
+		}
+		if seen[gr.rule] {
+			continue
+		}
+		seen[gr.rule] = true
+		matched = append(matched, gr.rule)
+		sp.Debug("Match glob target", "rule", gr.rule.GetName(), "target", gr.target, "dep", dep.ImportPath)
+	}
+	if matched == nil {
+		return relevantRules
+	}
+	return matched
+}
+
 // runMatch performs precise matching of rules against the dependency's source code.
 // It parses source files and matches rules by examining AST nodes.
 //
@@ -146,7 +183,7 @@ func (sp *SetupPhase) runMatch(
 	ctx context.Context,
 	dep *Dependency,
 	exactRules map[string][]rule.InstRule,
-	globRules []rule.InstRule,
+	globRules []targetRule,
 ) (*rule.InstRuleSet, error) {
 	set := rule.NewInstRuleSet(dep.ImportPath)
 
@@ -164,21 +201,7 @@ func (sp *SetupPhase) runMatch(
 	// allocation-free. When built, it is a fresh slice to avoid aliasing the
 	// exact-match slice shared read-only across goroutines.
 	if len(globRules) > 0 {
-		var matched []rule.InstRule
-		for _, r := range globRules {
-			if !rule.MatchGlobTarget(r.GetTarget(), dep.ImportPath) {
-				continue
-			}
-			if matched == nil {
-				matched = make([]rule.InstRule, 0, len(relevantRules)+1)
-				matched = append(matched, relevantRules...)
-			}
-			matched = append(matched, r)
-			sp.Debug("Match glob target", "rule", r.GetName(), "target", r.GetTarget(), "dep", dep.ImportPath)
-		}
-		if matched != nil {
-			relevantRules = matched
-		}
+		relevantRules = sp.matchGlobRules(dep, relevantRules, globRules)
 	}
 
 	if len(relevantRules) == 0 {
@@ -552,11 +575,26 @@ func (sp *SetupPhase) matchDeps(
 	// (unchanged fast path). Glob-target rules cannot be keyed, so they are
 	// kept in a flat slice and evaluated against every dependency's import path.
 	exactRules := make(map[string][]rule.InstRule)
-	globRules := make([]rule.InstRule, 0)
+	globRules := make([]targetRule, 0)
 	for _, r := range allRules {
 		target := r.GetTarget()
+		if rule.IsRootTarget(target) {
+			if len(sp.rootModulePaths) == 0 && len(sp.buildPackages) > 0 {
+				sp.rootModulePaths, err = rootModulePaths(ctx, sp.buildPackages)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if len(sp.rootModulePaths) == 0 {
+				return nil, ex.Newf("rule %q uses target %q, but no root module was found", r.GetName(), target)
+			}
+			for _, root := range sp.rootModulePaths {
+				globRules = append(globRules, targetRule{target: root + "/**", rule: r})
+			}
+			continue
+		}
 		if rule.IsGlobTarget(target) {
-			globRules = append(globRules, r)
+			globRules = append(globRules, targetRule{target: target, rule: r})
 			continue
 		}
 		exactRules[target] = append(exactRules[target], r)

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otelc/tool/internal/rule"
 	"go.opentelemetry.io/otelc/tool/util"
+	"golang.org/x/tools/go/packages"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1228,7 +1229,12 @@ func TestRunMatch_GlobTargetMatches(t *testing.T) {
 	globRule := globFuncRule("glob-rule", "example.com/svc/**")
 
 	sp := newTestSetupPhase()
-	set, err := sp.runMatch(context.Background(), dep, map[string][]rule.InstRule{}, []rule.InstRule{globRule})
+	set, err := sp.runMatch(
+		context.Background(),
+		dep,
+		map[string][]rule.InstRule{},
+		[]targetRule{{target: globRule.Target, rule: globRule}},
+	)
 	require.NoError(t, err)
 	require.Len(t, set.FuncRules, 1, "glob target should match the descendant package")
 	require.Contains(t, set.FuncRules, srcFile)
@@ -1246,7 +1252,12 @@ func TestRunMatch_GlobTargetNoMatch(t *testing.T) {
 	globRule := globFuncRule("glob-rule", "example.com/svc/**")
 
 	sp := newTestSetupPhase()
-	set, err := sp.runMatch(context.Background(), dep, map[string][]rule.InstRule{}, []rule.InstRule{globRule})
+	set, err := sp.runMatch(
+		context.Background(),
+		dep,
+		map[string][]rule.InstRule{},
+		[]targetRule{{target: globRule.Target, rule: globRule}},
+	)
 	require.NoError(t, err)
 	require.True(t, set.IsEmpty(), "glob target must not match an unrelated package")
 }
@@ -1263,7 +1274,12 @@ func TestRunMatch_SingleSegmentGlobDoesNotCrossBoundary(t *testing.T) {
 	globRule := globFuncRule("glob-rule", "example.com/svc/*")
 
 	sp := newTestSetupPhase()
-	set, err := sp.runMatch(context.Background(), dep, map[string][]rule.InstRule{}, []rule.InstRule{globRule})
+	set, err := sp.runMatch(
+		context.Background(),
+		dep,
+		map[string][]rule.InstRule{},
+		[]targetRule{{target: globRule.Target, rule: globRule}},
+	)
 	require.NoError(t, err)
 	require.True(t, set.IsEmpty(), "single-segment glob must not cross a path boundary")
 }
@@ -1285,7 +1301,12 @@ func TestRunMatch_ExactAndGlobCoexist(t *testing.T) {
 	exactRules := map[string][]rule.InstRule{
 		"example.com/svc/users": {exactRule},
 	}
-	set, err := sp.runMatch(context.Background(), dep, exactRules, []rule.InstRule{globRule})
+	set, err := sp.runMatch(
+		context.Background(),
+		dep,
+		exactRules,
+		[]targetRule{{target: globRule.Target, rule: globRule}},
+	)
 	require.NoError(t, err)
 	require.Len(t, set.FuncRules[srcFile], 2, "both exact and glob rules should match")
 }
@@ -1327,6 +1348,78 @@ func TestMatchDeps_GlobTargetSplit(t *testing.T) {
 	require.True(t, matchedPaths["example.com/svc/users"], "users package should match the glob target")
 	require.True(t, matchedPaths["example.com/svc/orders"], "orders package should match the glob target")
 	require.False(t, matchedPaths["example.com/other"], "unrelated package must not match")
+}
+
+func TestMatchDeps_RootTargetExpandsToRootModuleGlob(t *testing.T) {
+	dir := t.TempDir()
+	ruleFile := filepath.Join(dir, "root.yaml")
+	err := os.WriteFile(ruleFile, []byte(`root_hook:
+  target: $root
+  func: Handler
+  before: BeforeHandler
+  path: "example.com/hooks"
+`), 0o644)
+	require.NoError(t, err)
+
+	rootSrc := writeGoSource(t, "root.go", "package app\n\nfunc Handler() {}\n")
+	childSrc := writeGoSource(t, "child.go", "package child\n\nfunc Handler() {}\n")
+	pluginSrc := writeGoSource(t, "plugin.go", "package plugin\n\nfunc Handler() {}\n")
+	externalSrc := writeGoSource(t, "external.go", "package external\n\nfunc Handler() {}\n")
+	prefixSrc := writeGoSource(t, "prefix.go", "package prefix\n\nfunc Handler() {}\n")
+
+	sp := newTestSetupPhase()
+	sp.ruleConfig = ruleFile
+	sp.buildPackages = []*packages.Package{
+		{Module: &packages.Module{Path: "example.com/app"}},
+		{Module: &packages.Module{Path: "example.com/app/plugin"}},
+	}
+
+	deps := []*Dependency{
+		{ImportPath: "example.com/app", Sources: []string{rootSrc}, CgoFiles: map[string]string{}},
+		{ImportPath: "example.com/app/internal/child", Sources: []string{childSrc}, CgoFiles: map[string]string{}},
+		{ImportPath: "example.com/app/plugin", Sources: []string{pluginSrc}, CgoFiles: map[string]string{}},
+		{ImportPath: "example.com/other", Sources: []string{externalSrc}, CgoFiles: map[string]string{}},
+		{ImportPath: "example.com/appliance", Sources: []string{prefixSrc}, CgoFiles: map[string]string{}},
+	}
+
+	matched, err := sp.matchDeps(context.Background(), deps, nil)
+	require.NoError(t, err)
+
+	matchedPaths := make(map[string]bool)
+	for _, m := range matched {
+		matchedPaths[m.ModulePath] = true
+	}
+	require.True(t, matchedPaths["example.com/app"], "root package should match")
+	require.True(t, matchedPaths["example.com/app/internal/child"], "root sub-package should match")
+	require.True(t, matchedPaths["example.com/app/plugin"], "nested root package should match")
+	require.False(t, matchedPaths["example.com/other"], "external package must not match")
+	require.False(t, matchedPaths["example.com/appliance"], "prefix without slash boundary must not match")
+	for _, m := range matched {
+		if m.ModulePath == "example.com/app/plugin" {
+			require.Len(t, m.FuncRules[pluginSrc], 1, "overlapping roots must not apply the same rule twice")
+		}
+	}
+}
+
+func TestMatchDeps_RootTargetRequiresRootModule(t *testing.T) {
+	dir := t.TempDir()
+	ruleFile := filepath.Join(dir, "root.yaml")
+	err := os.WriteFile(ruleFile, []byte(`root_hook:
+  target: $root
+  func: Handler
+  before: BeforeHandler
+  path: "example.com/hooks"
+`), 0o644)
+	require.NoError(t, err)
+
+	sp := newTestSetupPhase()
+	sp.ruleConfig = ruleFile
+
+	_, err = sp.matchDeps(context.Background(), []*Dependency{
+		{ImportPath: "example.com/app", Sources: []string{}, CgoFiles: map[string]string{}},
+	}, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, `target "$root"`)
 }
 
 func TestMatchDeps_InvalidGlobTargetRejected(t *testing.T) {

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -24,8 +25,10 @@ import (
 )
 
 type SetupPhase struct {
-	logger     *slog.Logger
-	ruleConfig string
+	logger          *slog.Logger
+	ruleConfig      string
+	buildPackages   []*packages.Package
+	rootModulePaths []string
 }
 
 func (sp *SetupPhase) Info(msg string, args ...any)  { sp.logger.Info(msg, args...) }
@@ -135,6 +138,7 @@ func getBuildPackages(ctx context.Context, args []string) ([]*packages.Package, 
 	if err != nil {
 		return nil, ex.Wrapf(err, "splitting build targets")
 	}
+	buildFlags := extractBuildFlags(args)
 
 	var (
 		pkgs    []*packages.Package
@@ -142,7 +146,7 @@ func getBuildPackages(ctx context.Context, args []string) ([]*packages.Package, 
 	)
 	switch {
 	case len(fileTargets) > 0:
-		pkgs, loadErr = pkgload.LoadPackages(ctx, mode, nil, fileTargets...)
+		pkgs, loadErr = pkgload.LoadPackages(ctx, mode, buildFlags, fileTargets...)
 		if loadErr != nil {
 			return nil, ex.Wrapf(loadErr, "failed to load packages for files %v", fileTargets)
 		}
@@ -151,12 +155,12 @@ func getBuildPackages(ctx context.Context, args []string) ([]*packages.Package, 
 			return nil, ex.New("multiple packages found for file targets")
 		}
 	case len(pkgTargets) > 0:
-		pkgs, loadErr = pkgload.LoadPackages(ctx, mode, nil, pkgTargets...)
+		pkgs, loadErr = pkgload.LoadPackages(ctx, mode, buildFlags, pkgTargets...)
 		if loadErr != nil {
 			return nil, ex.Wrapf(loadErr, "failed to load packages for patterns %v", pkgTargets)
 		}
 	default:
-		pkgs, loadErr = pkgload.LoadPackages(ctx, mode, nil, ".")
+		pkgs, loadErr = pkgload.LoadPackages(ctx, mode, buildFlags, ".")
 		if loadErr != nil {
 			return nil, ex.Wrapf(loadErr, "failed to load packages for pattern .")
 		}
@@ -240,6 +244,28 @@ func splitBuildTargets(args []string) ([]string, []string, error) {
 	return pkgs, files, nil
 }
 
+func rootModulePaths(ctx context.Context, pkgs []*packages.Package) ([]string, error) {
+	roots := make(map[string]bool)
+	for _, pkg := range pkgs {
+		if pkg.Module != nil && pkg.Module.Path != "" {
+			roots[pkg.Module.Path] = true
+			continue
+		}
+		pkgDir := pkgload.PackageDir(pkg)
+		if pkgDir == "" {
+			continue
+		}
+		mod, err := pkgload.ResolveModule(ctx, pkgDir)
+		if err != nil {
+			return nil, ex.Wrapf(err, "finding module dir for package %s", pkg.PkgPath)
+		}
+		if mod.Path != "" {
+			roots[mod.Path] = true
+		}
+	}
+	return slices.Sorted(maps.Keys(roots)), nil
+}
+
 // generateRuntimePerPackage generates the injected hook code (otelc.runtime.go)
 // for every buildable package.
 func (sp *SetupPhase) generateRuntimePerPackage(
@@ -292,6 +318,7 @@ func Setup(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
+	sp.buildPackages = pkgs
 
 	// Find all dependencies of the project being build
 	deps, err := sp.findDeps(ctx, subcommand, args)
@@ -380,6 +407,8 @@ func setupGoCache(ctx context.Context, env []string) ([]string, error) {
 //
 //nolint:gochecknoglobals // private lookup table
 var buildContextFlagsWithValue = map[string]bool{
+	"-C":       true, // Change directory before running the command
+	"-overlay": true, // JSON overlay file used by go list/build
 	"-tags":    true, // Build tags
 	"-mod":     true, // Module mode (vendor, mod, readonly)
 	"-modfile": true, // Custom go.mod file

--- a/tool/internal/setup/setup_test.go
+++ b/tool/internal/setup/setup_test.go
@@ -123,6 +123,29 @@ func TestGetPackages(t *testing.T) {
 	}
 }
 
+func TestGetPackagesWithChangeDirectoryFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	appDir := filepath.Join(tmpDir, "app")
+	require.NoError(t, os.MkdirAll(appDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(appDir, "go.mod"),
+		[]byte("module example.com/app\n\ngo 1.21\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(appDir, "main.go"),
+		[]byte("package main\n\nfunc main() {}\n"),
+		0o644,
+	))
+	t.Chdir(tmpDir)
+
+	pkgs, err := getBuildPackages(t.Context(), []string{"-C", "app", "."})
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1)
+	require.NotNil(t, pkgs[0].Module)
+	require.Equal(t, "example.com/app", pkgs[0].Module.Path)
+}
+
 func TestSplitBuildTargets(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -288,6 +311,27 @@ func setupTestModule(t *testing.T, subDirs []string) {
 	t.Chdir(tmpDir)
 }
 
+func TestRootModulePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	appDir := filepath.Join(tmpDir, "app")
+	require.NoError(t, os.MkdirAll(appDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, "go.mod"),
+		[]byte("module example.com/app\n\ngo 1.25\n"),
+		0o644,
+	))
+	t.Chdir(tmpDir)
+	mainFile := filepath.Join(appDir, "main.go")
+	require.NoError(t, os.WriteFile(mainFile, []byte("package main\n\nfunc main() {}\n"), 0o644))
+
+	got, err := rootModulePaths(t.Context(), []*packages.Package{
+		{PkgPath: "example.com/direct", Module: &packages.Module{Path: "example.com/direct"}},
+		{PkgPath: pkgload.CommandLineArgumentsPackage, GoFiles: []string{mainFile}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"example.com/app", "example.com/direct"}, got)
+}
+
 func TestSetupGoCache(t *testing.T) {
 	t.Run("respects existing GOCACHE", func(t *testing.T) {
 		t.Setenv("GOCACHE", "/existing/cache")
@@ -395,6 +439,16 @@ func TestExtractBuildFlags(t *testing.T) {
 			name:     "modfile with spaces in path",
 			args:     []string{"build", "-modfile", "path with spaces/go.mod", "./..."},
 			expected: []string{"-modfile", "path with spaces/go.mod"},
+		},
+		{
+			name:     "change directory flag",
+			args:     []string{"build", "-C", "app", "./..."},
+			expected: []string{"-C", "app"},
+		},
+		{
+			name:     "overlay flag",
+			args:     []string{"build", "-overlay=overlay.json", "./..."},
+			expected: []string{"-overlay=overlay.json"},
 		},
 		{
 			name:     "race=true is normalized",


### PR DESCRIPTION
## Description

Adds `target: $root` for instrumentation rules.

During setup, `$root` is resolved from the build root module and expanded to `<module-path>/**`. Matching then goes through the existing glob target path, so this does not add a separate package-matching branch.

Fixes #611

## Motivation

Rules that target first-party code currently need either `target: main` or a hardcoded module path.

`target: main` only covers the main package, and hardcoding the module path is awkward for forks or renamed modules. `$root` gives rule authors a portable way to match the root package and its subpackages.

---

## Checklist

  - [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
  - [x] Code formatted: `gofmt`
  - [ ] Linters pass: `make lint`
    - `make lint/go` passes locally
    - full `make lint` hits unrelated YAML formatting diffs in this Windows checkout
  - [x] Tests pass: `make test`
  - [x] Tests added for new functionality
  - [x] Tests follow [testing guidelines](docs/testing.md)
  - [x] Documentation updated (if applicable)
  - [ ] OpenTelemetry Registry updated (not applicable)