### PR TITLE
feat(tool): implement isSetup check in setup phase

### DIFF
--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -46,8 +46,8 @@ func (sp *SetupPhase) keepForDebug(srcPath string) {
 
 // This function can be used to check if the setup has been completed.
 func isSetup() bool {
-	// TODO: Implement Task
-	return false
+	stateManager, err := LoadStateManager()
+	return err == nil && stateManager != nil
 }
 
 // flagsWithPathValues contains flags that accept a value from "go build" command.

--- a/tool/internal/setup/setup_test.go
+++ b/tool/internal/setup/setup_test.go
@@ -493,3 +493,34 @@ func TestExtractBuildFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSetup(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	// In a clean directory, isSetup should return false
+	require.False(t, isSetup())
+
+	// Create the build temp directory first so Commit doesn't fail
+	err := os.MkdirAll(util.GetBuildTempDir(), 0o755)
+	require.NoError(t, err)
+
+	// Create stateManager and commit to create the state file
+	stateManager := NewStateManager()
+	err = stateManager.Commit()
+	require.NoError(t, err)
+
+	// Since state.json now exists, isSetup should return true
+	require.True(t, isSetup())
+
+	// If we write invalid JSON to state.json, isSetup should return false
+	stateFile := util.GetBuildTemp(stateFileName)
+	err = os.WriteFile(stateFile, []byte("{invalid json"), 0o644)
+	require.NoError(t, err)
+	require.False(t, isSetup())
+
+	// Remove the state file, isSetup should return false
+	err = os.Remove(stateFile)
+	require.NoError(t, err)
+	require.False(t, isSetup())
+}


### PR DESCRIPTION
## Description

This PR implements the `isSetup` check in the compilation/setup pipeline. 

Key changes:
- Swapped the `isSetup()` stub in `tool/internal/setup/setup.go` for a functional check using `LoadStateManager()`.
- Added a unit test `TestIsSetup` in `tool/internal/setup/setup_test.go` to cover clean, valid, invalid, and deleted state scenarios.

## Motivation

Previously, `isSetup()` was an unimplemented stub returning `false`. Because of this, consecutive invocations of `otelc setup` or compile-time setup runs executed the entire setup lifecycle (extracting modules, matching rules, generating package runtime code, etc.) repeatedly. 

With this change, the pipeline checks for a successfully committed `state.json` file on disk via `LoadStateManager()`, avoiding redundant execution steps and disk I/O.

Fixes #658

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))


