### PR TITLE
docs: fix directive rule example to use template instead of replace

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -966,7 +966,7 @@ span_directive:
     directive: "otelc:span"
   do:
     - expand_directive:
-        replace: |-
+        template: |-
           println("span start: {{FuncName}}")
           defer println("span end: {{FuncName}}")
 ```


### PR DESCRIPTION
## Description
`docs/rules.md`'s Directive Rule example uses `replace:` under `expand_directive`, but `InstDirectiveRule` only reads `template` (`yaml:"template"`). Copy-pasting the example as-is fails to load with `template cannot be empty`. Fixes the key name so the example works.

## Motivation
Docs should be copy-pasteable without erroring. Found this while testing before the v1 cut.

---

## Checklist
- [x] PR title follows conventional commits format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint` (Dockerfile-typos check skipped locally — Docker registry auth issue on my machine, unrelated to this change)
- [x] Documentation updated (this PR is the doc fix)
