### PR TITLE
fix(ast): handle composite types in signature filters

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -483,7 +483,9 @@ Type names follow the form `[*][pkg.]Name`, for example `error`, `context.Contex
 
 > **Note on scalar filter semantics:** Because there is no type checker at instrumentation time, `result`, `last_result`, and `param` perform an exact type-name match. For example, `result: error` matches functions that literally return the `error` type, but not functions that return a concrete type (e.g. `*MyError`) that happens to implement `error`.
 >
-> **Unsupported type expressions:** Complex type expressions — `chan`, `func`, `map`, slice (`[]T`), and non-empty interface literals — cannot be matched by type-name filters. If a parameter or return value uses one of these forms, the filter will never match it.
+> **Unsupported filter type strings:** Filter values must use the `[*][pkg.]Name` form. Complex type literals such as `[]string` or `map[string]int` cannot be used as filter strings and are rejected at parse time.
+>
+> **Composite parameter and return types:** When a function signature uses slice, channel, map, or function types, signature sub-filters traverse those types and match named element types. For example, `signature_contains: {args: [byte]}` matches `func Read(p []byte) (n int, err error)`. Exact `signature` matching still requires the full type sequence to match field-by-field; composite slots do not match a bare element type name.
 
 **Example — match only functions with a specific signature:**
 

--- a/tool/internal/ast/funcmatch_test.go
+++ b/tool/internal/ast/funcmatch_test.go
@@ -242,3 +242,27 @@ func TestFuncDeclMatchesFilters_InvalidTypeReturnsError(t *testing.T) {
 	_, err = funcDeclMatchesFilters(decl, &rule.InstFuncRule{Param: "[]invalid"})
 	require.Error(t, err)
 }
+
+func TestFuncDeclMatchesFilters_CompositeParamTypes(t *testing.T) {
+	// func(ch chan int) error
+	chanDecl := makeFuncDecl(
+		[]*dst.Field{field(&dst.ChanType{Value: ident("int")})},
+		[]*dst.Field{field(ident("error"))},
+	)
+	sigInt := rule.FuncSignature{Args: []string{"int"}}
+	assert.True(t, mustMatch(t, chanDecl, &rule.InstFuncRule{SignatureContains: &sigInt}))
+	assert.False(t, mustMatch(t, chanDecl, &rule.InstFuncRule{Param: "string"}))
+
+	// func Read(p []byte) (n int, err error)
+	readDecl := makeFuncDecl(
+		[]*dst.Field{field(&dst.ArrayType{Elt: ident("byte")})},
+		[]*dst.Field{field(ident("int")), field(ident("error"))},
+	)
+	sigByte := rule.FuncSignature{Args: []string{"byte"}}
+	assert.True(t, mustMatch(t, readDecl, &rule.InstFuncRule{SignatureContains: &sigByte}))
+	assert.True(t, mustMatch(t, readDecl, &rule.InstFuncRule{Param: "byte"}))
+	assert.True(t, mustMatch(t, readDecl, &rule.InstFuncRule{LastResult: "error"}))
+
+	exactSig := rule.FuncSignature{Args: []string{"byte"}, Returns: []string{"int", "error"}}
+	assert.False(t, mustMatch(t, readDecl, &rule.InstFuncRule{Signature: &exactSig}))
+}

--- a/tool/internal/ast/typename.go
+++ b/tool/internal/ast/typename.go
@@ -4,13 +4,11 @@
 package ast
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/dave/dst"
 
 	"go.opentelemetry.io/otelc/tool/ex"
-	"go.opentelemetry.io/otelc/tool/util"
 )
 
 // typeNameRe parses type-name strings of the form [*][pkg.]Name.
@@ -37,7 +35,7 @@ func parseTypeName(s string) (parsedTypeName, error) {
 	return parsedTypeName{pointer: m[1] == "*", importPath: m[2], name: m[3]}, nil
 }
 
-// matches reports whether the dst.Expr node represents this type.
+// matches reports whether node is exactly this type (no composite traversal).
 func (t parsedTypeName) matches(node dst.Expr) bool {
 	switch n := node.(type) {
 	case *dst.Ident:
@@ -63,15 +61,44 @@ func (t parsedTypeName) matches(node dst.Expr) bool {
 		return !t.pointer && t.matches(n.X)
 
 	case *dst.InterfaceType:
-		// Only the empty interface matches "any".
+		// Only the empty interface matches "any"; named interfaces never match.
 		return len(n.Methods.List) == 0 && t.importPath == "" && t.name == "any"
 
 	default:
-		// Unsupported AST node types (chan, func, map, slice, array, interface
-		// literals) cannot be matched by type-name filters.
-		util.Unimplemented(fmt.Sprintf("signature filter: unsupported type node %T", node))
 		return false
 	}
+}
+
+// matchesContainedIn reports whether this type appears in node, traversing
+// composite types such as slices, channels, maps, and function signatures.
+func (t parsedTypeName) matchesContainedIn(node dst.Expr) bool {
+	if t.matches(node) {
+		return true
+	}
+	switch n := node.(type) {
+	case *dst.ArrayType:
+		return t.matchesContainedIn(n.Elt)
+	case *dst.ChanType:
+		return t.matchesContainedIn(n.Value)
+	case *dst.MapType:
+		return t.matchesContainedIn(n.Key) || t.matchesContainedIn(n.Value)
+	case *dst.FuncType:
+		return typeExprListContainsMatch(t, n.Params) || typeExprListContainsMatch(t, n.Results)
+	default:
+		return false
+	}
+}
+
+func typeExprListContainsMatch(t parsedTypeName, fields *dst.FieldList) bool {
+	if fields == nil {
+		return false
+	}
+	for _, field := range fields.List {
+		if t.matchesContainedIn(field.Type) {
+			return true
+		}
+	}
+	return false
 }
 
 // fieldListContainsType reports whether any field in fields has a type that
@@ -85,7 +112,7 @@ func fieldListContainsType(fields *dst.FieldList, typeStr string) (bool, error) 
 		return false, err
 	}
 	for _, field := range fields.List {
-		if tn.matches(field.Type) {
+		if tn.matchesContainedIn(field.Type) {
 			return true, nil
 		}
 	}

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -50,10 +50,11 @@ func TestParseTypeName(t *testing.T) {
 
 func TestTypeNameMatches(t *testing.T) {
 	tests := []struct {
-		name    string
-		typeStr string
-		node    dst.Expr
-		want    bool
+		name      string
+		typeStr   string
+		node      dst.Expr
+		want      bool
+		contained bool
 	}{
 		{
 			name:    "builtin ident matches",
@@ -114,13 +115,65 @@ func TestTypeNameMatches(t *testing.T) {
 			node:    &dst.InterfaceType{Methods: &dst.FieldList{}},
 			want:    true,
 		},
+		{
+			name:      "byte matches slice element",
+			typeStr:   "byte",
+			node:      &dst.ArrayType{Elt: &dst.Ident{Name: "byte"}},
+			want:      true,
+			contained: true,
+		},
+		{
+			name:      "int matches chan element",
+			typeStr:   "int",
+			node:      &dst.ChanType{Value: &dst.Ident{Name: "int"}},
+			want:      true,
+			contained: true,
+		},
+		{
+			name:    "string matches map value",
+			typeStr: "string",
+			node: &dst.MapType{
+				Key:   &dst.Ident{Name: "int"},
+				Value: &dst.Ident{Name: "string"},
+			},
+			want:      true,
+			contained: true,
+		},
+		{
+			name:    "error matches func result",
+			typeStr: "error",
+			node: &dst.FuncType{
+				Results: &dst.FieldList{
+					List: []*dst.Field{{Type: &dst.Ident{Name: "error"}}},
+				},
+			},
+			want:      true,
+			contained: true,
+		},
+		{
+			name:      "slice type does not match unrelated filter",
+			typeStr:   "int",
+			node:      &dst.ArrayType{Elt: &dst.Ident{Name: "string"}},
+			want:      false,
+			contained: true,
+		},
+		{
+			name:    "slice does not exact-match element filter",
+			typeStr: "byte",
+			node:    &dst.ArrayType{Elt: &dst.Ident{Name: "byte"}},
+			want:    false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tn, err := parseTypeName(tt.typeStr)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, tn.matches(tt.node))
+			matchFn := tn.matches
+			if tt.contained {
+				matchFn = tn.matchesContainedIn
+			}
+			assert.Equal(t, tt.want, matchFn(tt.node))
 		})
 	}
 }
@@ -153,6 +206,16 @@ func TestFieldListContainsType(t *testing.T) {
 	assert.False(t, mustContains(t, fields, "io.Reader"))
 	assert.False(t, mustContains(t, nil, "error"))
 	assert.False(t, mustContains(t, &dst.FieldList{}, "error"))
+
+	compositeFields := &dst.FieldList{
+		List: []*dst.Field{
+			{Type: &dst.ArrayType{Elt: &dst.Ident{Name: "byte"}}},
+			{Type: &dst.ChanType{Value: &dst.Ident{Name: "int"}}},
+		},
+	}
+	assert.True(t, mustContains(t, compositeFields, "byte"))
+	assert.True(t, mustContains(t, compositeFields, "int"))
+	assert.False(t, mustContains(t, compositeFields, "string"))
 
 	_, err := fieldListContainsType(fields, "[]invalid")
 	assert.Error(t, err)


### PR DESCRIPTION

## Description

Signature sub-filters (`signature_contains`, `param`, `result`, `last_result`) previously called `util.Unimplemented` and fatally aborted `otelc setup` when scanning function signatures that use composite Go types (`[]T`, `chan T`, `map[K]V`, `func(...)`, etc.).

This PR fixes that crash by:

- Adding `matchesContainedIn()` in `tool/internal/ast/typename.go` to traverse composite types when evaluating contains-style filters
- Keeping `matches()` as exact-only matching for the `signature` exact-match path
- Replacing the fatal `Unimplemented` path with safe match/no-match behavior
- Adding regression tests for `chan`, `[]byte`, and exact vs contains semantics
- Updating `docs/rules.md` to document composite traversal behavior

## Motivation

Rule authors use signature filters to disambiguate overloaded function names (e.g. `signature_contains: {args: [byte]}` on `func Read(p []byte) (n int, err error)`). Before this fix, any such rule against a function with slice/chan/map params caused:

```
Unimplemented: signature filter: unsupported type node *dst.ChanType
```

That aborted the entire build instead of matching or skipping gracefully, contradicting the documented behavior that filters should not match composite types fatally.

Fixes #756 

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [ ] Linters pass: `make lint` *(pre-existing `nolintlint` failure in `tool/internal/instrument/trampoline.go` on main; unchanged by this PR)*
- [x] Tests pass: `make test` *(verified: `go test ./tool/internal/ast/...`, `./tool/internal/setup/...`, `./tool/internal/instrument/...`)*
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [x] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation)) *(N/A - tool-only change)*
