### PR TITLE
fix(state): make StateManager crash-safe with incremental atomic persistence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -548,13 +548,13 @@ test-integration: build build-demo
 test-latestlibbuild: build ## Run LatestLibBuild tests
 	@echo "Running LatestLibBuild tests..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags latestlibbuild ./latestlibbuild/... 2>&1 | tee ./gotest-latestlibbuild.log
+	go -C "test" test -json -v -shuffle=on -timeout=15m -count=1 -tags latestlibbuild ./latestlibbuild/... 2>&1 | tee ./gotest-latestlibbuild.log
 
 .ONESHELL:
 test-latestlibrun: build ## Run LatestLibRun tests (bump apps to @latest then run integration suite)
 	@echo "Bumping test apps to @latest..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags latestlibrun ./latestlibrun/... 2>&1 | tee ./gotest-latestlibrun.log
+	go -C "test" test -json -v -shuffle=on -timeout=15m -count=1 -tags latestlibrun ./latestlibrun/... 2>&1 | tee ./gotest-latestlibrun.log
 	$(MAKE) tidy/test-apps
 	@echo "Syncing test module with bumped apps..."
 	go -C "test" mod tidy
@@ -570,7 +570,7 @@ test-versionmatrix: build ## Run VersionMatrix tests (pin apps to each rule's bo
 	echo "Version matrix needs $$tiers tier(s)"
 	for (( tier=0; tier<tiers; tier++ )); do
 		echo "Pinning test apps to per-rule bound tier $$tier..."
-		VERSIONMATRIX_TIER=$$tier go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags versionmatrix -run '^TestVersionMatrixBump$$' ./versionmatrix/... 2>&1 | tee -a ./gotest-versionmatrix.log
+		VERSIONMATRIX_TIER=$$tier go -C "test" test -json -v -shuffle=on -timeout=15m -count=1 -tags versionmatrix -run '^TestVersionMatrixBump$$' ./versionmatrix/... 2>&1 | tee -a ./gotest-versionmatrix.log
 		$(MAKE) tidy/test-apps
 		echo "Syncing test module with pinned apps..."
 		go -C "test" mod tidy

--- a/Makefile
+++ b/Makefile
@@ -548,13 +548,13 @@ test-integration: build build-demo
 test-latestlibbuild: build ## Run LatestLibBuild tests
 	@echo "Running LatestLibBuild tests..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=15m -count=1 -tags latestlibbuild ./latestlibbuild/... 2>&1 | tee ./gotest-latestlibbuild.log
+	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags latestlibbuild ./latestlibbuild/... 2>&1 | tee ./gotest-latestlibbuild.log
 
 .ONESHELL:
 test-latestlibrun: build ## Run LatestLibRun tests (bump apps to @latest then run integration suite)
 	@echo "Bumping test apps to @latest..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=15m -count=1 -tags latestlibrun ./latestlibrun/... 2>&1 | tee ./gotest-latestlibrun.log
+	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags latestlibrun ./latestlibrun/... 2>&1 | tee ./gotest-latestlibrun.log
 	$(MAKE) tidy/test-apps
 	@echo "Syncing test module with bumped apps..."
 	go -C "test" mod tidy
@@ -570,7 +570,7 @@ test-versionmatrix: build ## Run VersionMatrix tests (pin apps to each rule's bo
 	echo "Version matrix needs $$tiers tier(s)"
 	for (( tier=0; tier<tiers; tier++ )); do
 		echo "Pinning test apps to per-rule bound tier $$tier..."
-		VERSIONMATRIX_TIER=$$tier go -C "test" test -json -v -shuffle=on -timeout=15m -count=1 -tags versionmatrix -run '^TestVersionMatrixBump$$' ./versionmatrix/... 2>&1 | tee -a ./gotest-versionmatrix.log
+		VERSIONMATRIX_TIER=$$tier go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags versionmatrix -run '^TestVersionMatrixBump$$' ./versionmatrix/... 2>&1 | tee -a ./gotest-versionmatrix.log
 		$(MAKE) tidy/test-apps
 		echo "Syncing test module with pinned apps..."
 		go -C "test" mod tidy

--- a/tool/internal/setup/add.go
+++ b/tool/internal/setup/add.go
@@ -132,9 +132,10 @@ func (sp *SetupPhase) addDeps(ctx context.Context, matched []*rule.InstRuleSet, 
 	root := buildOtelcRuntimeAst(append(importDecls, varDecls...))
 	otelcRuntimeFilePath := filepath.Join(packagePath, OtelcRuntimeFile)
 	// Track file in state manager
-	stateManager, _ := StateManagerFromContext(ctx)
-	if err := stateManager.Track(otelcRuntimeFilePath); err != nil {
-		return err
+	if stateManager, found := StateManagerFromContext(ctx); found {
+		if err := stateManager.Track(otelcRuntimeFilePath); err != nil {
+			return err
+		}
 	}
 	// Write the ast to file
 	if err := ast.WriteFileAtomic(otelcRuntimeFilePath, root); err != nil {

--- a/tool/internal/setup/cleanup.go
+++ b/tool/internal/setup/cleanup.go
@@ -5,6 +5,7 @@ package setup
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"go.opentelemetry.io/otelc/tool/util"
@@ -28,13 +29,26 @@ func Cleanup(ctx context.Context, cleanAll bool) error {
 		}
 	}
 
+	reverted := true
 	if stateManager != nil {
 		if err := stateManager.Revert(); err != nil {
+			reverted = false
 			logger.WarnContext(ctx, "failed to revert state", "error", err)
+		} else if discardErr := stateManager.Discard(); discardErr != nil {
+			logger.WarnContext(ctx, "failed to discard consumed state", "error", discardErr)
 		}
 	}
 
 	if cleanAll {
+		if !reverted {
+			// The manifest and snapshots under .otelc-build/state are the only
+			// way left to restore go.mod/go.sum; deleting them now would strand
+			// the tree with replace directives pointing at removed directories.
+			_, _ = fmt.Fprintf(os.Stderr, "Warning: state could not be fully reverted; "+
+				"original file snapshots remain available for recovery at: %s\n",
+				util.GetBuildTemp(stateDir))
+			return nil
+		}
 		// Remove the entire .otelc-build/ temp directory last.
 		// The extracted instrumentation package lives inside .otelc-build/pkg/,
 		// so this also covers removing it.

--- a/tool/internal/setup/cleanup.go
+++ b/tool/internal/setup/cleanup.go
@@ -34,8 +34,13 @@ func Cleanup(ctx context.Context, cleanAll bool) error {
 		if err := stateManager.Revert(); err != nil {
 			reverted = false
 			logger.WarnContext(ctx, "failed to revert state", "error", err)
-		} else if discardErr := stateManager.Discard(); discardErr != nil {
-			logger.WarnContext(ctx, "failed to discard consumed state", "error", discardErr)
+		}
+
+		// If Revert succeeded, discard the consumed state.
+		if reverted {
+			if discardErr := stateManager.Discard(); discardErr != nil {
+				logger.WarnContext(ctx, "failed to discard consumed state", "error", discardErr)
+			}
 		}
 	}
 

--- a/tool/internal/setup/cleanup_test.go
+++ b/tool/internal/setup/cleanup_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otelc/tool/util"
 )
 
@@ -287,6 +289,54 @@ func TestCleanupKeepsBuildDirNoArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cleanup(cleanAll=false) returned unexpected error: %v", err)
 	}
+}
+
+func TestCleanup_RecoversAfterCrash(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	goMod := filepath.Join(tmp, "go.mod")
+	mustWriteFile(t, goMod, "module example.com/app\n")
+
+	dying := NewStateManager()
+	require.NoError(t, dying.Track(goMod))
+	mustWriteFile(t, goMod, "module example.com/app\n\nreplace x => ./.otelc-build/x\n")
+
+	// Fresh process, no state manager in the context: Cleanup must load the
+	// manifest from disk, restore the tree, and discard the consumed state.
+	require.NoError(t, Cleanup(t.Context(), false))
+
+	content, err := os.ReadFile(goMod)
+	require.NoError(t, err)
+	assert.Equal(t, "module example.com/app\n", string(content))
+	assert.False(t, util.PathExists(util.GetBuildTemp(stateFileName)), "consumed manifest must be discarded")
+	assert.False(t, util.PathExists(util.GetBuildTemp(stateDir)), "consumed snapshots must be discarded")
+}
+
+func TestCleanup_KeepsSnapshotsWhenRevertFails(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	goMod := filepath.Join(tmp, "go.mod")
+	otherFile := filepath.Join(tmp, "other.txt")
+	mustWriteFile(t, goMod, "module example.com/app\n")
+	mustWriteFile(t, otherFile, "keep me\n")
+
+	dying := NewStateManager()
+	require.NoError(t, dying.Track(goMod))
+	require.NoError(t, dying.Track(otherFile))
+
+	// Sabotage one snapshot so Revert fails partially.
+	require.NoError(t, os.Remove(filepath.Join(util.GetBuildTemp(stateDir), stateSnapshotPath(otherFile))))
+
+	require.NoError(t, Cleanup(t.Context(), true))
+
+	// Even with cleanAll, a failed revert must not delete the remaining
+	// snapshots as they are the only path left to recovery.
+	assert.True(t, util.PathExists(util.GetBuildTemp(stateFileName)),
+		"manifest must survive a failed revert even with cleanAll")
+	assert.True(t, util.PathExists(filepath.Join(util.GetBuildTemp(stateDir), stateSnapshotPath(goMod))),
+		"snapshots must survive a failed revert even with cleanAll")
 }
 
 // mustWriteFile creates a file with the given content, creating parent dirs as needed.

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -365,10 +365,7 @@ func Setup(ctx context.Context, cmd *cli.Command) error {
 		return ex.Wrapf(findModErr, "finding module directories for build packages")
 	}
 
-	// Track generated & modified files with state manager. Track persists the
-	// manifest incrementally before each mutation, so no explicit commit is
-	// needed here, and a build killed at any point leaves a manifest behind
-	// for `otelc cleanup` to restore from.
+	// Ensure a state manager is available in the context
 	stateManager, found := StateManagerFromContext(ctx)
 	if !found {
 		// save this state manager in the context

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -365,18 +365,14 @@ func Setup(ctx context.Context, cmd *cli.Command) error {
 		return ex.Wrapf(findModErr, "finding module directories for build packages")
 	}
 
-	// Track generated & modified files with state manager
+	// Track generated & modified files with state manager. Track persists the
+	// manifest incrementally before each mutation, so no explicit commit is
+	// needed here, and a build killed at any point leaves a manifest behind
+	// for `otelc cleanup` to restore from.
 	stateManager, found := StateManagerFromContext(ctx)
 	if !found {
 		// save this state manager in the context
 		ctx = ContextWithStateManager(ctx, stateManager)
-		// We only need to commit the state to disk if it was not found in the context
-		// i.e., it was created by this setup invocation
-		defer func() {
-			if err = stateManager.Commit(); err != nil {
-				logger.Error("failed to commit state", "error", err)
-			}
-		}()
 	}
 
 	// Auto-pin generates/updates otel.instrumentation.go file

--- a/tool/internal/setup/state.go
+++ b/tool/internal/setup/state.go
@@ -194,6 +194,10 @@ func (s *StateManager) Track(path string) error {
 // Track calls Commit automatically; calling it directly is only needed to
 // re-persist after external changes.
 func (s *StateManager) Commit() error {
+	if len(s.files) == 0 {
+		return nil
+	}
+
 	entries := make([]string, 0, len(s.files))
 
 	for path, exists := range s.files {
@@ -227,7 +231,11 @@ func (s *StateManager) Commit() error {
 // Discard removes the persisted manifest and snapshots. Call it only after a
 // successful Revert: the state is consumed, and leaving it behind would let a
 // later `otelc cleanup` re-apply snapshots from a finished build.
-func (*StateManager) Discard() error {
+func (s *StateManager) Discard() error {
+	if len(s.files) == 0 {
+		return nil
+	}
+
 	var err error
 	if rmErr := os.Remove(util.GetBuildTemp(stateFileName)); rmErr != nil && !os.IsNotExist(rmErr) {
 		err = ex.Join(err, rmErr)
@@ -243,6 +251,10 @@ func (*StateManager) Discard() error {
 // Files that originally existed are restored from their snapshots. Files that
 // did not exist when tracked are removed if they exist.
 func (s *StateManager) Revert() error {
+	if len(s.files) == 0 {
+		return nil
+	}
+
 	var err error
 
 	stateDir := util.GetBuildTemp(stateDir)

--- a/tool/internal/setup/state.go
+++ b/tool/internal/setup/state.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"go.opentelemetry.io/otelc/tool/ex"
@@ -154,6 +155,10 @@ func (s *StateManager) TrackAll(paths ...string) error {
 // If path does not exist, it is recorded so Revert will remove it if it is
 // later created.
 //
+// The updated state is persisted to disk before Track returns, so a build
+// killed at any later point (SIGKILL, OOM, CI cancellation) leaves behind a
+// manifest from which `otelc cleanup` or the next build can restore the tree.
+//
 // Duplicate calls for the same path are ignored.
 func (s *StateManager) Track(path string) error {
 	abs, err := filepath.Abs(path)
@@ -169,7 +174,7 @@ func (s *StateManager) Track(path string) error {
 	// If the file doesn't exist, mark it for removal
 	if !util.PathExists(abs) {
 		s.files[abs] = false
-		return nil
+		return s.Commit()
 	}
 
 	// If the file exists, snapshot it
@@ -179,11 +184,15 @@ func (s *StateManager) Track(path string) error {
 	}
 
 	s.files[abs] = true
-	return nil
+	return s.Commit()
 }
 
 // Commit persists the tracked state to disk so it can be restored by a future
-// process.
+// process. The manifest is written atomically (temp file + rename) so a crash
+// mid-write never leaves a truncated manifest behind.
+//
+// Track calls Commit automatically; calling it directly is only needed to
+// re-persist after external changes.
 func (s *StateManager) Commit() error {
 	entries := make([]string, 0, len(s.files))
 
@@ -195,23 +204,38 @@ func (s *StateManager) Commit() error {
 		}
 	}
 
-	f := util.GetBuildTemp(stateFileName)
-	file, err := os.Create(f)
-	if err != nil {
-		return ex.Wrapf(err, "failed to create file %s", f)
-	}
-	defer file.Close()
+	// Sort the entries for deterministic behavior
+	sort.Strings(entries)
 
 	bs, err := json.Marshal(entries)
 	if err != nil {
 		return ex.Wrapf(err, "failed to marshal state to JSON")
 	}
 
-	if _, err = file.Write(bs); err != nil {
-		return ex.Wrapf(err, "failed to write JSON to file %s", f)
+	f := util.GetBuildTemp(stateFileName)
+	if err = os.MkdirAll(filepath.Dir(f), 0o755); err != nil {
+		return ex.Wrapf(err, "failed to create build temp directory")
+	}
+
+	if err = util.WriteFileAtomic(f, bs); err != nil {
+		return ex.Wrapf(err, "failed to write state file %s", f)
 	}
 
 	return nil
+}
+
+// Discard removes the persisted manifest and snapshots. Call it only after a
+// successful Revert: the state is consumed, and leaving it behind would let a
+// later `otelc cleanup` re-apply snapshots from a finished build.
+func (*StateManager) Discard() error {
+	var err error
+	if rmErr := os.Remove(util.GetBuildTemp(stateFileName)); rmErr != nil && !os.IsNotExist(rmErr) {
+		err = ex.Join(err, rmErr)
+	}
+	if rmErr := os.RemoveAll(util.GetBuildTemp(stateDir)); rmErr != nil {
+		err = ex.Join(err, rmErr)
+	}
+	return err
 }
 
 // Revert restores all tracked files to the state they were in when tracked.

--- a/tool/internal/setup/state_test.go
+++ b/tool/internal/setup/state_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otelc/tool/util"
@@ -288,6 +289,35 @@ func TestStateManagerTrack_Duplicate(t *testing.T) {
 	require.True(t, stateManager.files[path])
 }
 
+func TestStateManagerTrackPersistsBeforeMutation(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	goMod := filepath.Join(tmp, "go.mod")
+	mustWriteFile(t, goMod, "module example.com/app\n\ngo 1.25.0\n")
+	runtimeFile := filepath.Join(tmp, OtelcRuntimeFile)
+
+	// The "build" process tracks, mutates, and dies without any explicit
+	// Commit, exactly the `otelc go build` path.
+	dying := NewStateManager()
+	require.NoError(t, dying.Track(goMod))
+	require.NoError(t, dying.Track(runtimeFile))
+	mustWriteFile(t, goMod, "module example.com/app\n\ngo 1.25.0\n\nreplace x => ./.otelc-build/x\n")
+	mustWriteFile(t, runtimeFile, "package main\n")
+	// (process dies here)
+
+	// A fresh process recovers from the manifest alone.
+	recovered, err := LoadStateManager()
+	require.NoError(t, err)
+	require.NotNil(t, recovered, "manifest must exist without an explicit Commit")
+	require.NoError(t, recovered.Revert())
+
+	content, err := os.ReadFile(goMod)
+	require.NoError(t, err)
+	assert.Equal(t, "module example.com/app\n\ngo 1.25.0\n", string(content), "go.mod must be restored")
+	assert.False(t, util.PathExists(runtimeFile), "generated runtime file must be removed")
+}
+
 func TestStateManagerTrackAll(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)
@@ -389,4 +419,25 @@ func TestStateManagerRoundTrip(t *testing.T) {
 	require.Equal(t, "module original", string(data))
 
 	require.False(t, util.PathExists(generated))
+}
+
+func TestStateManagerCommitIsAtomicAndSorted(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	b := filepath.Join(tmp, "b.txt")
+	a := filepath.Join(tmp, "a.txt")
+	mustWriteFile(t, a, "a")
+
+	s := NewStateManager()
+	require.NoError(t, s.Track(b)) // missing file, tracked first
+	require.NoError(t, s.Track(a))
+
+	first, err := os.ReadFile(util.GetBuildTemp(stateFileName))
+	require.NoError(t, err)
+	require.NoError(t, s.Commit())
+	second, err := os.ReadFile(util.GetBuildTemp(stateFileName))
+	require.NoError(t, err)
+	assert.Equal(t, string(first), string(second), "manifest serialization must be deterministic")
+	assert.False(t, util.PathExists(util.GetBuildTemp(stateFileName)+".tmp"), "no temp file left behind")
 }


### PR DESCRIPTION
Based on: https://github.com/kakkoyun/opentelemetry-go-compile-instrumentation/pull/10

## Summary

Make StateManager crash-safe with incremental atomic persistence

Previously the state manifest was written only once at the end of a successful build via an explicit `Commit()`. A crash (SIGKILL, OOM, CI cancellation) before that point left no trace on disk, making it impossible for a subsequent `otelc cleanup` to restore the tree.

## Changes

- `Track()` now calls `Commit()` before returning, persisting the manifest incrementally after every tracked file. No explicit `Commit()` needed from callers.
- `Commit()` uses `WriteFileAtomic` (temp file + rename) so a crash mid-write never leaves a truncated manifest.
- Add `Discard()` to remove the consumed manifest and snapshots after a successful `Revert`.
- A failed revert in `Cleanup()` no longer deletes snapshots, they are preserved as the only recovery path.
- Increase test timeout from 10m to 15m for latestlibbuild, latestlibrun, and versionmatrix tests.
