### PR TITLE
chore: add auto-regenerate bundle workflow and improve conflict guidance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.golden text eol=lf
+tool/data/otelc-bundle.tgz binary

--- a/.github/scripts/verify-bundle.sh
+++ b/.github/scripts/verify-bundle.sh
@@ -12,6 +12,8 @@ make package
 if git diff --exit-code -- "$archive"; then
     echo "archive verified successfully"
 else
-    echo 'archive verification failed; run "make package" and commit the updated archive'
+    echo 'archive verification failed.'
+    echo 'To fix: rebase your branch on main, run "make package", and commit the updated archive.'
+    echo 'If you are a maintainer, you can also comment "/regenerate-bundle" on the PR to auto-fix.'
     exit 1
 fi

--- a/.github/workflows/regenerate-bundle.yaml
+++ b/.github/workflows/regenerate-bundle.yaml
@@ -13,9 +13,8 @@ jobs:
     name: Regenerate Bundle
     runs-on: ubuntu-latest
     if: >-
-      github.event.issue.pull_request &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
-      github.event.comment.body == '/regenerate-bundle'
+      github.event.issue.pull_request && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      && github.event.comment.body == '/regenerate-bundle'
     steps:
       - name: Get PR details
         id: pr
@@ -26,9 +25,11 @@ jobs:
           head_ref=$(echo "$pr_json" | jq -r '.head.ref')
           head_repo_full=$(echo "$pr_json" | jq -r '.head.repo.full_name')
           is_fork=$(echo "$pr_json" | jq -r '.head.repo.fork')
-          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
-          echo "head_repo_full=$head_repo_full" >> "$GITHUB_OUTPUT"
-          echo "is_fork=$is_fork" >> "$GITHUB_OUTPUT"
+          {
+            echo "head_ref=$head_ref"
+            echo "head_repo_full=$head_repo_full"
+            echo "is_fork=$is_fork"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Abort if fork PR
         if: steps.pr.outputs.is_fork == 'true'

--- a/.github/workflows/regenerate-bundle.yaml
+++ b/.github/workflows/regenerate-bundle.yaml
@@ -1,0 +1,72 @@
+name: Regenerate Bundle
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  regenerate:
+    name: Regenerate Bundle
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      github.event.comment.body == '/regenerate-bundle'
+    steps:
+      - name: Get PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_json=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          head_ref=$(echo "$pr_json" | jq -r '.head.ref')
+          head_repo_full=$(echo "$pr_json" | jq -r '.head.repo.full_name')
+          is_fork=$(echo "$pr_json" | jq -r '.head.repo.fork')
+          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
+          echo "head_repo_full=$head_repo_full" >> "$GITHUB_OUTPUT"
+          echo "is_fork=$is_fork" >> "$GITHUB_OUTPUT"
+
+      - name: Abort if fork PR
+        if: steps.pr.outputs.is_fork == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+            -f body="Cannot regenerate bundle for fork PRs (GITHUB_TOKEN cannot push to forks). Please run \`make package\` locally and push the updated archive."
+          exit 1
+
+      - name: Add reaction
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content='+1'
+
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          ref: ${{ steps.pr.outputs.head_ref }}
+          repository: ${{ steps.pr.outputs.head_repo_full }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        with:
+          go-version-file: go.mod
+
+      - name: Regenerate bundle
+        run: make package
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet -- tool/data/otelc-bundle.tgz; then
+            echo "Bundle is already up to date."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tool/data/otelc-bundle.tgz
+          git commit -m "chore: regenerate otelc-bundle.tgz"
+          git push


### PR DESCRIPTION
## Summary

Add a GitHub Action workflow that allows maintainers to automatically regenerate `tool/data/otelc-bundle.tgz` on PR branches by commenting `/regenerate-bundle`. This resolves the recurring binary merge conflict issue when multiple PRs modify `pkg/` or `instrumentation/` directories.

## Problem

Every PR that modifies `pkg/` or `instrumentation/` must regenerate the embedded bundle file. Since Git cannot auto-merge binary files, once one PR merges, all other open PRs immediately have a merge conflict on `tool/data/otelc-bundle.tgz`.

## Solution

1. **New workflow** (`.github/workflows/regenerate-bundle.yaml`): Triggered by maintainer comment `/regenerate-bundle` on a PR. It checks out the PR branch, runs `make package`, and pushes the updated bundle.
   - Security: Only OWNER/MEMBER/COLLABORATOR can trigger
   - Fork PRs: Workflow posts a comment with manual resolution instructions (GITHUB_TOKEN cannot push to forks)

2. **Updated `.gitattributes`**: Mark `tool/data/otelc-bundle.tgz` as binary to prevent line-ending conversion.

3. **Improved error message** in `verify-bundle.sh`: Provides clear instructions for contributors on how to resolve bundle conflicts.

## Usage

For same-repo branch PRs with bundle conflicts:
1. Maintainer comments `/regenerate-bundle` on the PR
2. Bot regenerates and pushes the updated bundle

For fork PRs:
```bash
git fetch upstream main
git rebase upstream/main
make package
git add tool/data/otelc-bundle.tgz
git commit --amend --no-edit
git push --force-with-lease
```