### PR TITLE
fix: toolexec goflags dropin

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,6 +37,40 @@ No manual code changes required.
    go tool otelc go build -o myapp .
    ```
 
+## Using `go build` Directly (toolexec drop-in)
+
+Instead of wrapping the build with `otelc go build`, you can keep using the
+regular `go` toolchain and plug `otelc` in through `GOFLAGS`. This is useful
+when the build command is owned by a Makefile, CI pipeline, or another tool
+you don't want to change.
+
+1. **Prepare the module** (once, and again after dependencies change):
+
+   ```bash
+   cd path/to/your/module
+   otelc setup
+   ```
+
+   `otelc setup` analyzes the module, generates the instrumentation sources
+   (`otel.instrumentation.go`, `otelc.runtime.go`) and writes the matched
+   rules to `.otelc-build/`, which the build phase below reads.
+
+2. **Build with the standard toolchain**:
+
+   ```bash
+   export GOFLAGS="${GOFLAGS} '-toolexec=otelc toolexec'"
+   go build -o myapp .
+   ```
+
+Run `go build` from the module directory (or any subdirectory); `otelc`
+locates the `.otelc-build` directory created by `otelc setup` from there. To
+run the build from somewhere else, set `OTELC_WORK_DIR` to the directory
+where `otelc setup` ran.
+
+Instrumented and plain build artifacts are kept apart in Go's build cache
+(otelc marks the tool identity go hashes into every cache key), so switching
+between instrumented and regular builds does not require cleaning the cache.
+
 ## Managing Instrumentations
 
 Instrumentations are declared through an `otel.instrumentation.go` file located next to the application's `go.mod` file. The alternate filename `otelc.tool.go` is also accepted and behaves identically.

--- a/test/integration/toolexec_goflags_test.go
+++ b/test/integration/toolexec_goflags_test.go
@@ -1,0 +1,269 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package test
+
+import (
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otelc/test/testutil"
+)
+
+const preparedGoMod = `module example.com/otelc-prepared
+
+go 1.25.0
+`
+
+const preparedMainSource = `package main
+
+import (
+	"flag"
+	"io"
+	"net/http"
+)
+
+func main() {
+	addr := flag.String("addr", "", "server address")
+	flag.Parse()
+
+	resp, err := http.Get(*addr + "/hello")
+	if err != nil {
+		panic(err)
+	}
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		_ = resp.Body.Close()
+		panic(err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		panic(err)
+	}
+}
+`
+
+func TestGOFLAGSPreparedBuild(t *testing.T) {
+	otelcPath, err := testutil.OtelcPath()
+	require.NoError(t, err)
+	absoluteOtelcPath, err := filepath.Abs(otelcPath)
+	require.NoError(t, err)
+	require.FileExists(t, absoluteOtelcPath)
+	baseEnv := preparedBuildBaseEnvironment()
+	goFlags := strconv.Quote("-toolexec=" + absoluteOtelcPath + " toolexec")
+
+	t.Run("fresh cache with empty work dir env", func(t *testing.T) {
+		build := newPreparedBuildCase(t, absoluteOtelcPath, baseEnv, goFlags, ".")
+		build.setup()
+
+		_, err := os.Stat(build.goCache)
+		require.ErrorIs(t, err, os.ErrNotExist, "GOCACHE must not exist before go build")
+		build.directBuild(build.moduleDir, true)
+		require.DirExists(t, build.goCache, "go build did not create the fresh GOCACHE")
+		build.runAndRequireHTTPSpan()
+	})
+
+	t.Run("warm cache", func(t *testing.T) {
+		build := newPreparedBuildCase(t, absoluteOtelcPath, baseEnv, goFlags, ".")
+
+		_, err := os.Stat(build.goCache)
+		require.ErrorIs(t, err, os.ErrNotExist, "GOCACHE must not exist before plain go build")
+		build.plainBuild()
+		require.DirExists(t, build.goCache, "plain go build did not create the fresh GOCACHE")
+
+		build.setup()
+		build.directBuild(build.moduleDir, false)
+		require.DirExists(t, build.goCache, "direct go build removed the warm GOCACHE")
+		build.runAndRequireHTTPSpan()
+	})
+
+	t.Run("nested module directory", func(t *testing.T) {
+		build := newPreparedBuildCase(t, absoluteOtelcPath, baseEnv, goFlags, "cmd/app")
+		build.setup("./cmd/app")
+		build.directBuild(filepath.Join(build.moduleDir, "cmd", "app"), false)
+		build.runAndRequireHTTPSpan()
+	})
+
+	t.Run("re-prepared cache", func(t *testing.T) {
+		build := newPreparedBuildCase(t, absoluteOtelcPath, baseEnv, goFlags, ".")
+		build.setup()
+		build.directBuild(build.moduleDir, false)
+		build.runAndRequireHTTPSpan()
+		require.DirExists(t, build.goCache, "first direct build did not create GOCACHE")
+
+		build.cleanup()
+		require.DirExists(t, build.goCache, "otelc cleanup removed the shared GOCACHE")
+		build.setup()
+
+		build.directBuild(build.moduleDir, false)
+		build.runAndRequireHTTPSpan()
+	})
+}
+
+type preparedBuildCase struct {
+	t         *testing.T
+	otelcPath string
+	baseEnv   []string
+	goFlags   string
+	workspace string
+	moduleDir string
+	goCache   string
+	prepared  bool
+}
+
+func newPreparedBuildCase(
+	t *testing.T,
+	otelcPath string,
+	baseEnv []string,
+	goFlags string,
+	mainPackage string,
+) *preparedBuildCase {
+	t.Helper()
+
+	workspace := t.TempDir()
+	moduleDir := filepath.Join(workspace, "module")
+	mainDir := filepath.Join(moduleDir, filepath.FromSlash(mainPackage))
+	require.NoError(t, os.MkdirAll(mainDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "go.mod"), []byte(preparedGoMod), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(mainDir, "main.go"), []byte(preparedMainSource), 0o644))
+
+	build := &preparedBuildCase{
+		t:         t,
+		otelcPath: otelcPath,
+		baseEnv:   baseEnv,
+		goFlags:   goFlags,
+		workspace: workspace,
+		moduleDir: moduleDir,
+		goCache:   filepath.Join(workspace, "gocache"),
+	}
+	t.Cleanup(func() {
+		if !build.prepared {
+			return
+		}
+		output, err := build.cleanupCommand()
+		if err != nil {
+			t.Errorf("otelc cleanup failed: %v\n%s", err, output)
+			return
+		}
+		build.prepared = false
+	})
+	return build
+}
+
+func (b *preparedBuildCase) setup(args ...string) {
+	b.t.Helper()
+
+	cmd := exec.CommandContext(b.t.Context(), b.otelcPath, append([]string{"setup"}, args...)...)
+	cmd.Dir = b.moduleDir
+	cmd.Env = b.baseEnv
+	output, err := cmd.CombinedOutput()
+	require.NoError(b.t, err, "otelc setup failed:\n%s", output)
+	b.prepared = true
+
+	matchedPath := filepath.Join(b.moduleDir, ".otelc-build", "matched.json")
+	matched, err := os.ReadFile(matchedPath)
+	require.NoError(b.t, err)
+	require.Contains(b.t, string(matched), "/instrumentation/net/http/client")
+}
+
+func (b *preparedBuildCase) cleanup() {
+	b.t.Helper()
+
+	output, err := b.cleanupCommand()
+	require.NoError(b.t, err, "otelc cleanup failed:\n%s", output)
+	b.prepared = false
+}
+
+func (b *preparedBuildCase) cleanupCommand() ([]byte, error) {
+	cmd := exec.Command(b.otelcPath, "cleanup")
+	cmd.Dir = b.moduleDir
+	cmd.Env = b.baseEnv
+	return cmd.CombinedOutput()
+}
+
+func (b *preparedBuildCase) appPath() string {
+	name := "app"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(b.moduleDir, name)
+}
+
+func (b *preparedBuildCase) plainBuild() {
+	b.t.Helper()
+
+	cmd := exec.CommandContext(b.t.Context(), "go", "build", "-o", b.appPath(), ".")
+	cmd.Dir = b.moduleDir
+	cmd.Env = preparedPlainBuildEnvironment(b.baseEnv, b.goCache)
+	output, err := cmd.CombinedOutput()
+	require.NoError(b.t, err, "plain go build failed:\n%s", output)
+}
+
+func (b *preparedBuildCase) directBuild(buildDir string, emptyWorkDirEnv bool) {
+	b.t.Helper()
+
+	cmd := exec.CommandContext(b.t.Context(), "go", "build", "-o", b.appPath(), ".")
+	cmd.Dir = buildDir
+	cmd.Env = preparedDropInBuildEnvironment(b.baseEnv, b.goCache, b.goFlags)
+	if emptyWorkDirEnv {
+		cmd.Env = append(cmd.Env, "OTELC_WORK_DIR=")
+	}
+	output, err := cmd.CombinedOutput()
+	require.NoError(b.t, err, "go build failed:\n%s", output)
+}
+
+func (b *preparedBuildCase) runAndRequireHTTPSpan() {
+	b.t.Helper()
+
+	server := StartHTTPServerWithResponse(b.t, http.StatusOK, `{"message":"Hello"}`)
+	fixture := testutil.NewTestFixture(b.t, testutil.WithAppsDir(b.workspace))
+	fixture.Run("module", "-addr="+server.URL)
+
+	span := fixture.RequireSingleSpan()
+	testutil.RequireHTTPClientSemconv(
+		b.t,
+		span,
+		http.MethodGet,
+		server.URL+"/hello",
+		"127.0.0.1",
+		http.StatusOK,
+		server.Port(),
+		"1.1",
+		"http",
+	)
+}
+
+func preparedBuildBaseEnvironment() []string {
+	env := os.Environ()
+	filtered := env[:0]
+	for _, entry := range env {
+		name, _, _ := strings.Cut(entry, "=")
+		name = strings.ToLower(name)
+		if name == "goenv" || name == "goflags" || name == "gocache" || name == "gowork" ||
+			strings.HasPrefix(name, "otelc_") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return append(filtered, "GOENV=off")
+}
+
+func preparedPlainBuildEnvironment(baseEnv []string, goCache string) []string {
+	env := make([]string, len(baseEnv), len(baseEnv)+2)
+	copy(env, baseEnv)
+	return append(env, "GOWORK=off", "GOCACHE="+goCache)
+}
+
+func preparedDropInBuildEnvironment(baseEnv []string, goCache, goFlags string) []string {
+	env := make([]string, len(baseEnv), len(baseEnv)+3)
+	copy(env, baseEnv)
+	return append(env, "GOWORK=off", "GOCACHE="+goCache, "GOFLAGS="+goFlags)
+}

--- a/tool/cmd/otelc/cmd_toolexec.go
+++ b/tool/cmd/otelc/cmd_toolexec.go
@@ -5,10 +5,12 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/urfave/cli/v3"
 
 	"go.opentelemetry.io/otelc/tool/internal/instrument"
+	"go.opentelemetry.io/otelc/tool/util"
 )
 
 //nolint:gochecknoglobals // Implementation of a CLI command
@@ -19,6 +21,14 @@ var commandToolexec = cli.Command{
 	Hidden:          true,
 	Before:          addLoggerPhaseAttribute,
 	Action: func(ctx context.Context, cmd *cli.Command) error {
-		return instrument.Toolexec(ctx, cmd.Args().Slice())
+		nested := os.Getenv(util.EnvOtelcNestedToolexec) != ""
+		if !nested {
+			// Here, not in instrument.Toolexec, so os.Executable resolves to
+			// this binary for the go commands it spawns.
+			if err := instrument.EnableNestedToolexec(); err != nil {
+				return err
+			}
+		}
+		return instrument.Toolexec(ctx, cmd.Args().Slice(), nested)
 	},
 }

--- a/tool/cmd/otelc/main.go
+++ b/tool/cmd/otelc/main.go
@@ -83,6 +83,16 @@ func main() {
 			&commandVersion,
 		},
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+			// In drop-in mode (otelc is the GOFLAGS -toolexec tool) the go
+			// children otelc spawns would inherit the flag and recurse, so
+			// strip it process-wide; commands that need toolexec re-add it.
+			if goflags := os.Getenv("GOFLAGS"); goflags != "" {
+				if stripped := util.StripToolexecFromGoflags(goflags); stripped != goflags {
+					if err := os.Setenv("GOFLAGS", stripped); err != nil {
+						return ctx, ex.Wrapf(err, "stripping -toolexec from GOFLAGS")
+					}
+				}
+			}
 			ctx, err := initLogger(ctx, cmd)
 			if err != nil {
 				return ctx, err
@@ -112,6 +122,19 @@ func initLogger(ctx context.Context, cmd *cli.Command) (context.Context, error) 
 	if err != nil {
 		return ctx, ex.Wrapf(err, "failed to resolve work directory %q", cmd.String("work-dir"))
 	}
+
+	// Bare -toolexec (GOFLAGS drop-in): no parent set OTELC_WORK_DIR, and the
+	// toolchain may run us from the package source dir (asm runs in the
+	// read-only module cache). Discover the dir from `otelc setup` rather than
+	// trusting cwd; skip filesystem setup when none is found instead of
+	// creating .otelc-build in an arbitrary location.
+	if cmd.Args().First() == "toolexec" && !cmd.IsSet("work-dir") && os.Getenv(util.EnvOtelcWorkDir) == "" {
+		workDir = util.DiscoverWorkDir(workDir)
+		if workDir == "" {
+			return ctx, nil
+		}
+	}
+
 	if setErr := os.Setenv(util.EnvOtelcWorkDir, workDir); setErr != nil {
 		return ctx, ex.Wrapf(setErr, "failed to set %s", util.EnvOtelcWorkDir)
 	}

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -107,7 +107,7 @@ func runTest(t *testing.T, testName string) {
 	helpers := buildTestcaseHelpers(ctx, t, testcaseDir)
 
 	args := compileArgs(tempDir, sourceFile, helpers, importPath)
-	err := Toolexec(ctx, args)
+	err := Toolexec(ctx, args, false)
 
 	if testName == invalidReceiver {
 		require.Error(t, err)

--- a/tool/internal/instrument/match.go
+++ b/tool/internal/instrument/match.go
@@ -17,6 +17,11 @@ import (
 func (ip *InstrumentPhase) load() ([]*rule.InstRuleSet, error) {
 	f := util.GetMatchedRuleFile()
 	content, err := os.ReadFile(f)
+	if os.IsNotExist(err) {
+		return nil, ex.Newf("no instrumentation configuration found (%s does not exist); "+
+			"run `otelc setup` in the module directory before building with `-toolexec`, "+
+			"or build with `otelc go build` instead", f)
+	}
 	if err != nil {
 		return nil, ex.Wrapf(err, "failed to read file %s", f)
 	}

--- a/tool/internal/instrument/tool_version_test.go
+++ b/tool/internal/instrument/tool_version_test.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package instrument
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otelc/tool/util"
+)
+
+func TestToolVersionLine(t *testing.T) {
+	marker := "otelc@" + util.Version
+
+	t.Run("release toolchain without rules hash", func(t *testing.T) {
+		got := toolVersionLine("compile version go1.26.5", "")
+		assert.Equal(t, "compile version go1.26.5 "+marker, got)
+	})
+
+	t.Run("release toolchain with rules hash", func(t *testing.T) {
+		got := toolVersionLine("compile version go1.26.5", "abcd1234")
+		assert.Equal(t, "compile version go1.26.5 "+marker+"/abcd1234", got)
+	})
+
+	t.Run("devel toolchain keeps buildID as the last field", func(t *testing.T) {
+		line := "compile version devel go1.27-abc123 buildID=x/y/z"
+		got := toolVersionLine(line, "abcd1234")
+		assert.Equal(t, "compile version devel go1.27-abc123 "+marker+"/abcd1234 buildID=x/y/z", got)
+	})
+}
+
+func TestLoadMissingMatchedRules(t *testing.T) {
+	// Point the work dir at an empty directory: matched.json does not exist,
+	// which is what a bare -toolexec build sees when setup never ran.
+	t.Setenv(util.EnvOtelcWorkDir, t.TempDir())
+
+	ip := &InstrumentPhase{logger: slog.Default()}
+	_, err := ip.load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "otelc setup")
+}

--- a/tool/internal/instrument/tool_version_test.go
+++ b/tool/internal/instrument/tool_version_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -94,4 +95,13 @@ func TestLoadMissingMatchedRules(t *testing.T) {
 	_, err := ip.load()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "otelc setup")
+}
+
+// versionMarkerPattern documents the exact tool-ID shape the go build cache
+// keys on, guarding against accidental format drift.
+var versionMarkerPattern = regexp.MustCompile(`otelc@[^\s/]+(/[0-9a-f]{16})?`)
+
+func TestToolVersionLineMatchesCachePattern(t *testing.T) {
+	assert.Regexp(t, versionMarkerPattern, toolVersionLine("compile version go1.26.5", ""))
+	assert.Regexp(t, versionMarkerPattern, toolVersionLine("compile version go1.26.5", "0123456789abcdef"))
 }

--- a/tool/internal/instrument/tool_version_test.go
+++ b/tool/internal/instrument/tool_version_test.go
@@ -5,6 +5,8 @@ package instrument
 
 import (
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +32,53 @@ func TestToolVersionLine(t *testing.T) {
 		line := "compile version devel go1.27-abc123 buildID=x/y/z"
 		got := toolVersionLine(line, "abcd1234")
 		assert.Equal(t, "compile version devel go1.27-abc123 "+marker+"/abcd1234 buildID=x/y/z", got)
+	})
+}
+
+func TestMarkedToolVersion(t *testing.T) {
+	const raw = "compile version go1.26.5\n"
+
+	t.Run("no rules hash when matched.json is absent", func(t *testing.T) {
+		t.Setenv(util.EnvOtelcWorkDir, t.TempDir())
+
+		got := markedToolVersion(raw)
+		assert.Equal(t, "compile version go1.26.5 otelc@"+util.Version, got)
+	})
+
+	t.Run("appends a 16-hex-digit rules hash when matched.json is present", func(t *testing.T) {
+		workDir := t.TempDir()
+		t.Setenv(util.EnvOtelcWorkDir, workDir)
+		require.NoError(t, os.MkdirAll(filepath.Join(workDir, util.BuildTempDir), 0o755))
+		require.NoError(t, os.WriteFile(util.GetMatchedRuleFile(), []byte(`[{"module_path":"main"}]`), 0o644))
+
+		got := markedToolVersion(raw)
+		assert.Regexp(t, `^compile version go1\.26\.5 otelc@\S+/[0-9a-f]{16}$`, got)
+	})
+}
+
+func TestEnableNestedToolexec(t *testing.T) {
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	t.Run("appends to existing GOFLAGS and sets the nested marker", func(t *testing.T) {
+		t.Setenv("GOFLAGS", "-mod=mod")
+		t.Setenv(util.EnvOtelcNestedToolexec, "")
+
+		require.NoError(t, EnableNestedToolexec())
+
+		goflags := os.Getenv("GOFLAGS")
+		assert.Contains(t, goflags, "-mod=mod", "existing flags are preserved")
+		assert.Contains(t, goflags, "'-toolexec="+exe+" toolexec'", "otelc is added as the toolexec")
+		assert.Equal(t, "1", os.Getenv(util.EnvOtelcNestedToolexec))
+	})
+
+	t.Run("handles empty GOFLAGS without leading whitespace", func(t *testing.T) {
+		t.Setenv("GOFLAGS", "")
+		t.Setenv(util.EnvOtelcNestedToolexec, "")
+
+		require.NoError(t, EnableNestedToolexec())
+
+		assert.Equal(t, "'-toolexec="+exe+" toolexec'", os.Getenv("GOFLAGS"))
 	})
 }
 

--- a/tool/internal/instrument/tool_version_test.go
+++ b/tool/internal/instrument/tool_version_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,10 +29,12 @@ func TestToolVersionLine(t *testing.T) {
 		assert.Equal(t, "compile version go1.26.5 "+marker+"/abcd1234", got)
 	})
 
-	t.Run("devel toolchain keeps buildID as the last field", func(t *testing.T) {
+	t.Run("devel toolchain changes the content ID used by Go", func(t *testing.T) {
 		line := "compile version devel go1.27-abc123 buildID=x/y/z"
 		got := toolVersionLine(line, "abcd1234")
-		assert.Equal(t, "compile version devel go1.27-abc123 "+marker+"/abcd1234 buildID=x/y/z", got)
+		assert.Equal(t, "compile version devel go1.27-abc123 buildID=x/y/z+"+marker+"+abcd1234", got)
+		contentID := got[strings.LastIndex(got, "/")+1:]
+		assert.Equal(t, "z+"+marker+"+abcd1234", contentID)
 	})
 }
 

--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -355,15 +355,20 @@ func interceptLink(ctx context.Context, args []string) ([]string, error) {
 // toolVersionLine appends an otelc marker to a `tool -V=full` line so the tool
 // ID (and every build cache key derived from it) differs from a plain build.
 // The rules hash is included so editing the config invalidates cached
-// artifacts too. A devel toolchain's line ends in `buildID=...` and go keys
-// the cache on that field alone, so the marker goes just before it.
+// artifacts too. For devel toolchains, Go uses only the content ID in the
+// trailing `buildID=...` field, so append the marker to that field's value.
 func toolVersionLine(line, rulesHash string) string {
+	hasBuildID := strings.Contains(line, " buildID=")
 	marker := "otelc@" + util.Version
 	if rulesHash != "" {
-		marker += "/" + rulesHash
+		if hasBuildID {
+			marker += "+" + rulesHash
+		} else {
+			marker += "/" + rulesHash
+		}
 	}
-	if idx := strings.LastIndex(line, " buildID="); idx >= 0 {
-		return line[:idx] + " " + marker + line[idx:]
+	if hasBuildID {
+		return line + "+" + marker
 	}
 	return line + " " + marker
 }

--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -473,7 +473,11 @@ func EnableNestedToolexec() error {
 	if err != nil {
 		return ex.Wrapf(err, "resolving otelc executable path")
 	}
-	goflags := strings.TrimSpace(os.Getenv("GOFLAGS") + fmt.Sprintf(" '-toolexec=%s toolexec'", execPath))
+	toolexecFlag, err := util.QuoteGoflagsToken(fmt.Sprintf("-toolexec=%s toolexec", execPath))
+	if err != nil {
+		return ex.Wrapf(err, "quoting nested toolexec GOFLAGS entry")
+	}
+	goflags := strings.TrimSpace(os.Getenv("GOFLAGS") + " " + toolexecFlag)
 	if err = os.Setenv("GOFLAGS", goflags); err != nil {
 		return ex.Wrapf(err, "setting GOFLAGS for nested go commands")
 	}

--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -5,9 +5,13 @@ package instrument
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -348,27 +352,70 @@ func interceptLink(ctx context.Context, args []string) ([]string, error) {
 	return args, nil
 }
 
+// toolVersionLine appends an otelc marker to a `tool -V=full` line so the tool
+// ID (and every build cache key derived from it) differs from a plain build.
+// The rules hash is included so editing the config invalidates cached
+// artifacts too. A devel toolchain's line ends in `buildID=...` and go keys
+// the cache on that field alone, so the marker goes just before it.
+func toolVersionLine(line, rulesHash string) string {
+	marker := "otelc@" + util.Version
+	if rulesHash != "" {
+		marker += "/" + rulesHash
+	}
+	if idx := strings.LastIndex(line, " buildID="); idx >= 0 {
+		return line[:idx] + " " + marker + line[idx:]
+	}
+	return line + " " + marker
+}
+
+// interceptToolVersion handles the `tool -V=full` probe go uses to compute
+// tool IDs, printing the tool's own version line with an otelc marker added.
+func interceptToolVersion(ctx context.Context, args []string) error {
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...) //nolint:gosec // args come from the go toolchain
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return ex.Wrapf(err, "running %v", args)
+	}
+
+	var rulesHash string
+	if content, readErr := os.ReadFile(util.GetMatchedRuleFile()); readErr == nil {
+		sum := sha256.Sum256(content)
+		rulesHash = hex.EncodeToString(sum[:8])
+	}
+
+	// The line goes to stdout: it is the answer go itself is waiting for.
+	_, err = os.Stdout.WriteString(toolVersionLine(strings.TrimSpace(string(out)), rulesHash) + "\n")
+	if err != nil {
+		return ex.Wrapf(err, "writing tool version")
+	}
+	return nil
+}
+
 // Toolexec is the entry point of the toolexec command. It intercepts all the
 // commands(link, compile, asm, etc) during build process. Our responsibility is
 // to find out the compile command we are interested in and run it with the
 // instrumented code, and ensure the link command has all necessary dependencies.
-func Toolexec(ctx context.Context, args []string) error {
+// nested (see EnvOtelcNestedToolexec) means this runs inside a go command
+// another otelc spawned; such invocations only rewrite tool version probes.
+func Toolexec(ctx context.Context, args []string, nested bool) error {
 	// Use slice-based detection to correctly handle tool paths with spaces
 	// (common on Windows, e.g., "C:\Program Files\Go\pkg\tool\...")
 
-	// Intercept compile commands for instrumentation
-	if util.IsCompileCommandWithArgs(args) {
-		var err error
-		args, err = interceptCompile(ctx, args)
-		if err != nil {
-			return err
-		}
+	// go derives each tool's ID (an input to every build cache key) from
+	// `tool -V=full` run through toolexec. Answer it with an otelc marker
+	// appended so instrumented artifacts never share cache entries with plain
+	// builds; instrumentation changes compile output without changing any
+	// input go hashes.
+	if len(args) == 2 && args[1] == "-V=full" {
+		return interceptToolVersion(ctx, args)
 	}
 
-	// Intercept link commands to update importcfg with added dependencies
-	if util.IsLinkCommandWithArgs(args) {
+	// The tool version rewrite above already keeps a nested build's cache keys
+	// aligned with the outer one; instrumenting here too would recurse.
+	if !nested {
 		var err error
-		args, err = interceptLink(ctx, args)
+		args, err = interceptToolCommand(ctx, args)
 		if err != nil {
 			return err
 		}
@@ -389,4 +436,38 @@ func Toolexec(ctx context.Context, args []string) error {
 		"duration", elapsed,
 	)
 	return err
+}
+
+// interceptToolCommand rewrites the compile and link commands otelc cares
+// about; every other tool invocation is returned unchanged.
+func interceptToolCommand(ctx context.Context, args []string) ([]string, error) {
+	// Intercept compile commands for instrumentation
+	if util.IsCompileCommandWithArgs(args) {
+		return interceptCompile(ctx, args)
+	}
+	// Intercept link commands to update importcfg with added dependencies
+	if util.IsLinkCommandWithArgs(args) {
+		return interceptLink(ctx, args)
+	}
+	return args, nil
+}
+
+// EnableNestedToolexec points GOFLAGS at this executable in nested mode, so go
+// commands this process spawns (e.g. `go list -export`) run through a
+// version-only otelc toolexec and share this build's cache keys. Any existing
+// -toolexec was stripped at startup. Must only be called from the real otelc
+// binary, since os.Executable is what nested go commands will run.
+func EnableNestedToolexec() error {
+	execPath, err := os.Executable()
+	if err != nil {
+		return ex.Wrapf(err, "resolving otelc executable path")
+	}
+	goflags := strings.TrimSpace(os.Getenv("GOFLAGS") + fmt.Sprintf(" '-toolexec=%s toolexec'", execPath))
+	if err = os.Setenv("GOFLAGS", goflags); err != nil {
+		return ex.Wrapf(err, "setting GOFLAGS for nested go commands")
+	}
+	if err = os.Setenv(util.EnvOtelcNestedToolexec, "1"); err != nil {
+		return ex.Wrapf(err, "setting %s", util.EnvOtelcNestedToolexec)
+	}
+	return nil
 }

--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -368,6 +368,18 @@ func toolVersionLine(line, rulesHash string) string {
 	return line + " " + marker
 }
 
+// markedToolVersion turns a tool's raw `-V=full` output into the line otelc
+// reports in its place: the version with an otelc marker, plus the current
+// matched-rules hash when one exists.
+func markedToolVersion(rawOutput string) string {
+	var rulesHash string
+	if content, err := os.ReadFile(util.GetMatchedRuleFile()); err == nil {
+		sum := sha256.Sum256(content)
+		rulesHash = hex.EncodeToString(sum[:8])
+	}
+	return toolVersionLine(strings.TrimSpace(rawOutput), rulesHash)
+}
+
 // interceptToolVersion handles the `tool -V=full` probe go uses to compute
 // tool IDs, printing the tool's own version line with an otelc marker added.
 func interceptToolVersion(ctx context.Context, args []string) error {
@@ -378,14 +390,8 @@ func interceptToolVersion(ctx context.Context, args []string) error {
 		return ex.Wrapf(err, "running %v", args)
 	}
 
-	var rulesHash string
-	if content, readErr := os.ReadFile(util.GetMatchedRuleFile()); readErr == nil {
-		sum := sha256.Sum256(content)
-		rulesHash = hex.EncodeToString(sum[:8])
-	}
-
 	// The line goes to stdout: it is the answer go itself is waiting for.
-	_, err = os.Stdout.WriteString(toolVersionLine(strings.TrimSpace(string(out)), rulesHash) + "\n")
+	_, err = os.Stdout.WriteString(markedToolVersion(string(out)) + "\n")
 	if err != nil {
 		return ex.Wrapf(err, "writing tool version")
 	}

--- a/tool/internal/instrument/toolexec_exec_test.go
+++ b/tool/internal/instrument/toolexec_exec_test.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -118,13 +117,4 @@ func TestToolexecRecordsStatsWhenEnabled(t *testing.T) {
 
 	require.NoError(t, Toolexec(ctx, []string{stub, "-buildid", "x"}, false))
 	assert.FileExists(t, marker)
-}
-
-// versionMarkerPattern documents the exact tool-ID shape the go build cache
-// keys on, guarding against accidental format drift.
-var versionMarkerPattern = regexp.MustCompile(`otelc@[^\s/]+(/[0-9a-f]{16})?`)
-
-func TestToolVersionLineMatchesCachePattern(t *testing.T) {
-	assert.Regexp(t, versionMarkerPattern, toolVersionLine("compile version go1.26.5", ""))
-	assert.Regexp(t, versionMarkerPattern, toolVersionLine("compile version go1.26.5", "0123456789abcdef"))
 }

--- a/tool/internal/instrument/toolexec_exec_test.go
+++ b/tool/internal/instrument/toolexec_exec_test.go
@@ -1,0 +1,130 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package instrument
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otelc/tool/util"
+)
+
+// writeStub writes an executable shell script named name that runs body and
+// returns its path. It stands in for a go tool the toolexec wrapper would
+// otherwise exec; the name matters because command detection keys off the
+// tool's basename (e.g. ".../compile").
+func writeStub(t *testing.T, name, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755))
+	return path
+}
+
+// TestToolexecInterceptsToolVersion covers the exec plumbing of the `-V=full`
+// probe; the rewritten line's content is asserted by TestMarkedToolVersion.
+func TestToolexecInterceptsToolVersion(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	t.Setenv(util.EnvOtelcWorkDir, t.TempDir())
+
+	t.Run("runs the underlying tool and reports success", func(t *testing.T) {
+		stub := writeStub(t, "compile", `echo "compile version go1.26.5"`)
+		require.NoError(t, Toolexec(ctx, []string{stub, "-V=full"}, false))
+	})
+
+	t.Run("intercepts even in nested mode", func(t *testing.T) {
+		stub := writeStub(t, "compile", `echo "compile version go1.26.5"`)
+		require.NoError(t, Toolexec(ctx, []string{stub, "-V=full"}, true))
+	})
+
+	t.Run("propagates a failure from the underlying tool", func(t *testing.T) {
+		failing := writeStub(t, "compile", "exit 3")
+		err := Toolexec(ctx, []string{failing, "-V=full"}, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "running")
+	})
+}
+
+func TestToolexecPassesThroughNonToolCommands(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	t.Setenv(util.EnvOtelcWorkDir, t.TempDir())
+
+	// A command that is neither compile nor link is run unchanged. The stub
+	// records that it executed so the test can tell it was actually invoked.
+	marker := filepath.Join(t.TempDir(), "ran")
+	stub := writeStub(t, "asm", "touch "+marker)
+
+	require.NoError(t, Toolexec(ctx, []string{stub, "-buildid", "x"}, false))
+	assert.FileExists(t, marker)
+}
+
+// TestToolexecNestedGatesInstrumentation checks that the nested flag, not the
+// command shape, decides whether otelc instruments: the same compile-shaped
+// command is instrumented when nested is false (and here fails because no
+// matched.json exists) but passed straight through when nested is true.
+func TestToolexecNestedGatesInstrumentation(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	t.Setenv(util.EnvOtelcWorkDir, t.TempDir())
+
+	marker := filepath.Join(t.TempDir(), "ran")
+	stub := writeStub(t, "compile", "touch "+marker)
+	compileArgs := []string{stub, "-o", "out.a", "-p", "main", "-buildid", "id", "-pack", "main.go"}
+	require.True(t, util.IsCompileCommandWithArgs(compileArgs), "stub must look like a compile command")
+
+	t.Run("non-nested attempts instrumentation", func(t *testing.T) {
+		err := Toolexec(ctx, compileArgs, false)
+		require.Error(t, err, "instrumentation should try to load the absent matched.json")
+		assert.Contains(t, err.Error(), "otelc setup")
+		assert.NoFileExists(t, marker, "the tool is not run when instrumentation fails first")
+	})
+
+	t.Run("nested passes the command straight through", func(t *testing.T) {
+		require.NoError(t, Toolexec(ctx, compileArgs, true))
+		assert.FileExists(t, marker)
+	})
+}
+
+func TestToolexecPassesThroughLinkWithoutAddedImports(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	t.Setenv(util.EnvOtelcWorkDir, t.TempDir())
+
+	// A link command with no recorded added-imports needs no importcfg
+	// rewrite, so the wrapper runs it unchanged. -importcfg only has to be
+	// present for the command to be recognized as a link.
+	marker := filepath.Join(t.TempDir(), "ran")
+	stub := writeStub(t, "link", "touch "+marker)
+	linkArgs := []string{stub, "-o", "exe", "-buildid", "id", "-importcfg", "importcfg.link"}
+	require.True(t, util.IsLinkCommandWithArgs(linkArgs), "stub must look like a link command")
+
+	require.NoError(t, Toolexec(ctx, linkArgs, false))
+	assert.FileExists(t, marker)
+}
+
+func TestToolexecRecordsStatsWhenEnabled(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	t.Setenv(util.EnvOtelcWorkDir, t.TempDir())
+	t.Setenv(util.EnvOtelcStats, "1")
+
+	marker := filepath.Join(t.TempDir(), "ran")
+	stub := writeStub(t, "asm", "touch "+marker)
+
+	require.NoError(t, Toolexec(ctx, []string{stub, "-buildid", "x"}, false))
+	assert.FileExists(t, marker)
+}
+
+// versionMarkerPattern documents the exact tool-ID shape the go build cache
+// keys on, guarding against accidental format drift.
+var versionMarkerPattern = regexp.MustCompile(`otelc@[^\s/]+(/[0-9a-f]{16})?`)
+
+func TestToolVersionLineMatchesCachePattern(t *testing.T) {
+	assert.Regexp(t, versionMarkerPattern, toolVersionLine("compile version go1.26.5", ""))
+	assert.Regexp(t, versionMarkerPattern, toolVersionLine("compile version go1.26.5", "0123456789abcdef"))
+}

--- a/tool/internal/setup/testdata/non_main_package_name.otelc.runtime.go.golden
+++ b/tool/internal/setup/testdata/non_main_package_name.otelc.runtime.go.golden
@@ -10,4 +10,4 @@ import _ "unsafe"
 var _getstack0 = _otel_debug.Stack
 
 //go:linkname _printstack0 github.com/example/pkg.OtelPrintStackImpl
-var _printstack0 = func(bt []byte) { _otel_log.Printf(string(bt)) }
+var _printstack0 = func(bt []byte) { _otel_log.Print(string(bt)) }

--- a/tool/util/go.go
+++ b/tool/util/go.go
@@ -5,7 +5,6 @@ package util
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"strings"
 
@@ -168,7 +167,7 @@ func QuoteGoflagsToken(token string) (string, error) {
 	case !hasDoubleQuote:
 		return "\"" + token + "\"", nil
 	default:
-		return "", fmt.Errorf("cannot quote token containing both single and double quotes: %q", token)
+		return "", ex.Newf("cannot quote token containing both single and double quotes: %q", token)
 	}
 }
 

--- a/tool/util/go.go
+++ b/tool/util/go.go
@@ -5,6 +5,7 @@ package util
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"strings"
 
@@ -98,10 +99,13 @@ func IsCgoCommand(line string) bool {
 // space-separated, but a token starting with a quote runs to the matching close quote.
 // Quotes are kept so tokens re-join verbatim.
 func splitGoflags(goflags string) []string {
+	isSpace := func(c byte) bool {
+		return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+	}
 	var tokens []string
 	i := 0
 	for i < len(goflags) {
-		for i < len(goflags) && (goflags[i] == ' ' || goflags[i] == '\t') {
+		for i < len(goflags) && isSpace(goflags[i]) {
 			i++
 		}
 		if i >= len(goflags) {
@@ -117,7 +121,7 @@ func splitGoflags(goflags string) []string {
 				i++ // include the closing quote
 			}
 		} else {
-			for i < len(goflags) && goflags[i] != ' ' && goflags[i] != '\t' {
+			for i < len(goflags) && !isSpace(goflags[i]) {
 				i++
 			}
 		}
@@ -146,6 +150,26 @@ func StripToolexecFromGoflags(goflags string) string {
 		kept = append(kept, token)
 	}
 	return strings.Join(kept, " ")
+}
+
+// QuoteGoflagsToken quotes a token for inclusion in a GOFLAGS value, following
+// the same rules as cmd/internal/quoted.Join: unquoted if it has no space,
+// tab, or quote characters; otherwise wrapped in whichever of ' or " doesn't
+// appear in the token. A token containing both quote characters can't be
+// safely represented and returns an error.
+func QuoteGoflagsToken(token string) (string, error) {
+	hasSingleQuote := strings.ContainsRune(token, '\'')
+	hasDoubleQuote := strings.ContainsRune(token, '"')
+	switch {
+	case !strings.ContainsAny(token, " \t\n\r'\""):
+		return token, nil
+	case !hasSingleQuote:
+		return "'" + token + "'", nil
+	case !hasDoubleQuote:
+		return "\"" + token + "\"", nil
+	default:
+		return "", fmt.Errorf("cannot quote token containing both single and double quotes: %q", token)
+	}
 }
 
 // FindFlagValue finds the value of a flag in the command line.

--- a/tool/util/go.go
+++ b/tool/util/go.go
@@ -92,6 +92,61 @@ func IsCgoCommand(line string) bool {
 		!strings.Contains(line, "-dynimport")
 }
 
+// splitGoflags splits a GOFLAGS value into tokens like the go command does
+// (cmd/internal/quoted.Split): space-separated, but a token starting with a
+// quote runs to the matching close quote. Quotes are kept so tokens re-join
+// verbatim.
+func splitGoflags(goflags string) []string {
+	var tokens []string
+	i := 0
+	for i < len(goflags) {
+		for i < len(goflags) && (goflags[i] == ' ' || goflags[i] == '\t') {
+			i++
+		}
+		if i >= len(goflags) {
+			break
+		}
+		start := i
+		if q := goflags[i]; q == '\'' || q == '"' {
+			i++
+			for i < len(goflags) && goflags[i] != q {
+				i++
+			}
+			if i < len(goflags) {
+				i++ // include the closing quote
+			}
+		} else {
+			for i < len(goflags) && goflags[i] != ' ' && goflags[i] != '\t' {
+				i++
+			}
+		}
+		tokens = append(tokens, goflags[start:i])
+	}
+	return tokens
+}
+
+// StripToolexecFromGoflags returns goflags without any -toolexec entry. In
+// drop-in mode the go commands otelc spawns would inherit the flag and
+// recursively re-invoke otelc; stripping it lets each command choose its
+// children's toolexec: none for setup discovery, an explicit CLI flag for
+// `otelc go build`, and nested version-only mode during instrumentation.
+func StripToolexecFromGoflags(goflags string) string {
+	tokens := splitGoflags(goflags)
+	kept := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		unquoted := token
+		if len(unquoted) >= 2 && (unquoted[0] == '\'' || unquoted[0] == '"') &&
+			unquoted[len(unquoted)-1] == unquoted[0] {
+			unquoted = unquoted[1 : len(unquoted)-1]
+		}
+		if unquoted == "-toolexec" || strings.HasPrefix(unquoted, "-toolexec=") {
+			continue
+		}
+		kept = append(kept, token)
+	}
+	return strings.Join(kept, " ")
+}
+
 // FindFlagValue finds the value of a flag in the command line.
 func FindFlagValue(cmd []string, flag string) string {
 	flagWithValue := flag + "="

--- a/tool/util/go.go
+++ b/tool/util/go.go
@@ -93,9 +93,10 @@ func IsCgoCommand(line string) bool {
 }
 
 // splitGoflags splits a GOFLAGS value into tokens like the go command does
-// (cmd/internal/quoted.Split): space-separated, but a token starting with a
-// quote runs to the matching close quote. Quotes are kept so tokens re-join
-// verbatim.
+// (https://cs.opensource.google/go/go/+/master:src/cmd/internal/quoted/quoted.go)
+//
+// space-separated, but a token starting with a quote runs to the matching close quote.
+// Quotes are kept so tokens re-join verbatim.
 func splitGoflags(goflags string) []string {
 	var tokens []string
 	i := 0

--- a/tool/util/shared.go
+++ b/tool/util/shared.go
@@ -22,14 +22,17 @@ const (
 	EnvOtelcStats = "OTELC_STATS"
 	// EnvOtelcDebug enables debug-level logging when set to "1".
 	// Set automatically when --debug is used; propagated to child processes.
-	EnvOtelcDebug    = "OTELC_DEBUG"
-	BuildTempDir     = ".otelc-build"
-	BuildLockFile    = BuildTempDir + ".lock"
-	OtelcRoot        = "go.opentelemetry.io/otelc"
-	OtelcPkgRoot     = OtelcRoot + "/pkg"
-	OtelcInstRoot    = OtelcRoot + "/instrumentation"
-	OtelcToolCmdRoot = OtelcRoot + "/tool/cmd/otelc"
-	OtelcToolExe     = "otelc"
+	EnvOtelcDebug = "OTELC_DEBUG"
+	// EnvOtelcNestedToolexec marks toolexec invocations spawned by a go
+	// command otelc itself ran (e.g. `go list -export`).
+	EnvOtelcNestedToolexec = "OTELC_NESTED_TOOLEXEC"
+	BuildTempDir           = ".otelc-build"
+	BuildLockFile          = BuildTempDir + ".lock"
+	OtelcRoot              = "go.opentelemetry.io/otelc"
+	OtelcPkgRoot           = OtelcRoot + "/pkg"
+	OtelcInstRoot          = OtelcRoot + "/instrumentation"
+	OtelcToolCmdRoot       = OtelcRoot + "/tool/cmd/otelc"
+	OtelcToolExe           = "otelc"
 	// TODO: remove these once v1 is released and migrate all usage to the constants above
 	OtelcOldRoot        = "github.com/open-telemetry/opentelemetry-go-compile-instrumentation"
 	OtelcOldToolCmdRoot = OtelcOldRoot + "/tool/cmd"
@@ -61,6 +64,29 @@ func GetOtelcWorkDir() string {
 		return wd
 	}
 	return wd
+}
+
+// DiscoverWorkDir finds the work directory prepared by `otelc setup` when
+// otelc runs as a bare `-toolexec` (OTELC_WORK_DIR unset because the build
+// was started by `go build`).
+//
+// Needed because the go toolchain runs some tools (asm, cgo) from the package
+// source directory, which may be the read-only module cache.
+func DiscoverWorkDir(dir string) string {
+	dir = filepath.Clean(dir)
+	for {
+		if PathExists(filepath.Join(dir, BuildTempDir)) {
+			return dir
+		}
+		if PathExists(filepath.Join(dir, "go.mod")) {
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 // GetBuildTemp returns the path to the build temp directory $BUILD_TEMP/name

--- a/tool/util/toolexec_dropin_test.go
+++ b/tool/util/toolexec_dropin_test.go
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverWorkDir(t *testing.T) {
+	newDir := func(t *testing.T, parts ...string) string {
+		t.Helper()
+		dir := filepath.Join(parts...)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+	touch := func(t *testing.T, path string) {
+		t.Helper()
+		if err := os.WriteFile(path, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("found in current directory", func(t *testing.T) {
+		module := newDir(t, t.TempDir(), "module")
+		newDir(t, module, BuildTempDir)
+		touch(t, filepath.Join(module, "go.mod"))
+
+		if got := DiscoverWorkDir(module); got != module {
+			t.Errorf("DiscoverWorkDir() = %q, want %q", got, module)
+		}
+	})
+
+	t.Run("found walking up from a subdirectory", func(t *testing.T) {
+		module := newDir(t, t.TempDir(), "module")
+		newDir(t, module, BuildTempDir)
+		touch(t, filepath.Join(module, "go.mod"))
+		sub := newDir(t, module, "internal", "app")
+
+		if got := DiscoverWorkDir(sub); got != module {
+			t.Errorf("DiscoverWorkDir() = %q, want %q", got, module)
+		}
+	})
+
+	t.Run("stops at go.mod when no work dir exists", func(t *testing.T) {
+		// .otelc-build exists above the module boundary and must not be found.
+		root := t.TempDir()
+		newDir(t, root, BuildTempDir)
+		module := newDir(t, root, "module")
+		touch(t, filepath.Join(module, "go.mod"))
+		sub := newDir(t, module, "internal")
+
+		if got := DiscoverWorkDir(sub); got != "" {
+			t.Errorf("DiscoverWorkDir() = %q, want empty", got)
+		}
+	})
+}
+
+func TestStripToolexecFromGoflags(t *testing.T) {
+	tests := []struct {
+		name     string
+		goflags  string
+		expected string
+	}{
+		{
+			name:     "empty",
+			goflags:  "",
+			expected: "",
+		},
+		{
+			name:     "no toolexec flag",
+			goflags:  "-mod=mod -race",
+			expected: "-mod=mod -race",
+		},
+		{
+			name:     "bare toolexec flag",
+			goflags:  "-toolexec=otelc",
+			expected: "",
+		},
+		{
+			name:     "single-quoted toolexec flag with space",
+			goflags:  "'-toolexec=otelc toolexec'",
+			expected: "",
+		},
+		{
+			name:     "double-quoted toolexec flag with space",
+			goflags:  `"-toolexec=otelc toolexec"`,
+			expected: "",
+		},
+		{
+			name:     "toolexec flag between other flags",
+			goflags:  "-mod=mod '-toolexec=otelc toolexec' -race",
+			expected: "-mod=mod -race",
+		},
+		{
+			name:     "other quoted flags are preserved verbatim",
+			goflags:  "'-tags=a b' -toolexec=otelc",
+			expected: "'-tags=a b'",
+		},
+		{
+			name:     "extra whitespace between flags",
+			goflags:  "  -mod=mod   -toolexec=otelc  ",
+			expected: "-mod=mod",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripToolexecFromGoflags(tt.goflags); got != tt.expected {
+				t.Errorf("StripToolexecFromGoflags(%q) = %q, want %q", tt.goflags, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Contributing to https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/671

This solves `Case 2`, we'll need another PRs for fixing `Case 1`.

Main changes:
1. **Work-dir discovery (DiscoverWorkDir)**: walk up from cwd to .otelc-build, bounded by go.mod, instead of trusting cwd (which may be the read-only module cache for asm/cgo).
2. **GOFLAGS strip at startup**: remove -toolexec so spawned go children don't recurse.
3. **-V=full rewrite**: append an otelc@<version>/<rulesHash> marker to the tool ID so instrumented and plain artifacts never share build-cache entries.
4. **Nested version-only toolexec (OTELC_NESTED_TOOLEXEC)**: keep archives resolved during instrumentation aligned with the outer build's cache keys.
5. **Actionable error when matched.json is missing + docs**.