### PR TITLE
test: force 70% coverage limit + extra tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,10 @@
 # Codecov configuration.
 # https://docs.codecov.com/docs/codecov-yaml
 
+# Exclude test helpers from coverage.
+ignore:
+  - "pkg/hook/hooktest"
+
 coverage:
   status:
     project:
@@ -12,14 +16,12 @@ coverage:
         flags:
           - tool
         target: 70%
-        # informational: true — report-only; does not block CI or PR merges.
-        # Flip to false once tool/ consistently meets the 70% target.
-        informational: true
+        # informational: false (enforcing). A drop below target blocks the PR.
+        informational: false
       # pkg/ module tree
       pkg:
         flags:
           - pkg
         target: 70%
-        # informational: true — report-only; does not block CI or PR merges.
-        # Flip to false once pkg/ consistently meets the 70% target.
-        informational: true
+        # informational: false (enforcing). A drop below target blocks the PR.
+        informational: false

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -105,14 +105,12 @@ make test-e2e/coverage
 ## Coverage
 
 > [!NOTE]
-> The project targets a **≥70% unit-test coverage** goal for both the `tool/` and `pkg/` module trees.
-> This is an **aspirational target** currently being worked toward. The CI step reports coverage
-> for both trees but does **not yet block merges** when coverage is below the threshold.
-> Once the target is consistently met, the gate will be promoted to enforcement.
+> The project enforces a **≥74% unit-test coverage** floor for both the `tool/` and `pkg/` module trees.
+> Codecov checks each tree against the target and **blocks the PR** when coverage drops below it.
 
 ### Coverage target rationale
 
-The 70% floor is the minimum bar agreed in [issue #569](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/569)
+The 74% floor is the minimum bar agreed in [issue #569](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/569)
 (tracked under the release 1.0.0 roadmap). Coverage is tracked **per module tree** — `tool/` and
 `pkg/` are checked independently so that one area cannot mask regression in the other.
 
@@ -123,9 +121,9 @@ The `test-unit-coverage` job in `.github/workflows/test-unit.yaml`:
 1. Runs `make test-unit/coverage` to generate `coverage-tool.txt` and `coverage-pkg.txt`.
 2. Uploads both files to Codecov for historical tracking (flags: `tool`, `pkg`).
 
-Codecov evaluates each flag against the 70% target defined in `codecov.yml` and posts the result
-as an **informational** status check — a coverage shortfall is visible in the PR but does **not**
-block merges. Flip `informational: false` in `codecov.yml` once the target is consistently met.
+Codecov evaluates each flag against the 74% target defined in `codecov.yml` and posts the result
+as an **enforcing** status check (`informational: false`): a coverage shortfall below the target
+fails the check and blocks the PR.
 
 All test commands use `-shuffle=on` and `-count=1` to avoid ordering issues and caching.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -105,12 +105,12 @@ make test-e2e/coverage
 ## Coverage
 
 > [!NOTE]
-> The project enforces a **≥74% unit-test coverage** floor for both the `tool/` and `pkg/` module trees.
+> The project enforces a **≥70% unit-test coverage** floor for both the `tool/` and `pkg/` module trees.
 > Codecov checks each tree against the target and **blocks the PR** when coverage drops below it.
 
 ### Coverage target rationale
 
-The 74% floor is the minimum bar agreed in [issue #569](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/569)
+The 70% floor is the minimum bar agreed in [issue #569](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/569)
 (tracked under the release 1.0.0 roadmap). Coverage is tracked **per module tree** — `tool/` and
 `pkg/` are checked independently so that one area cannot mask regression in the other.
 
@@ -121,7 +121,7 @@ The `test-unit-coverage` job in `.github/workflows/test-unit.yaml`:
 1. Runs `make test-unit/coverage` to generate `coverage-tool.txt` and `coverage-pkg.txt`.
 2. Uploads both files to Codecov for historical tracking (flags: `tool`, `pkg`).
 
-Codecov evaluates each flag against the 74% target defined in `codecov.yml` and posts the result
+Codecov evaluates each flag against the 70% target defined in `codecov.yml` and posts the result
 as an **enforcing** status check (`informational: false`): a coverage shortfall below the target
 fails the check and blocks the PR.
 

--- a/pkg/runtime/setup_test.go
+++ b/pkg/runtime/setup_test.go
@@ -6,7 +6,6 @@ package runtime
 import (
 	"context"
 	"log/slog"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -75,24 +74,23 @@ func TestSetupOpenTelemetry(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
 	restoreProviders(t)
 
-	err := setupOpenTelemetry(Config{
-		ServiceName:            "test-service",
-		ServiceVersion:         "1.0.0",
+	setupOpenTelemetry(Config{
 		InstrumentationName:    "test-inst",
 		InstrumentationVersion: "2.0.0",
 	})
-	require.NoError(t, err)
+	assert.NotNil(t, tracerProvider, "trace provider should be configured when an OTLP endpoint is set")
 }
 
 func TestSetupOpenTelemetryExporterError(t *testing.T) {
 	// An invalid protocol makes the exporter fail to build, but setupOpenTelemetry
-	// logs and swallows the error rather than propagating it.
+	// logs and swallows the error rather than propagating it or panicking.
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "invalid-protocol")
 	restoreProviders(t)
 
-	err := setupOpenTelemetry(Config{ServiceName: "test-service"})
-	require.NoError(t, err)
+	assert.NotPanics(t, func() {
+		setupOpenTelemetry(Config{InstrumentationName: "test-service"})
+	})
 }
 
 func TestInitializePanicRecovery(t *testing.T) {
@@ -101,15 +99,13 @@ func TestInitializePanicRecovery(t *testing.T) {
 	origLogger := logger
 	t.Cleanup(func() {
 		logger = origLogger
-		initOnce = sync.Once{}
 	})
 	restoreProviders(t)
 
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 	logger = nil
-	initOnce = sync.Once{}
 
 	assert.NotPanics(t, func() {
-		Initialize(Config{ServiceName: "test-service"})
+		Initialize(Config{InstrumentationName: "test-service"})
 	})
 }

--- a/pkg/runtime/setup_test.go
+++ b/pkg/runtime/setup_test.go
@@ -1,0 +1,111 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestLogLevel(t *testing.T) {
+	tests := []struct {
+		envValue string
+		expected slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"", slog.LevelInfo},        // unset defaults to info
+		{"unknown", slog.LevelInfo}, // unrecognized value defaults to info
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.envValue, func(t *testing.T) {
+			t.Setenv("OTEL_LOG_LEVEL", tt.envValue)
+			assert.Equal(t, tt.expected, logLevel())
+		})
+	}
+}
+
+func TestShutdownNilProviders(t *testing.T) {
+	// The providers are package globals shared across tests, so save and restore
+	// them to keep this test order-independent.
+	origTracer, origMeter := tracerProvider, meterProvider
+	t.Cleanup(func() { tracerProvider, meterProvider = origTracer, origMeter })
+
+	// With no providers configured, Shutdown is a no-op that returns nil.
+	tracerProvider = nil
+	meterProvider = nil
+	require.NoError(t, Shutdown(context.Background()))
+}
+
+func TestShutdownProviders(t *testing.T) {
+	origTracer, origMeter := tracerProvider, meterProvider
+	t.Cleanup(func() { tracerProvider, meterProvider = origTracer, origMeter })
+
+	// Providers with no exporters shut down cleanly, exercising both shutdown
+	// branches without any network dependency.
+	tracerProvider = sdktrace.NewTracerProvider()
+	meterProvider = sdkmetric.NewMeterProvider()
+	require.NoError(t, Shutdown(context.Background()))
+}
+
+// restoreProviders resets the global providers after a test that configures them.
+func restoreProviders(t *testing.T) {
+	origTracer, origMeter := tracerProvider, meterProvider
+	t.Cleanup(func() { tracerProvider, meterProvider = origTracer, origMeter })
+}
+
+func TestSetupOpenTelemetry(t *testing.T) {
+	// A configured OTLP endpoint drives the full trace-provider setup path.
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+	restoreProviders(t)
+
+	err := setupOpenTelemetry(Config{
+		ServiceName:            "test-service",
+		ServiceVersion:         "1.0.0",
+		InstrumentationName:    "test-inst",
+		InstrumentationVersion: "2.0.0",
+	})
+	require.NoError(t, err)
+}
+
+func TestSetupOpenTelemetryExporterError(t *testing.T) {
+	// An invalid protocol makes the exporter fail to build, but setupOpenTelemetry
+	// logs and swallows the error rather than propagating it.
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "invalid-protocol")
+	restoreProviders(t)
+
+	err := setupOpenTelemetry(Config{ServiceName: "test-service"})
+	require.NoError(t, err)
+}
+
+func TestInitializePanicRecovery(t *testing.T) {
+	// Initialize must never crash the host application. A nil logger forces a
+	// panic inside setup, which the deferred recover in Initialize must absorb.
+	origLogger := logger
+	t.Cleanup(func() {
+		logger = origLogger
+		initOnce = sync.Once{}
+	})
+	restoreProviders(t)
+
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+	logger = nil
+	initOnce = sync.Once{}
+
+	assert.NotPanics(t, func() {
+		Initialize(Config{ServiceName: "test-service"})
+	})
+}

--- a/pkg/runtime/setup_test.go
+++ b/pkg/runtime/setup_test.go
@@ -29,7 +29,11 @@ func TestLogLevel(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.envValue, func(t *testing.T) {
+		name := tt.envValue
+		if name == "" {
+			name = "unset"
+		}
+		t.Run(name, func(t *testing.T) {
 			t.Setenv("OTEL_LOG_LEVEL", tt.envValue)
 			assert.Equal(t, tt.expected, logLevel())
 		})

--- a/pkg/runtime/suppress_test.go
+++ b/pkg/runtime/suppress_test.go
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPClientInstrumentationSuppression(t *testing.T) {
+	ctx := context.Background()
+
+	// A plain context carries no suppression flag.
+	assert.False(t, IsHTTPClientInstrumentationSuppressed(ctx))
+
+	// Once suppressed, the returned context reports the flag.
+	suppressed := SuppressHTTPClientInstrumentation(ctx)
+	assert.True(t, IsHTTPClientInstrumentationSuppressed(suppressed))
+
+	// Suppression does not leak back into the original context.
+	assert.False(t, IsHTTPClientInstrumentationSuppressed(ctx))
+}

--- a/tool/internal/profile/profile_test.go
+++ b/tool/internal/profile/profile_test.go
@@ -4,6 +4,7 @@
 package profile
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -204,6 +205,51 @@ func TestStartInvalidDir(t *testing.T) {
 	_, err := Start(filepath.Join(f.Name(), "subdir"), []Type{Heap})
 	if err == nil {
 		t.Fatal("Start() with invalid dir returned nil error, want error")
+	}
+}
+
+func TestMerge(t *testing.T) {
+	dir := t.TempDir()
+
+	// Produce a real PID-stamped heap profile to merge.
+	s, err := Start(dir, []Type{Heap})
+	if err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	if stopErr := s.Stop(); stopErr != nil {
+		t.Fatalf("Stop() error: %v", stopErr)
+	}
+	pidFile := filepath.Join(dir, fmt.Sprintf("otelc-heap-%d.pprof", os.Getpid()))
+	assertFileExists(t, pidFile)
+
+	if mergeErr := Merge(context.Background(), dir, []Type{Heap}); mergeErr != nil {
+		t.Fatalf("Merge() error: %v", mergeErr)
+	}
+
+	// The merged file is written and the PID-stamped input is removed.
+	assertFileExists(t, filepath.Join(dir, "otelc-heap.pprof"))
+	if _, statErr := os.Stat(pidFile); !os.IsNotExist(statErr) {
+		t.Errorf("expected PID-stamped file %q to be removed after merge", pidFile)
+	}
+}
+
+func TestMergeTraceSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	// Trace profiles cannot be merged, so Merge is a no-op for them and must not
+	// create a merged trace file.
+	if err := Merge(context.Background(), dir, []Type{Trace}); err != nil {
+		t.Fatalf("Merge() error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "otelc-trace.pprof")); !os.IsNotExist(statErr) {
+		t.Error("Merge() must not create a merged trace file")
+	}
+}
+
+func TestMergeNoFiles(t *testing.T) {
+	// With no matching profile files present, Merge succeeds without writing anything.
+	if err := Merge(context.Background(), t.TempDir(), []Type{Heap, CPU}); err != nil {
+		t.Fatalf("Merge() error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/569

Replaces https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pull/610

Forces >70% coverage + add extra tests