### PR TITLE
chore(semconv): add Weaver registry groups for grpc, database/sql, redis, kafka, k8s, openai, mongo

### DIFF
--- a/docs/semantic-conventions.md
+++ b/docs/semantic-conventions.md
@@ -43,7 +43,14 @@ The project maintains its own Weaver schema registry under [`schemas/otelc/`](..
 schemas/otelc/
 ├── registry_manifest.yaml   # registry metadata + pinned upstream semconv dependency
 ├── groups/                  # one file per instrumentation (metrics, spans, attributes)
-│   └── http.yaml            # net/http client & server telemetry
+│   ├── http.yaml            # net/http client & server metrics
+│   ├── grpc.yaml            # google.golang.org/grpc client & server metrics + spans
+│   ├── database-sql.yaml    # database/sql client spans
+│   ├── redis.yaml           # redis/go-redis (v9) client spans
+│   ├── kafka.yaml           # segmentio/kafka-go producer & consumer spans
+│   ├── k8s.yaml             # k8s.io/client-go informer spans
+│   ├── openai.yaml          # openai/openai-go GenAI client spans
+│   └── mongo.yaml           # go.mongodb.org/mongo-driver client spans
 └── .deps/                   # pre-fetched upstream semconv (git-ignored, generated)
 ```
 
@@ -56,8 +63,9 @@ Use `groups/http.yaml` as the template:
 
 1. Create `schemas/otelc/groups/<library>.yaml`.
 2. For each metric your instrumentation records (see its `instrumentation/**/semconv/*.go`), add a `type: metric` group with `metric_name`, `instrument`, `unit`, `stability`, and its attribute set.
-3. Reference upstream attributes with `- ref: <attribute.id>`. For attributes/metrics not defined upstream, declare them locally with `id:` (include `type`, `stability`, `brief`, and `examples` for string attributes — `--future` treats a missing example as an error).
-4. Run `make lint-schema` and fix any diagnostics.
+3. For each span your instrumentation creates, add a `type: span` group with `span_kind`, `stability`, `brief`, and its attribute set (see `groups/grpc.yaml`, `groups/database-sql.yaml`). List the union of all attributes the span may carry, including those set only conditionally.
+4. Reference upstream attributes with `- ref: <attribute.id>`. For attributes/metrics not defined upstream, declare them locally with `id:` (include `type`, `stability`, `brief`, and `examples` for string attributes — `--future` treats a missing example as an error). Group local attribute definitions in a `type: attribute_group` so several groups can `ref:` them (see `groups/k8s.yaml`, `groups/openai.yaml`).
+5. Run `make lint-schema` and fix any diagnostics.
 
 > **Note on re-declaring upstream metrics.** Most instrumentations emit standard upstream metrics (e.g. `http.client.request.duration`). Weaver has no way to *reference* a metric defined in a dependency, so we re-declare it locally to pin the emission contract. Weaver then reports a `DuplicateMetricName` between our registry and the upstream dependency; this specific, expected duplicate is allowlisted in [`scripts/semconv/lint-schema-filter.jq`](../scripts/semconv/lint-schema-filter.jq). Any *other* diagnostic — including a metric declared twice within our own registry, or an unresolved `ref:` — still fails the lint.
 

--- a/schemas/otelc/README.md
+++ b/schemas/otelc/README.md
@@ -9,7 +9,14 @@ otelc produces".
 schemas/otelc/
 ├── registry_manifest.yaml   # registry metadata + pinned upstream semconv dependency
 ├── groups/                  # one file per instrumentation (metrics, spans, attributes)
-│   └── http.yaml            # net/http client & server telemetry
+│   ├── http.yaml            # net/http client & server metrics
+│   ├── grpc.yaml            # google.golang.org/grpc client & server metrics + spans
+│   ├── database-sql.yaml    # database/sql client spans
+│   ├── redis.yaml           # redis/go-redis (v9) client spans
+│   ├── kafka.yaml           # segmentio/kafka-go producer & consumer spans
+│   ├── k8s.yaml             # k8s.io/client-go informer spans
+│   ├── openai.yaml          # openai/openai-go GenAI client spans
+│   └── mongo.yaml           # go.mongodb.org/mongo-driver client spans
 └── .deps/                   # pre-fetched upstream semconv (git-ignored, generated)
 ```
 

--- a/schemas/otelc/groups/database-sql.yaml
+++ b/schemas/otelc/groups/database-sql.yaml
@@ -1,0 +1,27 @@
+groups:
+  # ---------------------------------------------------------------------------
+  # database/sql instrumentation emission contract.
+  #
+  # Source of truth for this file:
+  #   instrumentation/database/sql/client.go        (span lifecycle)
+  #   instrumentation/database/sql/semconv/db.go     (DbClientRequestTraceAttrs)
+  #
+  # The database/sql instrumentation is trace-only: it creates one client span
+  # per database operation and records no metrics. Every attribute is standard
+  # upstream OpenTelemetry database telemetry, referenced with `ref:`.
+  # `server.port` is emitted only when the endpoint carries a parseable port.
+  # ---------------------------------------------------------------------------
+
+  - id: span.otelc.db.sql.client
+    type: span
+    span_kind: client
+    stability: development
+    brief: database/sql client span, one per database operation.
+    attributes:
+      - ref: db.system.name
+      - ref: db.operation.name
+      - ref: db.namespace
+      - ref: db.query.text
+      - ref: network.transport
+      - ref: server.address
+      - ref: server.port

--- a/schemas/otelc/groups/grpc.yaml
+++ b/schemas/otelc/groups/grpc.yaml
@@ -1,0 +1,172 @@
+groups:
+  # ---------------------------------------------------------------------------
+  # gRPC instrumentation emission contract.
+  #
+  # Source of truth for this file:
+  #   instrumentation/google.golang.org/grpc/client/client_hook.go
+  #   instrumentation/google.golang.org/grpc/server/server_hook.go
+  #   instrumentation/google.golang.org/grpc/semconv/grpc.go
+  #
+  # The gRPC instrumentation records ten standard upstream RPC histograms (via
+  # the generated `semconv/.../rpcconv` package) and creates one client or
+  # server span per RPC. All metrics and attributes are standard upstream
+  # OpenTelemetry RPC telemetry, referenced with `ref:`. Declaring them here
+  # pins the exact subset this project emits. The size histograms carry only
+  # `rpc.system`/`rpc.service`/`rpc.method` because their attribute set is
+  # captured before the RPC status code is known.
+  # ---------------------------------------------------------------------------
+
+  # --- Client metrics -------------------------------------------------------
+  - id: metric.otelc.rpc.client.duration
+    type: metric
+    metric_name: rpc.client.duration
+    instrument: histogram
+    unit: ms
+    stability: development
+    brief: Measures the duration of outbound RPC.
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+      - ref: rpc.grpc.status_code
+
+  - id: metric.otelc.rpc.client.request.size
+    type: metric
+    metric_name: rpc.client.request.size
+    instrument: histogram
+    unit: By
+    stability: development
+    brief: Measures the size of RPC request messages (uncompressed).
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+
+  - id: metric.otelc.rpc.client.response.size
+    type: metric
+    metric_name: rpc.client.response.size
+    instrument: histogram
+    unit: By
+    stability: development
+    brief: Measures the size of RPC response messages (uncompressed).
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+
+  - id: metric.otelc.rpc.client.requests_per_rpc
+    type: metric
+    metric_name: rpc.client.requests_per_rpc
+    instrument: histogram
+    unit: "{count}"
+    stability: development
+    brief: Measures the number of messages received per RPC.
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+      - ref: rpc.grpc.status_code
+
+  - id: metric.otelc.rpc.client.responses_per_rpc
+    type: metric
+    metric_name: rpc.client.responses_per_rpc
+    instrument: histogram
+    unit: "{count}"
+    stability: development
+    brief: Measures the number of messages sent per RPC.
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+      - ref: rpc.grpc.status_code
+
+  # --- Server metrics -------------------------------------------------------
+  - id: metric.otelc.rpc.server.duration
+    type: metric
+    metric_name: rpc.server.duration
+    instrument: histogram
+    unit: ms
+    stability: development
+    brief: Measures the duration of inbound RPC.
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+      - ref: rpc.grpc.status_code
+
+  - id: metric.otelc.rpc.server.request.size
+    type: metric
+    metric_name: rpc.server.request.size
+    instrument: histogram
+    unit: By
+    stability: development
+    brief: Measures the size of RPC request messages (uncompressed).
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+
+  - id: metric.otelc.rpc.server.response.size
+    type: metric
+    metric_name: rpc.server.response.size
+    instrument: histogram
+    unit: By
+    stability: development
+    brief: Measures the size of RPC response messages (uncompressed).
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+
+  - id: metric.otelc.rpc.server.requests_per_rpc
+    type: metric
+    metric_name: rpc.server.requests_per_rpc
+    instrument: histogram
+    unit: "{count}"
+    stability: development
+    brief: Measures the number of messages received per RPC.
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+      - ref: rpc.grpc.status_code
+
+  - id: metric.otelc.rpc.server.responses_per_rpc
+    type: metric
+    metric_name: rpc.server.responses_per_rpc
+    instrument: histogram
+    unit: "{count}"
+    stability: development
+    brief: Measures the number of messages sent per RPC.
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+      - ref: rpc.grpc.status_code
+
+  # --- Spans ----------------------------------------------------------------
+  - id: span.otelc.rpc.client
+    type: span
+    span_kind: client
+    stability: development
+    brief: gRPC client span, one per outbound RPC.
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+      - ref: rpc.grpc.status_code
+      - ref: server.address
+      - ref: server.port
+
+  - id: span.otelc.rpc.server
+    type: span
+    span_kind: server
+    stability: development
+    brief: gRPC server span, one per inbound RPC.
+    attributes:
+      - ref: rpc.system
+      - ref: rpc.service
+      - ref: rpc.method
+      - ref: rpc.grpc.status_code
+      - ref: client.address
+      - ref: client.port

--- a/schemas/otelc/groups/k8s.yaml
+++ b/schemas/otelc/groups/k8s.yaml
@@ -1,0 +1,102 @@
+groups:
+  # ---------------------------------------------------------------------------
+  # k8s.io/client-go instrumentation emission contract.
+  #
+  # Source of truth for this file:
+  #   instrumentation/k8s.io/client-go/hook.go                (span lifecycle)
+  #   instrumentation/k8s.io/client-go/k8s_otel_handler.go     (span names)
+  #   instrumentation/k8s.io/client-go/semconv/k8s.go          (attributes)
+  #
+  # The client-go instrumentation is trace-only: it instruments the informer /
+  # DeltaFIFO processing path and records no metrics. It creates internal spans
+  # covering (a) a batch "objects.process" step and (b) per-object add/update/
+  # delete events. Most attributes are standard upstream OpenTelemetry k8s
+  # resource attributes (referenced with `ref:`); six attributes are specific
+  # to this instrumentation and are not defined upstream, so they are declared
+  # locally with `id:` in the attribute group below.
+  # ---------------------------------------------------------------------------
+
+  - id: registry.otelc.k8s
+    type: attribute_group
+    display_name: otelc client-go informer attributes
+    brief: >
+      Attributes emitted by the client-go informer instrumentation that are not covered by the upstream OpenTelemetry k8s
+      semantic conventions.
+    attributes:
+      - id: k8s.object.uid
+        type: string
+        stability: development
+        brief: The UID of a Kubernetes object whose concrete kind has no dedicated upstream attribute.
+        examples: ["275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"]
+      - id: k8s.object.name
+        type: string
+        stability: development
+        brief: The name of a Kubernetes object whose concrete kind has no dedicated upstream attribute.
+        examples: ["my-object"]
+      - id: k8s.object.api_version
+        type: string
+        stability: development
+        brief: The API version (group/version) of the Kubernetes object.
+        examples: ["apps/v1", "v1"]
+      - id: k8s.object.kind
+        type: string
+        stability: development
+        brief: The kind of the Kubernetes object.
+        examples: ["Pod", "Deployment"]
+      - id: k8s.objects.count
+        type: int
+        stability: development
+        brief: The number of objects processed in a single informer batch.
+        examples: [42]
+      - id: k8s.objects.is_in_initial_list
+        type: boolean
+        stability: development
+        brief: Whether the processed objects are part of the informer's initial list (as opposed to a subsequent watch event).
+
+  - id: span.otelc.k8s.informer.objects.process
+    type: span
+    span_kind: internal
+    stability: development
+    brief: Span covering the informer processing of a batch of object deltas.
+    attributes:
+      - ref: k8s.objects.count
+      - ref: k8s.objects.is_in_initial_list
+
+  - id: span.otelc.k8s.informer.object
+    type: span
+    span_kind: internal
+    stability: development
+    brief: >
+      Span covering a single object add/update/delete event processed by the informer. The concrete kind determines which
+      attributes are set; the attribute set below is the union of all possible attributes.
+    attributes:
+      - ref: k8s.namespace.name
+      - ref: k8s.object.uid
+      - ref: k8s.object.name
+      - ref: k8s.object.api_version
+      - ref: k8s.object.kind
+      - ref: k8s.node.uid
+      - ref: k8s.node.name
+      - ref: k8s.pod.uid
+      - ref: k8s.pod.name
+      - ref: k8s.replicaset.uid
+      - ref: k8s.replicaset.name
+      - ref: k8s.deployment.uid
+      - ref: k8s.deployment.name
+      - ref: k8s.statefulset.uid
+      - ref: k8s.statefulset.name
+      - ref: k8s.daemonset.uid
+      - ref: k8s.daemonset.name
+      - ref: k8s.job.uid
+      - ref: k8s.job.name
+      - ref: k8s.cronjob.uid
+      - ref: k8s.cronjob.name
+      - ref: k8s.replicationcontroller.uid
+      - ref: k8s.replicationcontroller.name
+      - ref: k8s.hpa.uid
+      - ref: k8s.hpa.name
+      - ref: k8s.hpa.scaletargetref.api_version
+      - ref: k8s.hpa.scaletargetref.kind
+      - ref: k8s.hpa.scaletargetref.name
+      - ref: k8s.resourcequota.uid
+      - ref: k8s.resourcequota.name

--- a/schemas/otelc/groups/kafka.yaml
+++ b/schemas/otelc/groups/kafka.yaml
@@ -1,0 +1,50 @@
+groups:
+  # ---------------------------------------------------------------------------
+  # segmentio/kafka-go instrumentation emission contract.
+  #
+  # Source of truth for this file:
+  #   instrumentation/github.com/segmentio/kafka-go/producer/producer_hook.go
+  #   instrumentation/github.com/segmentio/kafka-go/consumer/consumer_hook.go
+  #   instrumentation/github.com/segmentio/kafka-go/semconv/client.go
+  #
+  # The kafka-go instrumentation is trace-only: it creates one producer span
+  # per sent message and one consumer span per read message, and records no
+  # metrics. Every attribute is standard upstream OpenTelemetry messaging
+  # telemetry, referenced with `ref:`. `messaging.system` is always `kafka`.
+  # Consumer-only attributes (`messaging.consumer.group.name`,
+  # `messaging.destination.partition.id`, `messaging.kafka.offset`) are not set
+  # on producer spans.
+  # ---------------------------------------------------------------------------
+
+  - id: span.otelc.messaging.kafka.producer
+    type: span
+    span_kind: producer
+    stability: development
+    brief: Kafka producer span, one per sent message.
+    attributes:
+      - ref: messaging.system
+      - ref: messaging.operation.name
+      - ref: messaging.operation.type
+      - ref: messaging.destination.name
+      - ref: messaging.kafka.message.key
+      - ref: messaging.message.body.size
+      - ref: server.address
+      - ref: server.port
+
+  - id: span.otelc.messaging.kafka.consumer
+    type: span
+    span_kind: consumer
+    stability: development
+    brief: Kafka consumer span, one per read message.
+    attributes:
+      - ref: messaging.system
+      - ref: messaging.operation.name
+      - ref: messaging.operation.type
+      - ref: messaging.destination.name
+      - ref: messaging.consumer.group.name
+      - ref: messaging.kafka.message.key
+      - ref: messaging.message.body.size
+      - ref: messaging.destination.partition.id
+      - ref: messaging.kafka.offset
+      - ref: server.address
+      - ref: server.port

--- a/schemas/otelc/groups/mongo.yaml
+++ b/schemas/otelc/groups/mongo.yaml
@@ -1,0 +1,34 @@
+groups:
+  # ---------------------------------------------------------------------------
+  # go.mongodb.org/mongo-driver instrumentation emission contract.
+  #
+  # Source of truth for this file:
+  #   instrumentation/go.mongodb.org/mongo-driver/mongo/client_hook.go
+  #
+  # The mongo-driver instrumentation is a compile-time hook that injects the
+  # upstream `otelmongo` command monitor (go.opentelemetry.io/contrib/.../otelmongo).
+  # That monitor is trace-only (no metrics) and, at its pinned version, emits
+  # the legacy v1.17.0 database conventions (`db.system`, `db.operation`,
+  # `db.name`, `net.peer.*`, `net.transport`, `db.mongodb.collection`) rather
+  # than the current `db.system.name` / `db.namespace` names. These attributes
+  # are deprecated upstream but still referenced here so the contract reflects
+  # what is actually emitted on the wire.
+  #
+  # `db.statement` is intentionally omitted: otelmongo gates it behind
+  # CommandAttributeDisabled, which defaults to true, and this project wires the
+  # monitor with no options -- so the statement is not emitted by default.
+  # ---------------------------------------------------------------------------
+
+  - id: span.otelc.db.mongodb.client
+    type: span
+    span_kind: client
+    stability: development
+    brief: MongoDB client span, one per command (emitted by the injected otelmongo monitor).
+    attributes:
+      - ref: db.system
+      - ref: db.operation
+      - ref: db.name
+      - ref: db.mongodb.collection
+      - ref: net.peer.name
+      - ref: net.peer.port
+      - ref: net.transport

--- a/schemas/otelc/groups/openai.yaml
+++ b/schemas/otelc/groups/openai.yaml
@@ -1,0 +1,67 @@
+groups:
+  # ---------------------------------------------------------------------------
+  # openai/openai-go instrumentation emission contract.
+  #
+  # Source of truth for this file:
+  #   instrumentation/github.com/openai/openai-go/v3/middleware.go  (span + attrs)
+  #   instrumentation/github.com/openai/openai-go/v3/streaming.go   (streaming attrs)
+  #   instrumentation/github.com/openai/openai-go/v3/semconv/genai.go (attribute keys)
+  #
+  # (v1, v2, and v3 are identical apart from the import path.)
+  #
+  # The openai-go instrumentation is trace-only: it wraps the SDK HTTP transport
+  # and creates one client span per chat / completion / embedding call, with
+  # GenAI attributes. It records no metrics. Most attributes are standard
+  # upstream OpenTelemetry GenAI attributes (referenced with `ref:`). Three
+  # attributes are not defined upstream and are declared locally with `id:`
+  # below: `gen_ai.usage.total_tokens`, `gen_ai.request.is_stream`, and
+  # `gen_ai.response.time_to_first_token`.
+  # ---------------------------------------------------------------------------
+
+  - id: registry.otelc.gen_ai
+    type: attribute_group
+    display_name: otelc GenAI attributes
+    brief: >
+      GenAI attributes emitted by the openai-go instrumentation that are not covered by the upstream OpenTelemetry GenAI semantic
+      conventions.
+    attributes:
+      - id: gen_ai.usage.total_tokens
+        type: int
+        stability: development
+        brief: The total number of tokens used in the request and response.
+        examples: [180]
+      - id: gen_ai.request.is_stream
+        type: boolean
+        stability: development
+        brief: Whether the request was served as a streaming (server-sent events) response.
+      - id: gen_ai.response.time_to_first_token
+        type: int
+        stability: development
+        brief: >
+          Time from sending the request to receiving the first token of a streaming response, in microseconds.
+        examples: [1200]
+
+  - id: span.otelc.gen_ai.client
+    type: span
+    span_kind: client
+    stability: development
+    brief: OpenAI client span, one per chat / completion / embedding call.
+    attributes:
+      - ref: gen_ai.system
+      - ref: gen_ai.provider.name
+      - ref: gen_ai.operation.name
+      - ref: gen_ai.request.model
+      - ref: gen_ai.request.max_tokens
+      - ref: gen_ai.request.temperature
+      - ref: gen_ai.request.top_p
+      - ref: gen_ai.request.frequency_penalty
+      - ref: gen_ai.request.presence_penalty
+      - ref: gen_ai.response.id
+      - ref: gen_ai.response.model
+      - ref: gen_ai.response.finish_reasons
+      - ref: gen_ai.usage.input_tokens
+      - ref: gen_ai.usage.output_tokens
+      - ref: gen_ai.usage.total_tokens
+      - ref: gen_ai.request.is_stream
+      - ref: gen_ai.response.time_to_first_token
+      - ref: error.type

--- a/schemas/otelc/groups/redis.yaml
+++ b/schemas/otelc/groups/redis.yaml
@@ -1,0 +1,27 @@
+groups:
+  # ---------------------------------------------------------------------------
+  # redis/go-redis (v9) instrumentation emission contract.
+  #
+  # Source of truth for this file:
+  #   instrumentation/github.com/redis/go-redis/v9/hook.go          (span lifecycle)
+  #   instrumentation/github.com/redis/go-redis/v9/semconv/client.go (RedisClientRequestTraceAttrs)
+  #
+  # The go-redis instrumentation is trace-only: it creates one client span per
+  # command (and one per pipeline) and records no metrics. Every attribute is
+  # standard upstream OpenTelemetry database telemetry, referenced with `ref:`.
+  # `db.system.name` is always `redis`. `server.port` is emitted only when the
+  # endpoint carries a parseable port.
+  # ---------------------------------------------------------------------------
+
+  - id: span.otelc.db.redis.client
+    type: span
+    span_kind: client
+    stability: development
+    brief: go-redis client span, one per command or pipeline.
+    attributes:
+      - ref: db.system.name
+      - ref: db.operation.name
+      - ref: db.query.text
+      - ref: network.transport
+      - ref: server.address
+      - ref: server.port


### PR DESCRIPTION
## What

Follows #696, which scaffolded the local OTel Weaver registry under `schemas/otelc/` with `net/http` as the worked example and noted the remaining instrumentations could be added incrementally using the same pattern. This adds the emission contract for those instrumentations, one `groups/*.yaml` per library, each derived from that instrumentation's source.

## What's included

| File | Telemetry |
|------|-----------|
| `grpc.yaml` | 10 standard RPC histograms (client + server) **plus** client & server spans (`rpc.system`/`service`/`method`, `rpc.grpc.status_code`, peer address) |
| `database-sql.yaml` | client spans (`db.system.name`, `db.operation.name`, `db.namespace`, `db.query.text`, `network.transport`, `server.address`/`port`) |
| `redis.yaml` | go-redis v9 client spans (`db.*` on redis) |
| `kafka.yaml` | segmentio/kafka-go producer & consumer spans (`messaging.*`) |
| `k8s.yaml` | client-go informer spans; declares the 6 informer-specific attributes (`k8s.object.*`, `k8s.objects.*`) not covered upstream |
| `openai.yaml` | openai-go GenAI client spans; declares the 3 attributes not covered upstream (`gen_ai.usage.total_tokens`, `gen_ai.request.is_stream`, `gen_ai.response.time_to_first_token`) |
| `mongo.yaml` | mongo-driver client spans emitted by the injected `otelmongo` monitor (legacy v1.17.0 `db.*`/`net.peer.*` conventions) |

## Notes

- Only gRPC emits metrics; the other six are trace-only, matching each instrumentation's source (verified per-file).
- Upstream telemetry is referenced with `ref:`; library-specific telemetry is declared locally with `id:` in an `attribute_group` (first use of `type: span` and locally-declared attributes in this registry).
- `mongo.yaml` deliberately references the legacy v1.17.0 `db.*`/`net.peer.*` attributes because the injected upstream `otelmongo` monitor still emits them; `db.statement` is omitted since `otelmongo` disables it by default.
- The registry README and `docs/semantic-conventions.md` are updated with the new file list and guidance for declaring spans + local attribute groups.

## Testing

- `make lint-schema` passes (Weaver via Docker; each new group validated against the pinned upstream v1.37.0 dependency, with the expected `DuplicateMetricName` allowlist covering the re-declared upstream RPC metrics).
- `yamlfmt` is clean on all new files.
- No runtime Go code is changed.