### PR TITLE
fix(build): quote the registry path in lint-schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -762,7 +762,7 @@ lint-schema: ## Validate the local semantic-convention registry (schemas/otelc/)
 lint-schema: fetch-upstream-semconv
 	@echo "Validating otelc semantic-convention registry (schemas/otelc)..."
 	@# Guard: the upstream dependency pinned in the registry manifest must match .semconv-version.
-	@MANIFEST_VERSION=$$(grep -oE 'upstream-v[0-9]+\.[0-9]+\.[0-9]+' $(OTELC_REGISTRY_DIR)/registry_manifest.yaml | head -1 | sed -E 's/upstream-v//'); \
+	@MANIFEST_VERSION=$$(grep -oE 'upstream-v[0-9]+\.[0-9]+\.[0-9]+' "$(OTELC_REGISTRY_DIR)/registry_manifest.yaml" | head -1 | sed -E 's/upstream-v//'); \
 	SEMCONV_VERSION=$$(grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' .semconv-version | head -1 | tr -d '[:space:]' | sed 's/^v//'); \
 	if [ -z "$$MANIFEST_VERSION" ]; then \
 		echo "::error::Could not read the upstream version from $(OTELC_REGISTRY_DIR)/registry_manifest.yaml"; \


### PR DESCRIPTION
Closes #749.

`make lint-schema` fails when the repository is checked out to a path containing a space: the unquoted `$(OTELC_REGISTRY_DIR)` word-splits, so `grep` gets several arguments instead of one path, the version guard reads an empty `MANIFEST_VERSION`, and the target exits before weaver runs.

Quote it, as the `lint-schema.sh` invocation ten lines below already does.

### Before

```console
$ make lint-schema
Validating otelc semantic-convention registry (schemas/otelc)...
grep: /home/pradhyum/go: Is a directory
grep: compler: No such file or directory
::error::Could not read the upstream version from /home/pradhyum/go compler intru/.../schemas/otelc/registry_manifest.yaml
make: *** [Makefile:763: lint-schema] Error 1
```

### After

```console
$ make lint-schema
Validating otelc semantic-convention registry (schemas/otelc)...
Upstream semconv dependency: v1.37.0 (matches .semconv-version)
weaver registry check passed: schemas/otelc is valid.
```

Verified on a checkout under a path with a space, with Docker 29.0.1 and `otel/weaver:v0.19.0`. No behaviour change on paths without spaces — the same string is passed to `grep`, just as a single argument.