### PR TITLE
feat(pkg/runtime): respect OTEL_SDK_DISABLED, add console/none exporters and setup logger provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,7 +542,7 @@ test-integration: go-protobuf-plugins ## Run integration tests
 test-integration: build build-demo
 	@echo "Running integration tests..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags integration ./integration/... 2>&1 | tee ./gotest-integration.log
+	go -C "test" test -json -v -shuffle=on -timeout=15m -count=1 -tags integration ./integration/... 2>&1 | tee ./gotest-integration.log
 
 .ONESHELL:
 test-latestlibbuild: build ## Run LatestLibBuild tests
@@ -583,7 +583,7 @@ test-integration/coverage: ## Run integration tests with coverage report
 test-integration/coverage: build build-demo
 	@echo "Running integration tests with coverage report..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags integration ./integration/... -coverprofile=../coverage-integration.txt -covermode=atomic 2>&1 | tee ./gotest-integration.log
+	go -C "test" test -json -v -shuffle=on -timeout=15m -count=1 -tags integration ./integration/... -coverprofile=../coverage-integration.txt -covermode=atomic 2>&1 | tee ./gotest-integration.log
 
 .ONESHELL:
 test-e2e: ## Run e2e tests

--- a/pkg/runtime/go.mod
+++ b/pkg/runtime/go.mod
@@ -7,7 +7,9 @@ require (
 	go.opentelemetry.io/contrib/exporters/autoexport v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0
 	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/log v0.20.0
 	go.opentelemetry.io/otel/sdk v1.44.0
+	go.opentelemetry.io/otel/sdk/log v0.20.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 )
@@ -41,9 +43,7 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 // indirect
-	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/pkg/runtime/otel_setup.go
+++ b/pkg/runtime/otel_setup.go
@@ -27,13 +27,15 @@ import (
 // Exporter Configuration (applies independently to each signal; traces,
 // metrics, and logs are all enabled by default and configured symmetrically):
 //   - OTEL_TRACES_EXPORTER: Traces exporter: otlp (default), console, none
-//   - OTEL_METRICS_EXPORTER: Metrics exporter: otlp (default), console, none
+//   - OTEL_METRICS_EXPORTER: Metrics exporter: otlp (default), console, prometheus, none
 //   - OTEL_LOGS_EXPORTER: Logs exporter: otlp (default), console, none
 //   - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint for all signals (default: http://localhost:4318)
 //   - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: Traces-specific endpoint override
 //   - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: Metrics-specific endpoint override
 //   - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: Logs-specific endpoint override
 //   - OTEL_EXPORTER_OTLP_PROTOCOL: Protocol (grpc, http/protobuf, http/json)
+//   - OTEL_EXPORTER_PROMETHEUS_HOST: Prometheus exporter host (default: localhost)
+//   - OTEL_EXPORTER_PROMETHEUS_PORT: Prometheus exporter port (default: 9464)
 //
 // When the exporter for a signal defaults to "otlp" and no endpoint override
 // is set, telemetry for that signal is sent to the OTLP-spec default endpoint

--- a/pkg/runtime/otel_setup.go
+++ b/pkg/runtime/otel_setup.go
@@ -14,22 +14,41 @@ import (
 // The SDK automatically configures exporters based on environment variables
 // following the OpenTelemetry specification:
 //
+// SDK Configuration:
+//   - OTEL_SDK_DISABLED: If set to the case-insensitive string "true", the SDK
+//     is disabled entirely and no providers are installed. Every other value
+//     (including unset) leaves the SDK enabled, per the OpenTelemetry
+//     specification.
+//
 // Service Configuration (highest to lowest precedence):
 //   - OTEL_RESOURCE_ATTRIBUTES: Key-value pairs (e.g., "service.name=myapp,service.version=1.2.3")
 //   - OTEL_SERVICE_NAME: Service name for telemetry
 //
-// Exporter Configuration:
-//   - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint (e.g., http://localhost:4317)
-//   - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: Traces-specific endpoint
-//   - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: Metrics-specific endpoint
+// Exporter Configuration (applies independently to each signal; traces,
+// metrics, and logs are all enabled by default and configured symmetrically):
+//   - OTEL_TRACES_EXPORTER: Traces exporter: otlp (default), console, none
+//   - OTEL_METRICS_EXPORTER: Metrics exporter: otlp (default), console, none
+//   - OTEL_LOGS_EXPORTER: Logs exporter: otlp (default), console, none
+//   - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint for all signals (default: http://localhost:4318)
+//   - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: Traces-specific endpoint override
+//   - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: Metrics-specific endpoint override
+//   - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: Logs-specific endpoint override
 //   - OTEL_EXPORTER_OTLP_PROTOCOL: Protocol (grpc, http/protobuf, http/json)
-//   - OTEL_TRACES_EXPORTER: Trace exporter (otlp, console, none)
-//   - OTEL_METRICS_EXPORTER: Metrics exporter (otlp, console, none)
+//
+// When the exporter for a signal defaults to "otlp" and no endpoint override
+// is set, telemetry for that signal is sent to the OTLP-spec default endpoint
+// (http://localhost:4318). This means traces, metrics, and logs are exported
+// by default even when no OTLP endpoint is configured; set the relevant
+// *_EXPORTER variable to "none" to disable a signal explicitly.
 //
 // Other Configuration:
 //   - OTEL_LOG_LEVEL: Log level (debug, info, warn, error)
-//   - OTEL_SDK_DISABLED: Disable the SDK (true/false)
 func SetupOTelSDK() {
+	if strings.EqualFold(os.Getenv("OTEL_SDK_DISABLED"), "true") {
+		Logger().Info("OpenTelemetry SDK disabled via OTEL_SDK_DISABLED=true, skipping initialization")
+		return
+	}
+
 	// Initialize OpenTelemetry SDK with defensive error handling
 	Initialize(Config{
 		InstrumentationName:    "go.opentelemetry.io/otelc",

--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -13,7 +13,9 @@ import (
 	"go.opentelemetry.io/contrib/exporters/autoexport"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
+	logglobal "go.opentelemetry.io/otel/log/global"
 	"go.opentelemetry.io/otel/propagation"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -29,6 +31,7 @@ var (
 	logger         *slog.Logger
 	meterProvider  *sdkmetric.MeterProvider
 	tracerProvider *sdktrace.TracerProvider
+	loggerProvider *sdklog.LoggerProvider
 )
 
 func init() {
@@ -110,14 +113,19 @@ func setupOpenTelemetry(cfg Config) {
 		res = resource.Default()
 	}
 
-	// Setup trace provider with OTLP exporter
+	// Setup trace provider with auto-configured exporter
 	if err := setupTraceProvider(ctx, res); err != nil {
 		logger.Warn("failed to setup trace provider", "error", err)
 	}
 
-	// Setup meter provider with OTLP exporter
+	// Setup meter provider with auto-configured exporter
 	if err := setupMeterProvider(ctx, res); err != nil {
 		logger.Warn("failed to setup meter provider", "error", err)
+	}
+
+	// Setup logger provider with auto-configured exporter
+	if err := setupLoggerProvider(ctx, res); err != nil {
+		logger.Warn("failed to setup logger provider", "error", err)
 	}
 
 	// Set W3C Trace Context as the propagator
@@ -133,23 +141,24 @@ func setupOpenTelemetry(cfg Config) {
 
 // setupTraceProvider creates and configures the trace provider
 func setupTraceProvider(ctx context.Context, res *resource.Resource) error {
-	// Get OTLP endpoint from environment
-	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-	if endpoint == "" {
-		endpoint = os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
-	}
-
-	// If no endpoint is configured, skip trace provider setup
-	if endpoint == "" {
-		logger.Debug("no OTLP endpoint configured, skipping trace provider setup")
-		return nil
-	}
-
 	// Use autoexport to automatically select the right exporter based on
-	// OTEL_EXPORTER_OTLP_PROTOCOL (defaults to http/protobuf)
+	// OTEL_TRACES_EXPORTER (defaults to otlp) and OTEL_EXPORTER_OTLP_PROTOCOL
+	// (defaults to http/protobuf). Supports: otlp, console, and none.
+	//
+	// This mirrors setupMeterProvider: the exporter-selection env vars decide
+	// whether/where traces go, not the presence of an OTLP endpoint env var.
+	// When otlp is selected (the default) and no endpoint is configured, the
+	// exporter falls back to the OTLP-spec default endpoint.
 	traceExporter, err := autoexport.NewSpanExporter(ctx)
 	if err != nil {
 		return err
+	}
+
+	// OTEL_TRACES_EXPORTER=none: skip building a provider/processor entirely
+	// rather than running a batch processor that will never export anything.
+	if autoexport.IsNoneSpanExporter(traceExporter) {
+		logger.Debug("trace exporter disabled via OTEL_TRACES_EXPORTER=none, skipping trace provider setup")
+		return nil
 	}
 
 	spanProcessor := sdktrace.NewBatchSpanProcessor(traceExporter,
@@ -169,18 +178,25 @@ func setupTraceProvider(ctx context.Context, res *resource.Resource) error {
 	// Set global tracer provider
 	otel.SetTracerProvider(tracerProvider)
 
-	logger.Info("trace provider initialized", "endpoint", endpoint)
+	logger.Info("trace provider initialized with auto-export")
 	return nil
 }
 
 // setupMeterProvider creates and configures the meter provider
 func setupMeterProvider(ctx context.Context, res *resource.Resource) error {
 	// Use autoexport to automatically select the right exporter based on
-	// OTEL_EXPORTER_OTLP_PROTOCOL (defaults to http/protobuf)
-	// Supports: otlp, console, and none
+	// OTEL_METRICS_EXPORTER (defaults to otlp) and OTEL_EXPORTER_OTLP_PROTOCOL
+	// (defaults to http/protobuf). Supports: otlp, console, prometheus, and none.
 	metricReader, err := autoexport.NewMetricReader(ctx)
 	if err != nil {
 		return err
+	}
+
+	// OTEL_METRICS_EXPORTER=none: skip building a provider around a reader
+	// that will never be collected, matching the traces/logs behavior.
+	if autoexport.IsNoneMetricReader(metricReader) {
+		logger.Debug("metric exporter disabled via OTEL_METRICS_EXPORTER=none, skipping meter provider setup")
+		return nil
 	}
 
 	// Create meter provider with the auto-configured reader
@@ -193,6 +209,38 @@ func setupMeterProvider(ctx context.Context, res *resource.Resource) error {
 	otel.SetMeterProvider(meterProvider)
 
 	logger.Info("meter provider initialized with auto-export")
+	return nil
+}
+
+// setupLoggerProvider creates and configures the logger provider
+func setupLoggerProvider(ctx context.Context, res *resource.Resource) error {
+	// Use autoexport to automatically select the right exporter based on
+	// OTEL_LOGS_EXPORTER (defaults to otlp) and OTEL_EXPORTER_OTLP_PROTOCOL
+	// (defaults to http/protobuf). Supports: otlp, console, and none.
+	//
+	// This mirrors setupTraceProvider/setupMeterProvider so all three signals
+	// are configured symmetrically via autoexport.
+	logExporter, err := autoexport.NewLogExporter(ctx)
+	if err != nil {
+		return err
+	}
+
+	// OTEL_LOGS_EXPORTER=none: skip building a provider/processor entirely
+	// rather than running a batch processor that will never export anything.
+	if autoexport.IsNoneLogExporter(logExporter) {
+		logger.Debug("log exporter disabled via OTEL_LOGS_EXPORTER=none, skipping logger provider setup")
+		return nil
+	}
+
+	loggerProvider = sdklog.NewLoggerProvider(
+		sdklog.WithResource(res),
+		sdklog.WithProcessor(sdklog.NewBatchProcessor(logExporter)),
+	)
+
+	// Set global logger provider
+	logglobal.SetLoggerProvider(loggerProvider)
+
+	logger.Info("logger provider initialized with auto-export")
 	return nil
 }
 
@@ -210,6 +258,13 @@ func Shutdown(ctx context.Context) error {
 	if meterProvider != nil {
 		if shutdownErr := meterProvider.Shutdown(ctx); shutdownErr != nil {
 			Logger().Error("failed to shutdown meter provider", "error", shutdownErr)
+			err = shutdownErr
+		}
+	}
+
+	if loggerProvider != nil {
+		if shutdownErr := loggerProvider.Shutdown(ctx); shutdownErr != nil {
+			Logger().Error("failed to shutdown logger provider", "error", shutdownErr)
 			err = shutdownErr
 		}
 	}

--- a/pkg/runtime/setup.go
+++ b/pkg/runtime/setup.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/contrib/exporters/autoexport"
@@ -28,10 +29,11 @@ const (
 )
 
 var (
-	logger         *slog.Logger
-	meterProvider  *sdkmetric.MeterProvider
-	tracerProvider *sdktrace.TracerProvider
-	loggerProvider *sdklog.LoggerProvider
+	logger                *slog.Logger
+	meterProvider         *sdkmetric.MeterProvider
+	tracerProvider        *sdktrace.TracerProvider
+	loggerProvider        *sdklog.LoggerProvider
+	registerSignalHandler sync.Once
 )
 
 func init() {
@@ -301,28 +303,31 @@ func StartRuntimeMetrics() {
 // setupSignalHandler registers a goroutine that listens for OS signals
 // and gracefully shuts down the OpenTelemetry SDK when receiving interrupt signals.
 // This ensures telemetry is flushed before the application exits.
+// This function is safe to call multiple times; it will only register the handler once.
 func setupSignalHandler() {
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt)
+	registerSignalHandler.Do(func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt)
 
-	go func() {
-		sig := <-sigCh
-		logger.Info("received signal, initiating graceful shutdown", "signal", sig.String())
+		go func() {
+			sig := <-sigCh
+			logger.Info("received signal, initiating graceful shutdown", "signal", sig.String())
 
-		// Create a context with timeout for shutdown
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
+			// Create a context with timeout for shutdown
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
 
-		// Shutdown OTel SDK
-		if err := Shutdown(ctx); err != nil {
-			logger.Error("error during shutdown", "error", err)
-		} else {
-			logger.Info("OpenTelemetry SDK shutdown completed successfully")
-		}
+			// Shutdown OTel SDK
+			if err := Shutdown(ctx); err != nil {
+				logger.Error("error during shutdown", "error", err)
+			} else {
+				logger.Info("OpenTelemetry SDK shutdown completed successfully")
+			}
 
-		// After shutdown completes, exit cleanly
-		// os.Interrupt is cross-platform (SIGINT on Unix, Ctrl+C on Windows)
-		signal.Reset(os.Interrupt)
-		os.Exit(0)
-	}()
+			// After shutdown completes, exit cleanly
+			// os.Interrupt is cross-platform (SIGINT on Unix, Ctrl+C on Windows)
+			signal.Reset(os.Interrupt)
+			os.Exit(0)
+		}()
+	})
 }

--- a/pkg/runtime/setup_test.go
+++ b/pkg/runtime/setup_test.go
@@ -134,6 +134,11 @@ func TestSetupOTelSDKDisabled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("OTEL_SDK_DISABLED", tt.envValue)
+			// Pin exporters to console so tests are hermetic regardless of the
+			// runner's environment (e.g. OTEL_TRACES_EXPORTER=none).
+			t.Setenv("OTEL_TRACES_EXPORTER", "console")
+			t.Setenv("OTEL_METRICS_EXPORTER", "console")
+			t.Setenv("OTEL_LOGS_EXPORTER", "console")
 			restoreProviders(t)
 			tracerProvider, meterProvider, loggerProvider = nil, nil, nil
 

--- a/pkg/runtime/setup_test.go
+++ b/pkg/runtime/setup_test.go
@@ -10,7 +10,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -42,30 +45,32 @@ func TestLogLevel(t *testing.T) {
 func TestShutdownNilProviders(t *testing.T) {
 	// The providers are package globals shared across tests, so save and restore
 	// them to keep this test order-independent.
-	origTracer, origMeter := tracerProvider, meterProvider
-	t.Cleanup(func() { tracerProvider, meterProvider = origTracer, origMeter })
+	origTracer, origMeter, origLogger := tracerProvider, meterProvider, loggerProvider
+	t.Cleanup(func() { tracerProvider, meterProvider, loggerProvider = origTracer, origMeter, origLogger })
 
 	// With no providers configured, Shutdown is a no-op that returns nil.
 	tracerProvider = nil
 	meterProvider = nil
+	loggerProvider = nil
 	require.NoError(t, Shutdown(context.Background()))
 }
 
 func TestShutdownProviders(t *testing.T) {
-	origTracer, origMeter := tracerProvider, meterProvider
-	t.Cleanup(func() { tracerProvider, meterProvider = origTracer, origMeter })
+	origTracer, origMeter, origLogger := tracerProvider, meterProvider, loggerProvider
+	t.Cleanup(func() { tracerProvider, meterProvider, loggerProvider = origTracer, origMeter, origLogger })
 
 	// Providers with no exporters shut down cleanly, exercising both shutdown
 	// branches without any network dependency.
 	tracerProvider = sdktrace.NewTracerProvider()
 	meterProvider = sdkmetric.NewMeterProvider()
+	loggerProvider = sdklog.NewLoggerProvider()
 	require.NoError(t, Shutdown(context.Background()))
 }
 
 // restoreProviders resets the global providers after a test that configures them.
 func restoreProviders(t *testing.T) {
-	origTracer, origMeter := tracerProvider, meterProvider
-	t.Cleanup(func() { tracerProvider, meterProvider = origTracer, origMeter })
+	origTracer, origMeter, origLogger := tracerProvider, meterProvider, loggerProvider
+	t.Cleanup(func() { tracerProvider, meterProvider, loggerProvider = origTracer, origMeter, origLogger })
 }
 
 func TestSetupOpenTelemetry(t *testing.T) {
@@ -108,4 +113,112 @@ func TestInitializePanicRecovery(t *testing.T) {
 	assert.NotPanics(t, func() {
 		Initialize(Config{InstrumentationName: "test-service"})
 	})
+}
+
+func TestSetupOTelSDKDisabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		disabled bool
+	}{
+		{"literal true disables", "true", true},
+		{"uppercase TRUE disables", "TRUE", true},
+		{"mixed case True disables", "True", true},
+		{"unset does not disable", "", false},
+		{"false does not disable", "false", false},
+		// Per spec, only the literal string "true" disables the SDK; other
+		// truthy-looking values must not.
+		{"arbitrary value does not disable", "1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OTEL_SDK_DISABLED", tt.envValue)
+			restoreProviders(t)
+			tracerProvider, meterProvider, loggerProvider = nil, nil, nil
+
+			origTracerProvider := otel.GetTracerProvider()
+			origMeterProvider := otel.GetMeterProvider()
+
+			assert.NotPanics(t, func() {
+				SetupOTelSDK()
+			})
+
+			if tt.disabled {
+				assert.Nil(t, tracerProvider, "trace provider must not be installed when the SDK is disabled")
+				assert.Nil(t, meterProvider, "meter provider must not be installed when the SDK is disabled")
+				assert.Nil(t, loggerProvider, "logger provider must not be installed when the SDK is disabled")
+				assert.Equal(t, origTracerProvider, otel.GetTracerProvider(),
+					"global tracer provider must be untouched when the SDK is disabled")
+				assert.Equal(t, origMeterProvider, otel.GetMeterProvider(),
+					"global meter provider must be untouched when the SDK is disabled")
+			} else {
+				assert.NotNil(t, tracerProvider, "trace provider should be installed when the SDK is not disabled")
+			}
+		})
+	}
+}
+
+func TestSetupTraceProviderConsoleExporterNoEndpoint(t *testing.T) {
+	// Regression test: OTEL_TRACES_EXPORTER alone must decide the outcome.
+	// Previously, setupTraceProvider silently skipped setup unless an OTLP
+	// endpoint env var was also set, so console (and any other non-otlp
+	// exporter) never produced a trace provider.
+	t.Setenv("OTEL_TRACES_EXPORTER", "console")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	restoreProviders(t)
+	tracerProvider = nil
+
+	err := setupTraceProvider(context.Background(), resource.Default())
+
+	require.NoError(t, err)
+	assert.NotNil(t, tracerProvider,
+		"trace provider should be initialized for OTEL_TRACES_EXPORTER=console even without an OTLP endpoint")
+}
+
+func TestSetupTraceProviderNoneExporter(t *testing.T) {
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+	restoreProviders(t)
+	tracerProvider = nil
+
+	err := setupTraceProvider(context.Background(), resource.Default())
+
+	require.NoError(t, err)
+	assert.Nil(t, tracerProvider, "no trace provider should be installed for OTEL_TRACES_EXPORTER=none")
+}
+
+func TestSetupMeterProviderNoneExporter(t *testing.T) {
+	// Metrics and traces must behave symmetrically for the "none" exporter.
+	t.Setenv("OTEL_METRICS_EXPORTER", "none")
+	restoreProviders(t)
+	meterProvider = nil
+
+	err := setupMeterProvider(context.Background(), resource.Default())
+
+	require.NoError(t, err)
+	assert.Nil(t, meterProvider, "no meter provider should be installed for OTEL_METRICS_EXPORTER=none")
+}
+
+func TestSetupLoggerProviderConsoleExporter(t *testing.T) {
+	t.Setenv("OTEL_LOGS_EXPORTER", "console")
+	restoreProviders(t)
+	loggerProvider = nil
+
+	err := setupLoggerProvider(context.Background(), resource.Default())
+
+	require.NoError(t, err)
+	assert.NotNil(t, loggerProvider,
+		"logger provider should be initialized for OTEL_LOGS_EXPORTER=console even without an OTLP endpoint")
+}
+
+func TestSetupLoggerProviderNoneExporter(t *testing.T) {
+	t.Setenv("OTEL_LOGS_EXPORTER", "none")
+	restoreProviders(t)
+	loggerProvider = nil
+
+	err := setupLoggerProvider(context.Background(), resource.Default())
+
+	require.NoError(t, err)
+	assert.Nil(t, loggerProvider, "no logger provider should be installed for OTEL_LOGS_EXPORTER=none")
 }


### PR DESCRIPTION
PR Source: https://github.com/kakkoyun/opentelemetry-go-compile-instrumentation/pull/15

## Summary

- Respect `OTEL_SDK_DISABLED` as defined in the [OTel spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration)
- Allow `console`/`none` as exporter values for all signals
- Add a logger provider - Allow third party integrations to use the log signal

## Changes

- **`OTEL_SDK_DISABLED`** - Early-return from `SetupOTelSDK()` when set to `"true"` (case-insensitive). The upstream Go SDK doesn't support this yet ([#3559](https://github.com/open-telemetry/opentelemetry-go/issues/3559)).
- **Exporter selection** - All three signals use `autoexport` and honor `OTEL_*_EXPORTER` (`otlp`/`console`/`none`). Traces previously only worked with an OTLP endpoint set.
- **Logger provider** - Added `setupLoggerProvider` mirroring traces and metrics.
