### PR TITLE
fix(tool): reject malformed version ranges

### DIFF
--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -90,6 +90,9 @@ func parseRuleFromYaml(content []byte) ([]rule.InstRule, error) {
 			if err3 := rule.ValidateTarget(r.GetTarget()); err3 != nil {
 				return nil, ex.Wrapf(err3, "rule %q", name)
 			}
+			if err4 := util.ValidateVersionRange(r.GetVersion()); err4 != nil {
+				return nil, ex.Wrapf(err4, "rule %q", name)
+			}
 			rules = append(rules, r)
 		}
 	}

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -1433,6 +1433,30 @@ func TestMatchDeps_InvalidGlobTargetRejected(t *testing.T) {
 	require.ErrorContains(t, err, "not a valid glob pattern")
 }
 
+func TestMatchDeps_InvalidVersionRangeRejected(t *testing.T) {
+	dir := t.TempDir()
+	ruleFile := filepath.Join(dir, "bad-version.yaml")
+	err := os.WriteFile(ruleFile, []byte(`bad_version_hook:
+  target: example.com/lib
+  version: "v1.0.0,"
+  func: Handler
+  before: BeforeHandler
+  path: "example.com/hooks"
+`), 0o644)
+	require.NoError(t, err)
+
+	sp := newTestSetupPhase()
+	sp.ruleConfig = ruleFile
+
+	deps := []*Dependency{
+		{ImportPath: "example.com/lib", Version: "v1.5.0", Sources: []string{}, CgoFiles: map[string]string{}},
+	}
+
+	_, err = sp.matchDeps(context.Background(), deps, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "empty end version")
+}
+
 func TestMatchDeps_EmptyTargetRejected(t *testing.T) {
 	// target is required: an empty (or whitespace-only) target would land under
 	// exactRules[""] and silently never match, so the loader must reject it at

--- a/tool/util/shared.go
+++ b/tool/util/shared.go
@@ -124,6 +124,49 @@ func EncodeBuildFlags(flags []string) string {
 	return string(encoded)
 }
 
+// ValidateVersionRange rejects malformed version ranges at rule load time.
+// Valid forms match docs/rules.md:
+//   - "" (match all versions)
+//   - "v0.11.0" (minimum version)
+//   - "v0.11.0,v0.12.0" (start_inclusive,end_exclusive)
+func ValidateVersionRange(versionRange string) error {
+	versionRange = strings.TrimSpace(versionRange)
+	if versionRange == "" {
+		return nil
+	}
+	if strings.Count(versionRange, ",") > 1 {
+		return fmt.Errorf(
+			"version range %q must use format start_inclusive,end_exclusive with at most one comma",
+			versionRange,
+		)
+	}
+	start, end, hasComma := strings.Cut(versionRange, ",")
+	if hasComma {
+		start = strings.TrimSpace(start)
+		end = strings.TrimSpace(end)
+		if start == "" {
+			return fmt.Errorf("version range %q has an empty start version", versionRange)
+		}
+		if end == "" {
+			return fmt.Errorf("version range %q has an empty end version", versionRange)
+		}
+		if !semver.IsValid(start) {
+			return fmt.Errorf("version range %q has invalid start version %q", versionRange, start)
+		}
+		if !semver.IsValid(end) {
+			return fmt.Errorf("version range %q has invalid end version %q", versionRange, end)
+		}
+		if semver.Compare(start, end) >= 0 {
+			return fmt.Errorf("version range %q start version must be less than end version", versionRange)
+		}
+		return nil
+	}
+	if !semver.IsValid(versionRange) {
+		return fmt.Errorf("version %q is not a valid semver", versionRange)
+	}
+	return nil
+}
+
 // VersionInRange checks if a given version is within a specified version range.
 // The version range can be in one of the following formats:
 // - "" (empty string): means all versions are supported.

--- a/tool/util/shared_test.go
+++ b/tool/util/shared_test.go
@@ -7,6 +7,37 @@ import (
 	"testing"
 )
 
+func TestValidateVersionRange(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		expectError bool
+	}{
+		{name: "empty matches all", version: "", expectError: false},
+		{name: "minimum version", version: "v1.0.0", expectError: false},
+		{name: "valid range", version: "v1.0.0,v2.0.0", expectError: false},
+		{name: "trailing comma", version: "v1.0.0,", expectError: true},
+		{name: "missing lower bound", version: ",v2.0.0", expectError: true},
+		{name: "extra comma", version: "v1.0.0,v2.0.0,v3.0.0", expectError: true},
+		{name: "start not less than end", version: "v2.0.0,v1.0.0", expectError: true},
+		{name: "invalid semver", version: "not-a-version", expectError: true},
+		{name: "invalid start semver", version: "bad,v2.0.0", expectError: true},
+		{name: "invalid end semver", version: "v1.0.0,bad", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateVersionRange(tt.version)
+			if tt.expectError && err == nil {
+				t.Fatalf("ValidateVersionRange(%q) = nil, want error", tt.version)
+			}
+			if !tt.expectError && err != nil {
+				t.Fatalf("ValidateVersionRange(%q) = %v, want nil", tt.version, err)
+			}
+		})
+	}
+}
+
 func TestVersionInRange(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Description

Adds `ValidateVersionRange()` and rejects malformed `version` fields at rule load time, consistent with how invalid `target` values are already handled.

Changes:
- Add `ValidateVersionRange()` in `tool/util/shared.go`
- Call it from `tool/internal/setup/match.go` when rules are loaded
- Add unit tests in `tool/util/shared_test.go`
- Add `TestMatchDeps_InvalidVersionRangeRejected` in `tool/internal/setup/match_test.go`

Valid formats (per `docs/rules.md`):
- `""` - match all versions
- `"v1.0.0"` - minimum version
- `"v1.0.0,v2.0.0"` - `start_inclusive,end_exclusive`

Invalid formats now fail loudly at load time instead of being accepted silently.

## Motivation

Malformed `version` ranges were accepted without error but produced incorrect matching behavior:

| Malformed `version` | Before (bug) |
|---------------------|--------------|
| `v1.0.0,` (trailing comma) | Rule loaded; instrumentation never matched |
| `,v2.0.0` (missing lower bound) | Rule loaded; matched too broadly |
| `v1.0.0,v2.0.0,v3.0.0` (extra comma) | Rule loaded; instrumentation never matched |
| `v2.0.0,v1.0.0` (inverted range) | Rule loaded; nonsensical matching |

This is inconsistent with `target` validation, which already fails loudly at load time. Version gating is a safety mechanism - silent failures from typos are hard to debug.

Fixes #717 

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint` (Go/YAML/Actions/Makefile/license pass locally)
- [x] Tests pass: `make test` (PR-specific tests verified; `TestValidateVersionRange`, `TestMatchDeps_InvalidVersionRangeRejected`)
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [x] Documentation updated (if applicable) - N/A, behavior now matches existing docs
- [x] OpenTelemetry Registry updated (if applicable) -  N/A