### PR TITLE
fix(instrument): no-op call rules on files without matching calls

### DIFF
--- a/tool/internal/instrument/apply_call.go
+++ b/tool/internal/instrument/apply_call.go
@@ -30,7 +30,9 @@ func (ip *InstrumentPhase) applyCallRule(ctx context.Context, r *rule.InstCallRu
 		}
 	}
 
-	util.Assert(appendModified || replaceModified, "call rule did not match any call")
+	if !appendModified && !replaceModified {
+		return nil
+	}
 
 	if err := ip.addRuleImports(ctx, root, r.Imports, r.Name); err != nil {
 		return err

--- a/tool/internal/instrument/apply_call_test.go
+++ b/tool/internal/instrument/apply_call_test.go
@@ -446,9 +446,31 @@ func TestMatchesCallRule_ImportAliasFromGopkgIn(t *testing.T) {
 	assert.True(t, matches)
 }
 
+func TestApplyCallRule_NoMatchIsNoOp(t *testing.T) {
+	file := makeCallFile(&dst.CallExpr{
+		Fun: &dst.SelectorExpr{
+			X:   &dst.Ident{Name: "fmt", Path: "fmt"},
+			Sel: &dst.Ident{Name: "Println"},
+		},
+		Args: []dst.Expr{&dst.BasicLit{Kind: token.STRING, Value: `"hello"`}},
+	})
+
+	r := &rule.InstCallRule{
+		InstBaseRule: rule.InstBaseRule{Name: "wrap_sizeof"},
+		FunctionCall: "unsafe.Sizeof",
+		ImportPath:   "unsafe",
+		FuncName:     "Sizeof",
+		Replace:      "Wrapper({{ . }})",
+	}
+
+	err := newTestPhase().applyCallRule(context.Background(), r, file)
+
+	require.NoError(t, err, "applyCallRule must no-op when no calls match")
+}
+
 func TestApplyCallAppendArgs_NoMatchReturnsFalse(t *testing.T) {
 	// A file with no matching calls should cause applyCallAppendArgs to
-	// return false so the assertion in applyCallRule can detect unmatched rules.
+	// return false so applyCallRule can skip the file as a no-op.
 	file := makeCallFile(&dst.CallExpr{
 		Fun: &dst.SelectorExpr{
 			X:   &dst.Ident{Name: "fmt", Path: "fmt"},

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -54,6 +53,7 @@ const (
 	importPathFileName = "importpath"
 	mainGoFileName     = "main.go"
 	mainTestFileName   = "main_test.go"
+	otherGoFileName    = "other.go"
 	mainPackage        = "main"
 	buildID            = "foo/bar"
 	compiledOutput     = "_pkg_.a"
@@ -100,14 +100,22 @@ func runTest(t *testing.T, testName string) {
 	require.NoError(t, util.CopyFile(testSpecificSource, sourceFile),
 		"missing %s for test %q at %s", srcName, testName, testSpecificSource)
 
+	packageFiles := copyExtraPackageFiles(t, testName, tempDir, sourceFile)
+
 	importPath := testImportPath(t, testName)
-	ruleSet := loadRulesYAML(t, testName, sourceFile, importPath, isTest)
+	ruleSet := loadRulesYAML(t, loadRulesParams{
+		testName:     testName,
+		sourceFile:   sourceFile,
+		packageFiles: packageFiles,
+		importPath:   importPath,
+		isTest:       isTest,
+	})
 	writeMatchedJSON(ruleSet)
 
 	testcaseDir := filepath.Join(testdataDir, goldenDir, testName)
 	helpers := buildTestcaseHelpers(ctx, t, testcaseDir)
 
-	args := compileArgs(tempDir, helpers, importPath, sourceFile)
+	args := compileArgs(tempDir, helpers, importPath, packageFiles...)
 	err := Toolexec(ctx, args, false)
 
 	if testName == invalidReceiver {
@@ -120,84 +128,29 @@ func runTest(t *testing.T, testName string) {
 	verifyGoldenFiles(t, tempDir, testName)
 }
 
-func TestInstrument_CallRuleMultiFilePackage(t *testing.T) {
-	tempDir := t.TempDir()
-	t.Setenv(util.EnvOtelcWorkDir, tempDir)
-	ctx := util.ContextWithLogger(
-		t.Context(),
-		slog.New(slog.NewTextHandler(io.Discard, nil)),
-	)
-
-	mainFile := filepath.Join(tempDir, mainGoFileName)
-	otherFile := filepath.Join(tempDir, "other.go")
-	require.NoError(t, os.WriteFile(mainFile, []byte(`// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-package main
-
-import "unsafe"
-
-func Wrapper(size uintptr) uintptr {
-	println("Wrapped!")
-	return size
-}
-
-func CallSizeof() {
-	x := 42
-	size := unsafe.Sizeof(x)
-	_ = size
-}
-
-func main() {
-	y := "hello"
-	_ = unsafe.Sizeof(y)
-}
-`), 0o644))
-	require.NoError(t, os.WriteFile(otherFile, []byte(`// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-package main
-
-func Helper() {
-	println("helper")
-}
-`), 0o644))
-
-	callRule := &rule.InstCallRule{
-		InstBaseRule: rule.InstBaseRule{
-			Name:   "wrap_sizeof_call",
-			Target: mainPackage,
-		},
-		FunctionCall: "unsafe.Sizeof",
-		ImportPath:   "unsafe",
-		FuncName:     "Sizeof",
-		Replace:      "Wrapper({{ . }})",
+func copyExtraPackageFiles(t *testing.T, testName, tempDir, primaryFile string) []string {
+	t.Helper()
+	files := make([]string, 1, 2)
+	files[0] = primaryFile
+	otherSrc := filepath.Join(testdataDir, goldenDir, testName, otherGoFileName)
+	if !util.PathExists(otherSrc) {
+		return files
 	}
-
-	ruleSet := &rule.InstRuleSet{
-		PackageName: mainPackage,
-		ModulePath:  mainPackage,
-		CallRules: map[string][]*rule.InstCallRule{
-			mainFile:  {callRule},
-			otherFile: {callRule},
-		},
-	}
-	writeMatchedJSON(ruleSet)
-
-	args := compileArgs(tempDir, nil, mainPackage, mainFile, otherFile)
-	require.NoError(t, Toolexec(ctx, args, false))
-
-	mainContent, err := os.ReadFile(mainFile)
-	require.NoError(t, err)
-	otherContent, err := os.ReadFile(otherFile)
-	require.NoError(t, err)
-
-	assert.Contains(t, string(mainContent), "Wrapper(unsafe.Sizeof")
-	assert.NotContains(t, string(otherContent), "Wrapper(")
+	otherFile := filepath.Join(tempDir, otherGoFileName)
+	require.NoError(t, util.CopyFile(otherSrc, otherFile))
+	return append(files, otherFile)
 }
 
-func loadRulesYAML(t *testing.T, testName, sourceFile, importPath string, isTest bool) *rule.InstRuleSet {
-	data, err := os.ReadFile(filepath.Join(testdataDir, goldenDir, testName, rulesFileName))
+type loadRulesParams struct {
+	testName     string
+	sourceFile   string
+	packageFiles []string
+	importPath   string
+	isTest       bool
+}
+
+func loadRulesYAML(t *testing.T, p loadRulesParams) *rule.InstRuleSet {
+	data, err := os.ReadFile(filepath.Join(testdataDir, goldenDir, p.testName, rulesFileName))
 	require.NoError(t, err)
 
 	var rawRules map[string]map[string]any
@@ -206,7 +159,7 @@ func loadRulesYAML(t *testing.T, testName, sourceFile, importPath string, isTest
 	// Parse the source AST once and reuse it for every rule's where.file gating
 	// below. The gating is per-rule, but the tree is shared, so N rules do not
 	// trigger N reparses of the same file.
-	sourceTree, parseErr := ast.ParseFileFast(sourceFile)
+	sourceTree, parseErr := ast.ParseFileFast(p.sourceFile)
 	require.NoError(t, parseErr)
 
 	ruleSet := &rule.InstRuleSet{
@@ -215,7 +168,7 @@ func loadRulesYAML(t *testing.T, testName, sourceFile, importPath string, isTest
 		// checks against the -p flag before applying the set. They coincide for
 		// the default "main" fixtures but differ for a deep-path glob fixture.
 		PackageName:    sourceTree.Name.Name,
-		ModulePath:     importPath,
+		ModulePath:     p.importPath,
 		FuncRules:      make(map[string][]*rule.InstFuncRule),
 		StructRules:    make(map[string][]*rule.InstStructRule),
 		RawRules:       make(map[string][]*rule.InstRawRule),
@@ -243,7 +196,7 @@ func loadRulesYAML(t *testing.T, testName, sourceFile, importPath string, isTest
 			// that setup.preciseMatching would evaluate is applied inline here.
 			// A rule whose file predicate does not match the source is skipped,
 			// exactly as it would be gated out during matching.
-			if !whereFileMatches(t, ruleData, isTest, sourceTree) {
+			if !whereFileMatches(t, ruleData, p.isTest, sourceTree) {
 				continue
 			}
 
@@ -251,32 +204,34 @@ func loadRulesYAML(t *testing.T, testName, sourceFile, importPath string, isTest
 			// target selects this fixture's import path (exact equality or glob
 			// match). This lets golden fixtures prove glob match vs no-match
 			// against realistic deep import paths, not just "main".
-			if !targetMatches(props, importPath) {
+			if !targetMatches(props, p.importPath) {
 				continue
 			}
 
 			switch {
 			case props["struct"] != nil:
 				r, _ := rule.NewInstStructRule(ruleData, name)
-				ruleSet.StructRules[sourceFile] = append(ruleSet.StructRules[sourceFile], r)
+				ruleSet.StructRules[p.sourceFile] = append(ruleSet.StructRules[p.sourceFile], r)
 			case props["file"] != nil:
 				r, _ := rule.NewInstFileRule(ruleData, name)
 				ruleSet.FileRules = append(ruleSet.FileRules, r)
 			case props["directive"] != nil:
 				r, _ := rule.NewInstDirectiveRule(ruleData, name)
-				ruleSet.DirectiveRules[sourceFile] = append(ruleSet.DirectiveRules[sourceFile], r)
+				ruleSet.DirectiveRules[p.sourceFile] = append(ruleSet.DirectiveRules[p.sourceFile], r)
 			case props["raw"] != nil:
 				r, _ := rule.NewInstRawRule(ruleData, name)
-				ruleSet.RawRules[sourceFile] = append(ruleSet.RawRules[sourceFile], r)
+				ruleSet.RawRules[p.sourceFile] = append(ruleSet.RawRules[p.sourceFile], r)
 			case props["func"] != nil:
 				r, _ := rule.NewInstFuncRule(ruleData, name)
-				ruleSet.FuncRules[sourceFile] = append(ruleSet.FuncRules[sourceFile], r)
+				ruleSet.FuncRules[p.sourceFile] = append(ruleSet.FuncRules[p.sourceFile], r)
 			case props["function_call"] != nil:
 				r, _ := rule.NewInstCallRule(ruleData, name)
-				ruleSet.CallRules[sourceFile] = append(ruleSet.CallRules[sourceFile], r)
+				for _, file := range p.packageFiles {
+					ruleSet.CallRules[file] = append(ruleSet.CallRules[file], r)
+				}
 			case props["identifier"] != nil:
 				r, _ := rule.NewInstDeclRule(ruleData, name)
-				ruleSet.DeclRules[sourceFile] = append(ruleSet.DeclRules[sourceFile], r)
+				ruleSet.DeclRules[p.sourceFile] = append(ruleSet.DeclRules[p.sourceFile], r)
 			}
 		}
 	}

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -435,7 +435,8 @@ func compileArgs(tempDir string, helpers []helperPkg, importPath string, sourceF
 	importCfgPath := filepath.Join(tempDir, "importcfg")
 	createImportCfg(importCfgPath, helpers)
 
-	args := []string{
+	args := make([]string, 0, 11+len(sourceFiles))
+	args = append(args,
 		filepath.Join(strings.TrimSpace(string(output)), "compile"),
 		"-o", filepath.Join(tempDir, compiledOutput),
 		"-p", importPath,
@@ -443,7 +444,7 @@ func compileArgs(tempDir string, helpers []helperPkg, importPath string, sourceF
 		"-buildid", buildID,
 		"-importcfg", importCfgPath,
 		"-pack",
-	}
+	)
 	return append(args, sourceFiles...)
 }
 

--- a/tool/internal/instrument/instrument_test.go
+++ b/tool/internal/instrument/instrument_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -106,7 +107,7 @@ func runTest(t *testing.T, testName string) {
 	testcaseDir := filepath.Join(testdataDir, goldenDir, testName)
 	helpers := buildTestcaseHelpers(ctx, t, testcaseDir)
 
-	args := compileArgs(tempDir, sourceFile, helpers, importPath)
+	args := compileArgs(tempDir, helpers, importPath, sourceFile)
 	err := Toolexec(ctx, args, false)
 
 	if testName == invalidReceiver {
@@ -117,6 +118,82 @@ func runTest(t *testing.T, testName string) {
 
 	require.NoError(t, err)
 	verifyGoldenFiles(t, tempDir, testName)
+}
+
+func TestInstrument_CallRuleMultiFilePackage(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, tempDir)
+	ctx := util.ContextWithLogger(
+		t.Context(),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	mainFile := filepath.Join(tempDir, mainGoFileName)
+	otherFile := filepath.Join(tempDir, "other.go")
+	require.NoError(t, os.WriteFile(mainFile, []byte(`// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "unsafe"
+
+func Wrapper(size uintptr) uintptr {
+	println("Wrapped!")
+	return size
+}
+
+func CallSizeof() {
+	x := 42
+	size := unsafe.Sizeof(x)
+	_ = size
+}
+
+func main() {
+	y := "hello"
+	_ = unsafe.Sizeof(y)
+}
+`), 0o644))
+	require.NoError(t, os.WriteFile(otherFile, []byte(`// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+func Helper() {
+	println("helper")
+}
+`), 0o644))
+
+	callRule := &rule.InstCallRule{
+		InstBaseRule: rule.InstBaseRule{
+			Name:   "wrap_sizeof_call",
+			Target: mainPackage,
+		},
+		FunctionCall: "unsafe.Sizeof",
+		ImportPath:   "unsafe",
+		FuncName:     "Sizeof",
+		Replace:      "Wrapper({{ . }})",
+	}
+
+	ruleSet := &rule.InstRuleSet{
+		PackageName: mainPackage,
+		ModulePath:  mainPackage,
+		CallRules: map[string][]*rule.InstCallRule{
+			mainFile:  {callRule},
+			otherFile: {callRule},
+		},
+	}
+	writeMatchedJSON(ruleSet)
+
+	args := compileArgs(tempDir, nil, mainPackage, mainFile, otherFile)
+	require.NoError(t, Toolexec(ctx, args, false))
+
+	mainContent, err := os.ReadFile(mainFile)
+	require.NoError(t, err)
+	otherContent, err := os.ReadFile(otherFile)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(mainContent), "Wrapper(unsafe.Sizeof")
+	assert.NotContains(t, string(otherContent), "Wrapper(")
 }
 
 func loadRulesYAML(t *testing.T, testName, sourceFile, importPath string, isTest bool) *rule.InstRuleSet {
@@ -351,14 +428,14 @@ func writeMatchedJSON(ruleSet *rule.InstRuleSet) {
 	util.WriteFile(matchedFile, string(matchedJSON))
 }
 
-func compileArgs(tempDir, sourceFile string, helpers []helperPkg, importPath string) []string {
+func compileArgs(tempDir string, helpers []helperPkg, importPath string, sourceFiles ...string) []string {
 	output, _ := exec.Command("go", "env", "GOTOOLDIR").Output()
 
 	// Create importcfg file for the test
 	importCfgPath := filepath.Join(tempDir, "importcfg")
 	createImportCfg(importCfgPath, helpers)
 
-	return []string{
+	args := []string{
 		filepath.Join(strings.TrimSpace(string(output)), "compile"),
 		"-o", filepath.Join(tempDir, compiledOutput),
 		"-p", importPath,
@@ -366,8 +443,8 @@ func compileArgs(tempDir, sourceFile string, helpers []helperPkg, importPath str
 		"-buildid", buildID,
 		"-importcfg", importCfgPath,
 		"-pack",
-		sourceFile,
 	}
+	return append(args, sourceFiles...)
 }
 
 // createImportCfg creates an importcfg file with standard library packages

--- a/tool/internal/instrument/testdata/golden/call-rule-multi-file/call_rule_multi_file.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/call-rule-multi-file/call_rule_multi_file.main.go.golden
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "unsafe"
+
+func Wrapper(size uintptr) uintptr {
+	println("Wrapped!")
+	return size
+}
+
+func CallSizeof() {
+	x := 42
+	size := Wrapper(unsafe.Sizeof(x))
+	_ = size
+}
+
+func main() {
+	y := "hello"
+	_ = Wrapper(unsafe.Sizeof(y))
+}

--- a/tool/internal/instrument/testdata/golden/call-rule-multi-file/call_rule_multi_file.other.go.golden
+++ b/tool/internal/instrument/testdata/golden/call-rule-multi-file/call_rule_multi_file.other.go.golden
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+func Helper() {
+	println("helper")
+}

--- a/tool/internal/instrument/testdata/golden/call-rule-multi-file/other.go
+++ b/tool/internal/instrument/testdata/golden/call-rule-multi-file/other.go
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+func Helper() {
+	println("helper")
+}

--- a/tool/internal/instrument/testdata/golden/call-rule-multi-file/rules.yml
+++ b/tool/internal/instrument/testdata/golden/call-rule-multi-file/rules.yml
@@ -1,0 +1,7 @@
+wrap_sizeof_call:
+  target: main
+  where:
+    function_call: unsafe.Sizeof
+  do:
+    - wrap_call:
+        replace: "Wrapper({{ . }})"

--- a/tool/internal/instrument/testdata/golden/call-rule-multi-file/source.go
+++ b/tool/internal/instrument/testdata/golden/call-rule-multi-file/source.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "unsafe"
+
+func Wrapper(size uintptr) uintptr {
+	println("Wrapped!")
+	return size
+}
+
+func CallSizeof() {
+	x := 42
+	size := unsafe.Sizeof(x)
+	_ = size
+}
+
+func main() {
+	y := "hello"
+	_ = unsafe.Sizeof(y)
+}

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -800,6 +800,40 @@ func TestPreciseMatching_WhereFileAllOf(t *testing.T) {
 	require.NotContains(t, result.FuncRules, noMatchFile)
 }
 
+func TestPreciseMatching_CallRuleAddedToAllFiles(t *testing.T) {
+	matchFile := writeGoSource(
+		t,
+		"calls.go",
+		"package main\n\nimport \"unsafe\"\n\nfunc CallSizeof() {\n\t_ = unsafe.Sizeof(42)\n}\n",
+	)
+	noMatchFile := writeGoSource(t, "other.go", "package main\n\nfunc Helper() { println(\"hi\") }\n")
+
+	dep := &Dependency{
+		ImportPath: "example.com/app",
+		Sources:    []string{matchFile, noMatchFile},
+	}
+
+	callRule := &rule.InstCallRule{
+		InstBaseRule: rule.InstBaseRule{
+			Name:   "wrap-sizeof",
+			Target: "example.com/app",
+		},
+		FunctionCall: "unsafe.Sizeof",
+		ImportPath:   "unsafe",
+		FuncName:     "Sizeof",
+		Replace:      "Wrapper({{ . }})",
+	}
+
+	sp := newTestSetupPhase()
+	set := rule.NewInstRuleSet(dep.ImportPath)
+
+	result, err := sp.preciseMatching(t.Context(), dep, []rule.InstRule{callRule}, set)
+	require.NoError(t, err)
+	require.Len(t, result.CallRules, 2)
+	require.Contains(t, result.CallRules, matchFile)
+	require.Contains(t, result.CallRules, noMatchFile)
+}
+
 func TestPreciseMatching_WhereFileOneOf(t *testing.T) {
 	// one-of matches the file when it declares EITHER backend driver. The match
 	// file declares PostgresDriver (one of the two), so Open is selected; the


### PR DESCRIPTION

## Description

When a package has multiple `.go` files, the setup phase attaches `wrap_call` rules to every source file in the package. The instrument phase previously fatalled on files that contained no matching call sites:

```
Assertion failed: call rule did not match any call
```

This change makes `applyCallRule` return early (no-op) when neither `append_args` nor `replace` modified the file, matching the behavior documented in `match.go`.

Tests added:
- `TestApplyCallRule_NoMatchIsNoOp` - unit test for the no-op path
- `TestPreciseMatching_CallRuleAddedToAllFiles` - setup attaches call rules to all files
- `TestInstrument_CallRuleMultiFilePackage` - end-to-end multi-file package build

## Motivation

Real-world packages often split call sites across files (e.g. `handler.go` has the instrumented call, `utils.go` does not). Call rules must not crash the build on files without matching calls; those files should be skipped silently while files with matches are still instrumented.

Fixes #732 

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [ ] Linters pass: `make lint`
- [x] Tests pass: `make test` (instrument + setup packages verified locally)
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))

