### PR TITLE
chore: retract v1.0.0 in favor of v1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,3 +28,5 @@ require (
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 )
+
+retract v1.0.0 // otelc pin generates incorrect module paths in user go.mod files; use v1.0.1


### PR DESCRIPTION
v1.0.0 ships with a bug in \`otelc pin\` (#688): it writes incorrect
module paths into user go.mod files due to stale constant references.
v1.0.1 fixes this.

Adding a \`retract\` directive so the Go toolchain warns users who depend
on v1.0.0 and skips it during automatic version selection.

## Test plan

- [x] \`go mod\` accepts the retract directive (no syntax errors)
- [x] Retract reason matches the user-visible warning Go tooling displays