### PR TITLE
test(bench): raise baseline overhead threshold to 550%

### DIFF
--- a/test/bench/overhead_test.go
+++ b/test/bench/overhead_test.go
@@ -73,7 +73,7 @@ func TestOverheadCeiling(t *testing.T) {
 		// keeping the default threshold for all others.
 		scenarioMaxPct := maxPct
 		if name == "baseline" {
-			scenarioMaxPct = 500
+			scenarioMaxPct = 550
 		}
 
 		if pct > scenarioMaxPct {


### PR DESCRIPTION
The baseline scenario intentionally has no matched instrumentation rules, but otelc injects the OpenTelemetry SDK initialization package. Updating the OpenTelemetry SDK increased its compile-time cost enough to consistently exceed the current 500% ceiling, so raise the baseline threshold while keeping the existing threshold for the other benchmark scenarios.