### PR TITLE
docs: prepare v1.0.0 GA release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,9 @@
   <br />
   <img src="https://img.shields.io/badge/Go-1.25%2B-4A90E2?style=flat&logo=go" alt="Go" />
   <img src="https://img.shields.io/badge/License-Apache%202.0-4A90E2?style=flat&logo=apache" alt="License" />
-  <img src="https://img.shields.io/badge/Status-Development-FF6B35?style=flat&logo=github" alt="Status" />
+  <img src="https://img.shields.io/badge/Status-Stable-4A90E2?style=flat&logo=github" alt="Status" />
   <img src="https://img.shields.io/badge/Slack-CNCF-FF6B35?style=flat&logo=slack" alt="Slack" />
 </div>
-
-> [!IMPORTANT]
-> This is a work in progress and not ready for production use. 🚨
 
 ## Overview
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@ between scheduled releases when a critical bug or security issue is found.
 ## Release Shepherd
 
 Each release is owned by a **release shepherd** — one of the project
-[maintainers](CONTRIBUTING.md#maintainers). The shepherd is responsible for
+[maintainers](README.md#maintainers). The shepherd is responsible for
 driving the release end-to-end: tagging, monitoring the workflow, and
 publishing the final release notes.
 
@@ -62,19 +62,19 @@ and watch the `Build and Release` job. It runs the following steps:
 3. Runs `make build-all` — cross-compiles `otelc` for all supported platforms
 4. Creates a GitHub release and uploads the binaries
 
-### 3. Review and publish the release
+### 3. Review and polish the release
 
-The workflow publishes the GitHub release automatically using
+The workflow publishes the GitHub release live immediately using
 `softprops/action-gh-release` with auto-generated release notes. After the
 workflow completes:
 
 1. Open the [Releases page](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/releases)
 2. Review the auto-generated release notes (derived from PR titles since the
    previous tag).
-3. Edit the notes to add context, highlight breaking changes, or group entries
-   as needed.
-4. Publish the release if it was created as a draft, or confirm it looks
-   correct if already published.
+3. Edit the notes in place to add context, highlight breaking changes, or
+   group entries as needed — the release is already public at this point.
+4. Confirm the release page lists all 5 platform binaries as downloadable
+   assets.
 
 ## Cross-Compilation Targets
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,9 @@ No manual code changes required.
 2. **Try the demo**
 
    ```bash
-   make demo
+   cd demo/app/basic
+   ../../otelc go build
+   ./basic
    ```
 
 3. **Use with your application**
@@ -149,6 +151,6 @@ Learn more about the project from these presentations:
 
 ## Status
 
-> **Note**: This project is currently in active development and not yet ready for production use.
+This project is stable and ready for production use as of v1.0.0.
 
-For the latest updates and development progress, follow the project on GitHub and join the community discussions.
+For the latest updates, follow the project on GitHub and join the community discussions.


### PR DESCRIPTION
## Summary

- Remove the "work in progress / not ready for production" banner from
  README.md and flip the status badge from Development to Stable.
- Fix a broken anchor in RELEASE.md: the maintainers list is under
  \`README.md#maintainers\`, not \`CONTRIBUTING.md#maintainers\`.
- Reword RELEASE.md step 3 to reflect reality: \`softprops/action-gh-release\`
  publishes the release live immediately — there is no draft step.
- Fix the broken \`make demo\` quick-start in getting-started.md (that
  Make target does not exist). Replace with the working path:
  \`cd demo/app/basic && ../../otelc go build && ./basic\`.
- Remove the "currently in active development and not yet ready for
  production use" note from getting-started.md's Status section.

## Test plan

- [x] \`typos\` passes on all changed files — no spelling regressions.
- [x] \`npx markdownlint-cli -c .tools/markdownlint.yaml\` on changed files
  shows the same pre-existing errors as \`main\` — no new issues introduced.
- [x] \`README.md#maintainers\` anchor resolves: \`### Maintainers\` heading
  confirmed present in README.md.
- [x] \`make demo\` target does not exist (verified against Makefile);
  replacement path \`demo/app/basic\` confirmed to exist.