### PR TITLE
fix(instrument): avoid _ignoredParam name collision in generated sign…

### DIFF
--- a/tool/internal/instrument/apply_func.go
+++ b/tool/internal/instrument/apply_func.go
@@ -70,7 +70,7 @@ func collectReturnValues(funcDecl *dst.FuncDecl) []string {
 				// Collect only (for further use)
 				for _, name := range field.Names {
 					if name.Name == ast.IdentIgnore {
-						name.Name = fmt.Sprintf("%s%d", ignoredParam, idx)
+						name.Name = fmt.Sprintf("%s%d", ignoredRetValName, idx)
 						idx++
 					}
 					retVals = append(retVals, name.Name)

--- a/tool/internal/instrument/apply_func_test.go
+++ b/tool/internal/instrument/apply_func_test.go
@@ -5,8 +5,16 @@ package instrument
 
 import (
 	"context"
+	goast "go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
 	"testing"
 
+	"github.com/dave/dst"
+	"github.com/dave/dst/decorator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -121,7 +129,7 @@ func TestCollectReturnValues(t *testing.T) {
 		{
 			name:     "underscore return values",
 			src:      "package main\nfunc F() (_ int, _ string) { return }",
-			expected: []string{"_ignoredParam0", "_ignoredParam1"},
+			expected: []string{"_ignoredRetVal0", "_ignoredRetVal1"},
 		},
 	}
 
@@ -132,4 +140,89 @@ func TestCollectReturnValues(t *testing.T) {
 			assert.Equal(t, tt.expected, retVals)
 		})
 	}
+}
+
+// Regression for #736: a blank param/receiver and a blank named return share
+// one scope, so the two collectors must not rename them to the same identifier.
+func TestCollectNamesNoCollision(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "blank param and blank named return",
+			src:  "package main\nfunc F(_ int) (_ error) { return nil }",
+		},
+		{
+			name: "unnamed param and blank named return",
+			src:  "package main\nfunc F(int) (_ error) { return nil }",
+		},
+		{
+			name: "unnamed receiver and blank named return",
+			src:  "package main\ntype T struct{}\nfunc (T) M() (_ error) { return nil }",
+		},
+		{
+			name: "unnamed param and unnamed return (control)",
+			src:  "package main\nfunc F(int) (int) { return 0 }",
+		},
+		{
+			name: "multiple blanks on both sides",
+			src:  "package main\nfunc F(_ int, _ string) (_ error, _ bool) { return nil, false }",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, funcDecl := parseFileFunc(t, tt.src)
+
+			// Mirror insertTJump: returns are collected first, then arguments.
+			retVals := collectReturnValues(funcDecl)
+			args := collectArguments(funcDecl)
+
+			seen := make(map[string]struct{})
+			for _, name := range append(append([]string{}, retVals...), args...) {
+				require.NotEqual(t, ast.IdentIgnore, name, "blank binding was left unnamed")
+				_, dup := seen[name]
+				require.Falsef(t, dup, "binding %q generated in two positions", name)
+				seen[name] = struct{}{}
+			}
+
+			requireTypeChecks(t, renderFile(t, file))
+		})
+	}
+}
+
+// parseFileFunc parses source into a file and returns it alongside the first
+// function declaration it contains.
+func parseFileFunc(t *testing.T, source string) (*dst.File, *dst.FuncDecl) {
+	t.Helper()
+	parser := ast.NewAstParser()
+	file, err := parser.ParseSource(source)
+	require.NoError(t, err)
+	for _, decl := range file.Decls {
+		if funcDecl, ok := decl.(*dst.FuncDecl); ok {
+			return file, funcDecl
+		}
+	}
+	require.Fail(t, "no function declaration found in source")
+	return nil, nil
+}
+
+// renderFile restores a dst.File back to Go source code.
+func renderFile(t *testing.T, file *dst.File) string {
+	t.Helper()
+	var buf strings.Builder
+	require.NoError(t, decorator.Fprint(&buf, file))
+	return buf.String()
+}
+
+// requireTypeChecks fails the test unless src is valid, type-correct Go.
+func requireTypeChecks(t *testing.T, src string) {
+	t.Helper()
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, "src.go", src, parser.AllErrors)
+	require.NoErrorf(t, err, "generated code does not parse:\n%s", src)
+	conf := types.Config{Importer: importer.Default()}
+	_, err = conf.Check("main", fset, []*goast.File{parsed}, nil)
+	require.NoErrorf(t, err, "generated code does not type-check:\n%s", src)
 }

--- a/tool/internal/instrument/apply_raw.go
+++ b/tool/internal/instrument/apply_raw.go
@@ -23,6 +23,9 @@ import (
 const (
 	unnamedRetValName = "_unnamedRetVal"
 	ignoredParam      = "_ignoredParam"
+	// Blank named returns get their own prefix; sharing ignoredParam with a blank
+	// param or receiver would collide, since both live in the same scope.
+	ignoredRetValName = "_ignoredRetVal"
 )
 
 func renameReturnValues(funcDecl *dst.FuncDecl) {

--- a/tool/internal/instrument/testdata/golden/underscore-param-and-return/hook.go
+++ b/tool/internal/instrument/testdata/golden/underscore-param-and-return/hook.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import (
+	_ "unsafe"
+
+	"go.opentelemetry.io/otelc/pkg/hook"
+)
+
+func H12UnderscoreParamReturnBefore(ctx hook.HookContext, p1 int) {}
+
+func H12UnderscoreParamReturnAfter(ctx hook.HookContext, r1 error) {}

--- a/tool/internal/instrument/testdata/golden/underscore-param-and-return/rules.yml
+++ b/tool/internal/instrument/testdata/golden/underscore-param-and-return/rules.yml
@@ -1,0 +1,9 @@
+hook_underscore_param_return:
+  target: main
+  where:
+    func: UnderscoreParamReturnFunc
+  do:
+    - inject_hooks:
+        before: H12UnderscoreParamReturnBefore
+        after: H12UnderscoreParamReturnAfter
+        path: testdata/golden/underscore-param-and-return

--- a/tool/internal/instrument/testdata/golden/underscore-param-and-return/source.go
+++ b/tool/internal/instrument/testdata/golden/underscore-param-and-return/source.go
@@ -1,0 +1,11 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+// Blank param + blank named return, the collision case from issue #736.
+func UnderscoreParamReturnFunc(_ int) (_ error) {
+	return nil
+}
+
+func main() {}

--- a/tool/internal/instrument/testdata/golden/underscore-param-and-return/underscore_param_and_return.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/underscore-param-and-return/underscore_param_and_return.main.go.golden
@@ -1,0 +1,146 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import _ "unsafe"
+
+// Blank param + blank named return, the collision case from issue #736.
+func UnderscoreParamReturnFunc(_ignoredParam0 int) (_ignoredRetVal0 error) {
+	//line <generated>:1
+	if hookContext1353090234, _ := OtelBeforeTrampoline_UnderscoreParamReturnFunc1353090234(&_ignoredParam0); false {
+	} else {
+		defer OtelAfterTrampoline_UnderscoreParamReturnFunc1353090234(hookContext1353090234, &_ignoredRetVal0)
+	}
+	//line main.go:8:2
+	return nil
+}
+
+func main() {}
+
+//line <generated>:1
+type HookContextImpl1353090234 struct {
+	params      []interface{}
+	returnVals  []interface{}
+	skipCall    bool
+	data        interface{}
+	funcName    string
+	packageName string
+}
+
+func (c *HookContextImpl1353090234) SetSkipCall(skip bool)    { c.skipCall = skip }
+func (c *HookContextImpl1353090234) IsSkipCall() bool         { return c.skipCall }
+func (c *HookContextImpl1353090234) SetData(data interface{}) { c.data = data }
+func (c *HookContextImpl1353090234) GetData() interface{}     { return c.data }
+func (c *HookContextImpl1353090234) GetKeyData(key string) interface{} {
+	if c.data == nil {
+		return nil
+	}
+	return c.data.(map[string]interface{})[key]
+}
+
+func (c *HookContextImpl1353090234) SetKeyData(key string, val interface{}) {
+	if c.data == nil {
+		c.data = make(map[string]interface{})
+	}
+	c.data.(map[string]interface{})[key] = val
+}
+
+func (c *HookContextImpl1353090234) HasKeyData(key string) bool {
+	if c.data == nil {
+		return false
+	}
+	_, ok := c.data.(map[string]interface{})[key]
+	return ok
+}
+
+func (c *HookContextImpl1353090234) GetParam(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.params[0].(*int))
+	}
+	return nil
+}
+
+func (c *HookContextImpl1353090234) SetParam(idx int, val interface{}) {
+	if val == nil {
+		c.params[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.params[0].(*int)) = val.(int)
+	}
+}
+
+func (c *HookContextImpl1353090234) GetReturnVal(idx int) interface{} {
+	switch idx {
+	case 0:
+		return *(c.returnVals[0].(*error))
+	}
+	return nil
+}
+
+func (c *HookContextImpl1353090234) SetReturnVal(idx int, val interface{}) {
+	if val == nil {
+		c.returnVals[idx] = nil
+		return
+	}
+	switch idx {
+	case 0:
+		*(c.returnVals[0].(*error)) = val.(error)
+	}
+}
+func (c *HookContextImpl1353090234) GetParamCount() int     { return len(c.params) }
+func (c *HookContextImpl1353090234) GetReturnValCount() int { return len(c.returnVals) }
+func (c *HookContextImpl1353090234) GetFuncName() string    { return c.funcName }
+func (c *HookContextImpl1353090234) GetPackageName() string { return c.packageName }
+
+// Trampoline Template
+func OtelBeforeTrampoline_UnderscoreParamReturnFunc1353090234(param0 *int) (hookContext *HookContextImpl1353090234, skipCall bool) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec Before hook", "H12UnderscoreParamReturnBefore")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext = &HookContextImpl1353090234{}
+	hookContext.params = []interface{}{param0}
+	hookContext.funcName = "UnderscoreParamReturnFunc"
+	hookContext.packageName = "main"
+	if H12UnderscoreParamReturnBefore != nil {
+		H12UnderscoreParamReturnBefore(hookContext, *param0)
+	}
+	return hookContext, hookContext.skipCall
+}
+
+func OtelAfterTrampoline_UnderscoreParamReturnFunc1353090234(hookContext HookContext, arg0 *error) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec After hook", "H12UnderscoreParamReturnAfter")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext.(*HookContextImpl1353090234).returnVals = []interface{}{arg0}
+	if H12UnderscoreParamReturnAfter != nil {
+		H12UnderscoreParamReturnAfter(hookContext, *arg0)
+	}
+}
+
+//go:linkname H12UnderscoreParamReturnBefore testdata/golden/underscore-param-and-return.H12UnderscoreParamReturnBefore
+func H12UnderscoreParamReturnBefore(hookContext HookContext, param0 int)
+
+//go:linkname H12UnderscoreParamReturnAfter testdata/golden/underscore-param-and-return.H12UnderscoreParamReturnAfter
+func H12UnderscoreParamReturnAfter(hookContext HookContext, arg0 error)

--- a/tool/internal/instrument/testdata/golden/underscore-param-and-return/underscore_param_and_return.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/underscore-param-and-return/underscore_param_and_return.otelc.globals.go.golden
@@ -1,0 +1,41 @@
+package main
+
+// Variable Template
+var (
+	OtelGetStackImpl   func() []byte = nil
+	OtelPrintStackImpl func([]byte)  = nil
+)
+
+// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+type HookContext interface {
+	// Set the skip call flag, can be used to skip the original function call
+	SetSkipCall(bool)
+	// Get the skip call flag, can be used to skip the original function call
+	IsSkipCall() bool
+	// Set the data field, can be used to pass information between Before and After hooks
+	SetData(interface{})
+	// Get the data field, can be used to pass information between Before and After hooks
+	GetData() interface{}
+	// Get a value from the data field by key
+	GetKeyData(key string) interface{}
+	// Set a key-value pair in the data field
+	SetKeyData(key string, val interface{})
+	// Check if a key exists in the data field
+	HasKeyData(key string) bool
+	// Number of original function parameters
+	GetParamCount() int
+	// Get the original function parameter at index idx
+	GetParam(idx int) interface{}
+	// Change the original function parameter at index idx
+	SetParam(idx int, val interface{})
+	// Number of original function return values
+	GetReturnValCount() int
+	// Get the original function return value at index idx
+	GetReturnVal(idx int) interface{}
+	// Change the original function return value at index idx
+	SetReturnVal(idx int, val interface{})
+	// Get the original function name
+	GetFuncName() string
+	// Get the package name of the original function
+	GetPackageName() string
+}

--- a/tool/internal/instrument/testdata/golden/underscore-return-syntax/underscore_return_syntax.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/underscore-return-syntax/underscore_return_syntax.main.go.golden
@@ -5,11 +5,11 @@ package main
 
 import _ "unsafe"
 
-func UnderscoreReturnFunc() (_ignoredParam0 int, _ignoredParam1 error) {
+func UnderscoreReturnFunc() (_ignoredRetVal0 int, _ignoredRetVal1 error) {
 	//line <generated>:1
 	if false {
 	} else {
-		defer OtelAfterTrampoline_UnderscoreReturnFunc2035128499(&HookContextImpl2035128499{params: []interface{}{}, returnVals: []interface{}{&_ignoredParam0, &_ignoredParam1}}, &_ignoredParam0, &_ignoredParam1)
+		defer OtelAfterTrampoline_UnderscoreReturnFunc2035128499(&HookContextImpl2035128499{params: []interface{}{}, returnVals: []interface{}{&_ignoredRetVal0, &_ignoredRetVal1}}, &_ignoredRetVal0, &_ignoredRetVal1)
 	}
 	//line main.go:7:2
 	return 0, nil


### PR DESCRIPTION
## Description

Instrumenting a function with both a blank/unnamed param (or unnamed receiver)
and a blank (`_`) named return generated uncompilable code:

```
_ignoredParam0 redeclared in this block
```

`collectArguments` and `collectReturnValues` both renamed blank bindings with the
same `_ignoredParam` prefix, each counting from 0. Since a receiver, params, and
named results share one Go scope, the two `_ignoredParam0` bindings collided.

### Fix

Fixes #736

Blank named returns now use their own `_ignoredRetVal` prefix, mirroring the
existing `_unnamedRetVal` handling for unnamed returns. Params and returns can no
longer produce the same name.

## Tests

- Unit regression that type-checks the rewritten signature via `go/types`.
- New golden fixture that compiles a blank-param + blank-named-return function
  through the real toolchain (fails without the fix).