### PR TITLE
docs: update external configuration guide for shipped otelc pin flow

### DIFF
--- a/docs/external-configuration.md
+++ b/docs/external-configuration.md
@@ -80,12 +80,14 @@ Rules:
 - **Every import must be a blank import** (`_ "path"`). Named imports and dot imports are
   rejected at load time.
 
-**Planned — `otelc pin`:** an upcoming `otelc pin` subcommand (#655) will create or update
-the tool file automatically, discover applicable instrumentation packages, and run
-`go mod tidy`. Until #655 lands, create the file manually as shown above.
+`otelc pin` can create or update the tool file automatically, discover applicable
+instrumentation packages, and run `go mod tidy`.
 
-After creating or editing the tool file, run `go mod tidy` to record the new dependencies
-in `go.mod` and `go.sum`.
+After creating or editing the tool file manually, run `go mod tidy` to record the new
+dependencies in `go.mod` and `go.sum`.
+
+For current limitations around committing generated instrumentation files, see
+[Managing Instrumentations](getting-started.md#managing-instrumentations).
 
 ### Module scope
 


### PR DESCRIPTION
## Summary

Updates `docs/external-configuration.md` to reflect that `otelc pin` is now available.

The page still described `otelc pin` as planned, but the command has since landed and can create or update `otel.instrumentation.go` and run `go mod tidy`.

This also avoids duplicating the longer note about current limitations around committed generated instrumentation files by linking to the existing Getting Started guidance.

## Validation

Docs-only change. No code behavior changed.