### PR TITLE
refactor(tool/rule): add selector and modifier registry

### DIFF
--- a/tool/internal/rule/normalize.go
+++ b/tool/internal/rule/normalize.go
@@ -10,48 +10,6 @@ import (
 	"go.opentelemetry.io/otelc/tool/util"
 )
 
-// Structured top-level keys.
-const (
-	KeyWhere = "where"
-	KeyDo    = "do"
-)
-
-// where selectors (hoisted to flat by normalizeWhere).
-const (
-	SelTarget       = "target"
-	SelVersion      = "version"
-	SelFunc         = "func"
-	SelRecv         = "recv"
-	SelStruct       = "struct"
-	SelFunctionCall = "function_call"
-	SelDirective    = "directive"
-	SelKind         = "kind"
-	SelIdentifier   = "identifier"
-
-	// Signature match-narrowing selectors for func rules (see InstFuncRule).
-	SelSignature         = "signature"
-	SelSignatureContains = "signature_contains"
-	SelResult            = "result"
-	SelLastResult        = "last_result"
-	SelParam             = "param"
-
-	// Raw match-narrowing selector for raw rules (see InstRawRule).
-	SelPattern   = "pattern"
-	SelPlacement = "placement"
-)
-
-// where sub-groups / combinators (preserved nested under flat).
-const (
-	WhereFile = "file"
-	CombAllOf = "all-of"
-	CombOneOf = "one-of"
-	CombNot   = "not"
-)
-
-// RawField is the modifier-output key produced by normalize for raw rules.
-// It is not a where selector; exposed here so match.go can share the literal.
-const RawField = "raw"
-
 // Normalize detects the structured target/version + where + do format defined
 // in ADR-0003 and expands it into one or more flat rule maps expected by the
 // existing rule constructors. If the fields map contains neither "where" nor
@@ -160,10 +118,6 @@ func normalizeWhere(common, where map[string]any) (map[string]any, error) {
 	normalized := make(map[string]any)
 	for key, value := range where {
 		switch key {
-		case SelFunc, SelRecv, SelStruct, SelFunctionCall, SelDirective, SelKind, SelIdentifier,
-			SelSignature, SelSignatureContains, SelResult, SelLastResult, SelParam,
-			SelPattern, SelPlacement:
-			common[key] = value
 		case WhereFile:
 			if _, ok := value.(map[string]any); !ok {
 				return nil, ex.Newf("where.file must be a map")
@@ -172,7 +126,10 @@ func normalizeWhere(common, where map[string]any) (map[string]any, error) {
 		case CombAllOf, CombOneOf, CombNot:
 			normalized[key] = value
 		default:
-			return nil, ex.Newf("unsupported where key %q", key)
+			if !IsValidSelector(key) {
+				return nil, ex.Newf("unsupported where key %q", key)
+			}
+			common[key] = value
 		}
 	}
 
@@ -211,7 +168,10 @@ func normalizeDoSequence(items []any) ([]map[string]any, error) {
 		if len(modifierMap) != 1 {
 			return nil, ex.Newf("do[%d] must contain exactly one modifier key", idx)
 		}
-		for _, modifierRaw := range modifierMap {
+		for modifierName, modifierRaw := range modifierMap {
+			if !IsValidModifier(modifierName) {
+				return nil, ex.Newf("unsupported do modifier %q", modifierName)
+			}
 			modifierFields, hasModifierFields := modifierRaw.(map[string]any)
 			if !hasModifierFields {
 				return nil, ex.Newf("do[%d] modifier payload must be a map", idx)
@@ -233,7 +193,10 @@ func normalizeDoMap(modifier map[string]any) ([]map[string]any, error) {
 				"use the sequence form for multiple modifiers",
 		)
 	}
-	for _, modifierRaw := range modifier {
+	for modifierName, modifierRaw := range modifier {
+		if !IsValidModifier(modifierName) {
+			return nil, ex.Newf("unsupported do modifier %q", modifierName)
+		}
 		modifierFields, ok := modifierRaw.(map[string]any)
 		if !ok {
 			return nil, ex.Newf("do modifier payload must be a map")

--- a/tool/internal/rule/normalize_test.go
+++ b/tool/internal/rule/normalize_test.go
@@ -405,6 +405,36 @@ func TestNormalize_Errors(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "unknown do modifier in map form",
+			fields: map[string]any{
+				"target": "database/sql",
+				"where": map[string]any{
+					"func": "Open",
+				},
+				"do": map[string]any{
+					"inject_hook": map[string]any{
+						"before": "BeforeOpen",
+					},
+				},
+			},
+		},
+		{
+			name: "unknown do modifier in sequence form",
+			fields: map[string]any{
+				"target": "database/sql",
+				"where": map[string]any{
+					"func": "Open",
+				},
+				"do": []any{
+					map[string]any{
+						"inject_hook": map[string]any{
+							"before": "BeforeOpen",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/internal/rule/schema.go
+++ b/tool/internal/rule/schema.go
@@ -1,0 +1,181 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rule
+
+import "slices"
+
+// Selector names the structured where-key selectors accepted by normalizeWhere.
+// These keys are hoisted into the flat rule form consumed by the existing rule
+// constructors.
+type Selector string
+
+// Modifier names the structured do-key modifiers accepted by normalizeDo.
+// The current implementation validates these names during normalization but
+// still derives the concrete rule type from field presence; see #546.
+type Modifier string
+
+// Structured top-level keys.
+const (
+	KeyWhere = "where"
+	KeyDo    = "do"
+)
+
+// Package selectors that must stay top-level rather than inside where.
+const (
+	SelTarget  = "target"
+	SelVersion = "version"
+)
+
+// Valid structured where selectors.
+const (
+	SelectorFunc         Selector = "func"
+	SelectorRecv         Selector = "recv"
+	SelectorStruct       Selector = "struct"
+	SelectorFunctionCall Selector = "function_call"
+	SelectorDirective    Selector = "directive"
+	SelectorKind         Selector = "kind"
+	SelectorIdentifier   Selector = "identifier"
+
+	// Signature match-narrowing selectors for func rules (see InstFuncRule).
+	SelectorSignature         Selector = "signature"
+	SelectorSignatureContains Selector = "signature_contains"
+	SelectorResult            Selector = "result"
+	SelectorLastResult        Selector = "last_result"
+	SelectorParam             Selector = "param"
+
+	// Raw match-narrowing selectors for raw rules (see InstRawRule).
+	SelectorPattern   Selector = "pattern"
+	SelectorPlacement Selector = "placement"
+)
+
+// String aliases preserved for existing call sites.
+const (
+	SelFunc         = string(SelectorFunc)
+	SelRecv         = string(SelectorRecv)
+	SelStruct       = string(SelectorStruct)
+	SelFunctionCall = string(SelectorFunctionCall)
+	SelDirective    = string(SelectorDirective)
+	SelKind         = string(SelectorKind)
+	SelIdentifier   = string(SelectorIdentifier)
+
+	SelSignature         = string(SelectorSignature)
+	SelSignatureContains = string(SelectorSignatureContains)
+	SelResult            = string(SelectorResult)
+	SelLastResult        = string(SelectorLastResult)
+	SelParam             = string(SelectorParam)
+
+	SelPattern   = string(SelectorPattern)
+	SelPlacement = string(SelectorPlacement)
+)
+
+// where sub-groups / combinators (preserved nested under flat).
+const (
+	WhereFile = "file"
+	CombAllOf = "all-of"
+	CombOneOf = "one-of"
+	CombNot   = "not"
+)
+
+// RawField is the modifier-output key produced by normalize for raw rules.
+// It is not a where selector; exposed here so match.go can share the literal.
+const RawField = "raw"
+
+// Valid structured do modifiers.
+const (
+	ModifierInjectHooks     Modifier = "inject_hooks"
+	ModifierInjectCode      Modifier = "inject_code"
+	ModifierAddStructFields Modifier = "add_struct_fields"
+	ModifierAddFile         Modifier = "add_file"
+	ModifierWrapCall        Modifier = "wrap_call"
+	ModifierExpandDirective Modifier = "expand_directive"
+	ModifierAssignValue     Modifier = "assign_value"
+)
+
+var allSelectors = []Selector{ //nolint:gochecknoglobals // immutable schema registry
+	SelectorFunc,
+	SelectorRecv,
+	SelectorStruct,
+	SelectorFunctionCall,
+	SelectorDirective,
+	SelectorKind,
+	SelectorIdentifier,
+	SelectorSignature,
+	SelectorSignatureContains,
+	SelectorResult,
+	SelectorLastResult,
+	SelectorParam,
+	SelectorPattern,
+	SelectorPlacement,
+}
+
+var allModifiers = []Modifier{ //nolint:gochecknoglobals // immutable schema registry
+	ModifierInjectHooks,
+	ModifierInjectCode,
+	ModifierAddStructFields,
+	ModifierAddFile,
+	ModifierWrapCall,
+	ModifierExpandDirective,
+	ModifierAssignValue,
+}
+
+var validSelectors = map[string]struct{}{ //nolint:gochecknoglobals // immutable schema lookup
+	SelFunc:              {},
+	SelRecv:              {},
+	SelStruct:            {},
+	SelFunctionCall:      {},
+	SelDirective:         {},
+	SelKind:              {},
+	SelIdentifier:        {},
+	SelSignature:         {},
+	SelSignatureContains: {},
+	SelResult:            {},
+	SelLastResult:        {},
+	SelParam:             {},
+	SelPattern:           {},
+	SelPlacement:         {},
+}
+
+var validModifiers = map[string]struct{}{ //nolint:gochecknoglobals // immutable schema lookup
+	string(ModifierInjectHooks):     {},
+	string(ModifierInjectCode):      {},
+	string(ModifierAddStructFields): {},
+	string(ModifierAddFile):         {},
+	string(ModifierWrapCall):        {},
+	string(ModifierExpandDirective): {},
+	string(ModifierAssignValue):     {},
+}
+
+// IsValidSelector reports whether s is a supported structured where selector.
+func IsValidSelector(s string) bool {
+	_, ok := validSelectors[s]
+	return ok
+}
+
+// IsValidModifier reports whether s is a supported structured do modifier.
+func IsValidModifier(s string) bool {
+	_, ok := validModifiers[s]
+	return ok
+}
+
+// AllSelectors returns the supported structured where selectors in stable order.
+func AllSelectors() []Selector {
+	return slices.Clone(allSelectors)
+}
+
+// AllModifiers returns the supported structured do modifiers in stable order.
+func AllModifiers() []Modifier {
+	return slices.Clone(allModifiers)
+}
+
+// HasWhereSelectors reports whether where carries any non-file point selectors.
+// Top-level where combinators are checked separately by the setup filter.
+func HasWhereSelectors(where *WhereDef) bool {
+	if where == nil {
+		return false
+	}
+
+	return where.Func != "" || where.Recv != "" || where.Struct != "" ||
+		where.FunctionCall != "" || where.Directive != "" ||
+		where.Kind != "" || where.Identifier != ""
+}

--- a/tool/internal/rule/schema_test.go
+++ b/tool/internal/rule/schema_test.go
@@ -1,0 +1,133 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rule_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"go.opentelemetry.io/otelc/tool/internal/rule"
+)
+
+func TestAllSelectors(t *testing.T) {
+	want := []rule.Selector{
+		rule.SelectorFunc,
+		rule.SelectorRecv,
+		rule.SelectorStruct,
+		rule.SelectorFunctionCall,
+		rule.SelectorDirective,
+		rule.SelectorKind,
+		rule.SelectorIdentifier,
+		rule.SelectorSignature,
+		rule.SelectorSignatureContains,
+		rule.SelectorResult,
+		rule.SelectorLastResult,
+		rule.SelectorParam,
+		rule.SelectorPattern,
+		rule.SelectorPlacement,
+	}
+
+	if diff := cmp.Diff(want, rule.AllSelectors()); diff != "" {
+		t.Fatalf("AllSelectors() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestAllModifiers(t *testing.T) {
+	want := []rule.Modifier{
+		rule.ModifierInjectHooks,
+		rule.ModifierInjectCode,
+		rule.ModifierAddStructFields,
+		rule.ModifierAddFile,
+		rule.ModifierWrapCall,
+		rule.ModifierExpandDirective,
+		rule.ModifierAssignValue,
+	}
+
+	if diff := cmp.Diff(want, rule.AllModifiers()); diff != "" {
+		t.Fatalf("AllModifiers() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRegistryAccessorsReturnCopies(t *testing.T) {
+	selectors := rule.AllSelectors()
+	selectors[0] = rule.Selector("bogus")
+	if got := rule.AllSelectors()[0]; got != rule.SelectorFunc {
+		t.Fatalf("AllSelectors() returned shared backing slice, first selector = %q", got)
+	}
+
+	modifiers := rule.AllModifiers()
+	modifiers[0] = rule.Modifier("bogus")
+	if got := rule.AllModifiers()[0]; got != rule.ModifierInjectHooks {
+		t.Fatalf("AllModifiers() returned shared backing slice, first modifier = %q", got)
+	}
+}
+
+func TestIsValidSelector(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "func selector", value: rule.SelFunc, want: true},
+		{name: "signature selector", value: rule.SelSignature, want: true},
+		{name: "raw selector", value: rule.SelPattern, want: true},
+		{name: "file is structural not selector", value: rule.WhereFile, want: false},
+		{name: "typo", value: "fnc", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rule.IsValidSelector(tt.value); got != tt.want {
+				t.Fatalf("IsValidSelector(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidModifier(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "inject hooks", value: string(rule.ModifierInjectHooks), want: true},
+		{name: "inject code", value: string(rule.ModifierInjectCode), want: true},
+		{name: "assign value", value: string(rule.ModifierAssignValue), want: true},
+		{name: "legacy alias not accepted", value: "raw_inject", want: false},
+		{name: "typo", value: "inject_hook", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rule.IsValidModifier(tt.value); got != tt.want {
+				t.Fatalf("IsValidModifier(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasWhereSelectors(t *testing.T) {
+	tests := []struct {
+		name  string
+		where *rule.WhereDef
+		want  bool
+	}{
+		{name: "nil where", want: false},
+		{name: "file only", where: &rule.WhereDef{File: &rule.FilterDef{HasFunc: "init"}}, want: false},
+		{name: "func selector", where: &rule.WhereDef{Func: "Open"}, want: true},
+		{name: "call selector", where: &rule.WhereDef{FunctionCall: "net/http.Get"}, want: true},
+		{name: "directive selector", where: &rule.WhereDef{Directive: "otelc:span"}, want: true},
+		{name: "kind selector", where: &rule.WhereDef{Kind: "var"}, want: true},
+		{name: "identifier selector", where: &rule.WhereDef{Identifier: "DefaultTransport"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rule.HasWhereSelectors(tt.where); got != tt.want {
+				t.Fatalf("HasWhereSelectors(%+v) = %v, want %v", tt.where, got, tt.want)
+			}
+		})
+	}
+}

--- a/tool/internal/setup/filter.go
+++ b/tool/internal/setup/filter.go
@@ -192,9 +192,7 @@ func Build(where *rule.WhereDef) (Filter, error) {
 		return nil, ex.Newf("where not selector composition is not yet supported")
 	}
 
-	if where.Func != "" || where.Recv != "" || where.Struct != "" ||
-		where.FunctionCall != "" || where.Directive != "" ||
-		where.Kind != "" || where.Identifier != "" {
+	if rule.HasWhereSelectors(where) {
 		return nil, ex.Newf("where selector composition beyond where.file is not yet supported")
 	}
 


### PR DESCRIPTION
## Summary

This PR adds a central registry for structured rule selectors and modifiers.

It introduces `tool/internal/rule/schema.go` as the shared place for valid `where` selector keys and `do` modifier names, and updates normalization/filter validation to use that registry.

Unknown structured `do` modifiers now fail early instead of being accepted silently.

This PR does not change rule dispatch semantics; that remains separate work under `#546`.

Fixes #542.

## Testing

Ran:
- `go test ./tool/internal/rule ./tool/internal/setup`
- `make test-unit/tool`
- `make lint/go`