### PR TITLE
test: skip container-based tests when Docker is not available

### DIFF
--- a/test/e2e/kafka_test.go
+++ b/test/e2e/kafka_test.go
@@ -31,6 +31,7 @@ func TestKafka(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("kafka testcontainer not supported on windows")
 	}
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 
 	brokers := startKafkaContainer(t)
 	brokerAddrs := strings.Join(brokers, ",")

--- a/test/integration/k8s_client_test.go
+++ b/test/integration/k8s_client_test.go
@@ -20,6 +20,7 @@ func TestK8SClient(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("k3s not supported on windows")
 	}
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 
 	t.Parallel()
 	testutil.Build(t, "", "k8sclient", "go", "build", "-a")

--- a/test/integration/kafka_client_test.go
+++ b/test/integration/kafka_client_test.go
@@ -22,6 +22,7 @@ func TestKafkaClient(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("kafka testcontainer not supported on windows")
 	}
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 
 	t.Parallel()
 	testutil.Build(t, "", "kafkaproducer", "go", "build", "-a")


### PR DESCRIPTION
## Description

The Kafka and k8s tests use `testcontainers-go`, which needs a running Docker. They only skip when the OS is Windows, so on macOS or Linux without Docker running they don't skip. The test hangs for about 80 seconds and then panics.

This adds `testcontainers.SkipIfProviderIsNotHealthy(t)` right after the existing Windows check in the three tests that start containers:

- `test/integration/kafka_client_test.go`
- `test/integration/k8s_client_test.go`
- `test/e2e/kafka_test.go`

The helper is shipped by `testcontainers-go` for exactly this case. Its doc says it is "designed to be used in your test, when Docker is not mandatory for CI/CD".

Before (Docker not running):

```
--- FAIL: TestKafkaClient (82.68s)
panic: rootless Docker not found [recovered, repanicked]
```

After (same command, Docker still not running):

```
--- SKIP: TestKafkaClient (0.00s)
    testing.go:26: Recovered from panic: rootless Docker not found. Docker is not running.
PASS
ok  	go.opentelemetry.io/otelc/test/integration	1.546s
```

CI is unaffected since it has Docker available, so these tests keep running there as before. The change only affects running the suite locally without Docker.

## Motivation

Better first-run experience for anyone running the tests locally without Docker. This was also the original intent in #661, which describes the Kafka test as "skipping on Windows/macOS if Docker isn't available", but only the Windows case ended up in the code.

Fixes #734

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint/go` (0 issues)
- [x] Tests pass: `make test-unit`, plus the three affected tests verified to skip cleanly (see before/after above)
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))

> Note: I ran the Go linter and unit tests locally. The full `make lint` and `make test` need Docker running (for the `typos`/`dockerfile` lint steps and the container-based tests), which is exactly the case this PR handles, so I relied on CI for those. Verified the fix by running the affected tests with Docker off: they now skip instead of panicking.
