### PR TITLE
fix: use Print instead of Printf around variable

### DIFF
--- a/tool/internal/setup/add.go
+++ b/tool/internal/setup/add.go
@@ -68,18 +68,18 @@ func genVarDecl(matched []*rule.InstFuncRule) []dst.Decl {
 		}
 		// Second variable declaration
 		// //go:linkname _printstack%d %s.OtelPrintStackImpl
-		// var _printstack%d = func (bt []byte){ _otel_log.Printf(string(bt)) }
+		// var _printstack%d = func (bt []byte){ _otel_log.Print(string(bt)) }
 		// Build: string(bt)
 		stringCall := &dst.CallExpr{
 			Fun:  ast.Ident("string"),
 			Args: []dst.Expr{ast.Ident("bt")},
 		}
-		// Build: _otel_log.Printf(string(bt))
-		printfCall := &dst.CallExpr{
-			Fun:  ast.SelectorExpr(ast.Ident("_otel_log"), "Printf"),
+		// Build: _otel_log.Print(string(bt))
+		printCall := &dst.CallExpr{
+			Fun:  ast.SelectorExpr(ast.Ident("_otel_log"), "Print"),
 			Args: []dst.Expr{stringCall},
 		}
-		// Build: func (bt []byte) { _otel_log.Printf(string(bt)) }
+		// Build: func (bt []byte) { _otel_log.Print(string(bt)) }
 		printStackFunc := &dst.FuncLit{
 			Type: &dst.FuncType{
 				Params: &dst.FieldList{
@@ -88,7 +88,7 @@ func genVarDecl(matched []*rule.InstFuncRule) []dst.Decl {
 					},
 				},
 			},
-			Body: ast.BlockStmts(ast.ExprStmt(printfCall)),
+			Body: ast.BlockStmts(ast.ExprStmt(printCall)),
 		}
 		printStackVar := ast.VarDecl(fmt.Sprintf("_printstack%d", i), printStackFunc)
 		printStackVar.Decs = dst.GenDeclDecorations{

--- a/tool/internal/setup/testdata/multiple_rule_sets.otelc.runtime.go.golden
+++ b/tool/internal/setup/testdata/multiple_rule_sets.otelc.runtime.go.golden
@@ -13,10 +13,10 @@ import _ "unsafe"
 var _getstack0 = _otel_debug.Stack
 
 //go:linkname _printstack0 github.com/example/pkg1.OtelPrintStackImpl
-var _printstack0 = func(bt []byte) { _otel_log.Printf(string(bt)) }
+var _printstack0 = func(bt []byte) { _otel_log.Print(string(bt)) }
 
 //go:linkname _getstack1 github.com/example/pkg3.OtelGetStackImpl
 var _getstack1 = _otel_debug.Stack
 
 //go:linkname _printstack1 github.com/example/pkg3.OtelPrintStackImpl
-var _printstack1 = func(bt []byte) { _otel_log.Printf(string(bt)) }
+var _printstack1 = func(bt []byte) { _otel_log.Print(string(bt)) }

--- a/tool/internal/setup/testdata/single_func_rule.otelc.runtime.go.golden
+++ b/tool/internal/setup/testdata/single_func_rule.otelc.runtime.go.golden
@@ -10,4 +10,4 @@ import _ "unsafe"
 var _getstack0 = _otel_debug.Stack
 
 //go:linkname _printstack0 github.com/example/pkg.OtelPrintStackImpl
-var _printstack0 = func(bt []byte) { _otel_log.Printf(string(bt)) }
+var _printstack0 = func(bt []byte) { _otel_log.Print(string(bt)) }


### PR DESCRIPTION
<!--
Thank you for contributing to OpenTelemetry Go Compile Instrumentation!

INSTRUCTIONS:
1. Fill in the description and motivation sections below
2. Complete the checklist before submitting
3. Ensure PR title follows conventional commits format (enforced by CI)

PR TITLE FORMAT (required):
  type(scope): description

  Types: chore, doc, docs, feat, fix, release, refactor, test
  Scopes: tool, pkg, demo, test, docs

  Examples:
  - feat(pkg): add gRPC client instrumentation
  - fix(tool): resolve hook signature matching issue
  - docs(api): update instrumenter interface documentation
  - refactor(pkg): simplify attribute extractor composition

BEFORE SUBMITTING:
  make format  # Format Go code and YAML files
  make lint    # Run all linters
  make test    # Run all tests (unit + integration + e2e)

If your PR adds a new user-facing instrumentation, please also submit a corresponding OpenTelemetry Registry PR:
https://opentelemetry.io/ecosystem/registry/adding/

For detailed contribution guidelines, see CONTRIBUTING.md
For available make targets, run: make help
-->

## Description

<!-- What changes does this PR introduce? -->

Fixes an issue where a print statement was not properly formatted, but never caught since it was unreachable before https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pull/682.

## Motivation

<!-- Why is this change needed? What problem does it solve? -->

Previously, we were injecting `log.Printf(string(bt))`, which fails to compile with `vet`.

```
Error: net_http/otelc.runtime.go:13:55: non-constant format string in call to log.Printf
Error:
[0] failed to run command "/opt/hostedtoolcache/go/1.26.5/x64/pkg/tool/linux_amd64/vet" in dir '""' with args: [-atomic -bool -buildtags -directive -errorsas -ifaceassert -nilfunc -printf -slog -stringintconv -tests $WORK/b125/vet.cfg]: exit status 1
```

---

## Checklist

- [ ] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [ ] Code formatted: `make format`
- [ ] Linters pass: `make lint`
- [ ] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))
