### PR TITLE
chore(bundle): add git merge driver to stop otelc-bundle.tgz rebase conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 *.golden text eol=lf
-tool/data/otelc-bundle.tgz binary
+# otelc-bundle.tgz is a binary archive derived from pkg/ and instrumentation/.
+# Treat it as binary (no diff/eol conversion). The custom 'otelc-bundle' merge
+# driver keeps the current version instead of conflicting so rebases/merges
+# don't stop on it; regenerate it afterwards with `make package`. Register the
+# driver once per clone with `make setup-git`.
+tool/data/otelc-bundle.tgz -text -diff merge=otelc-bundle

--- a/.github/scripts/merge-bundle.sh
+++ b/.github/scripts/merge-bundle.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Git merge driver for tool/data/otelc-bundle.tgz.
+#
+# The bundle is a reproducible binary archive derived from pkg/ and
+# instrumentation/ (see .tools/bundle/main.go). Because it is binary, git cannot
+# 3-way merge it, so every branch that touches the sources conflicts with the
+# base on this one file and halts an otherwise-clean rebase/merge.
+#
+# We deliberately do NOT regenerate the bundle here: when git invokes a merge
+# driver it has not yet materialized the *other* merged source files into the
+# working tree, so `make package` would read stale sources and embed the wrong
+# bytes (missing the incoming changes). Instead we keep the current ("ours")
+# version so the rebase/merge completes without stopping, and remind the user to
+# regenerate the bundle from the fully-merged sources afterwards with
+# `make package`. The verify-bundle CI enforces that the committed bundle
+# matches the sources, so a forgotten regeneration cannot slip through.
+#
+# Register it once per clone with `make setup-git`.
+#
+# Git invokes this as: merge-bundle.sh %A
+#   $1 = %A  current/ours version, which is already the result git will keep.
+
+set -euo pipefail
+
+cat >&2 <<'EOF'
+------------------------------------------------------------------------
+otelc-bundle merge driver: kept the current bundle to let the merge/rebase
+proceed. tool/data/otelc-bundle.tgz is now likely STALE. Regenerate and
+amend it from the fully-merged sources before pushing:
+
+    make package
+    git add tool/data/otelc-bundle.tgz && git commit --amend --no-edit
+
+(verify-bundle CI will fail if you skip this.)
+------------------------------------------------------------------------
+EOF
+
+# Leave %A untouched (keep "ours") and report success so git accepts it.
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,25 @@ This project uses several tools for development. Most tools will be automaticall
    cd opentelemetry-go-compile-instrumentation
    ```
 
-2. Build the project:
+2. Configure the git merge driver for the instrumentation bundle (run once per clone):
+
+   ```sh
+   make setup-git
+   ```
+
+   `tool/data/otelc-bundle.tgz` is a binary archive generated from `pkg/` and
+   `instrumentation/`, so git cannot merge it and it conflicts on almost every
+   rebase. This registers a merge driver that keeps the current bundle instead
+   of stopping the rebase/merge; you then refresh it with `make package`. See
+   [Keeping the bundle in sync](#keeping-the-bundle-in-sync).
+
+3. Build the project:
 
    ```sh
    make build
    ```
 
-3. Run tests:
+4. Run tests:
 
    ```sh
    make test
@@ -131,6 +143,43 @@ make all
 ```
 
 This will run: `build`, `format`, `lint`, and `test` in sequence.
+
+### Keeping the bundle in sync
+
+`tool/data/otelc-bundle.tgz` is a reproducible archive of `pkg/` and
+`instrumentation/` that is embedded into `otelc` via `//go:embed`. It must stay
+committed so that `go install go.opentelemetry.io/otelc/tool/cmd/otelc@latest`
+works, but because it is binary, git cannot 3-way merge it — so any branch that
+touches the sources conflicts with `main` on this file.
+
+To make this painless, run `make setup-git` once per clone (see
+[Getting Started](#getting-started)). It registers a custom merge driver
+(defined in `.gitattributes` + `.github/scripts/merge-bundle.sh`) that keeps the
+current ("ours") bundle on conflict so the rebase/merge runs to completion
+without stopping. You then regenerate the bundle from the fully-merged sources:
+
+```sh
+git fetch origin main
+git rebase origin/main   # no longer halts on the bundle
+make package             # regenerate tool/data/otelc-bundle.tgz from merged sources
+git add tool/data/otelc-bundle.tgz && git commit --amend --no-edit
+git push --force-with-lease
+```
+
+Why the driver doesn't regenerate the bundle for you: when git invokes a merge
+driver it has not yet written the *other* merged source files to the working
+tree, so running `make package` at that moment would embed stale sources and
+miss the incoming changes. Regenerating after the rebase/merge completes is the
+only reliable point, hence the explicit `make package` step above.
+
+Notes:
+
+- GitHub's "This branch has conflicts" indicator is computed server-side and
+  does **not** use your local merge driver. Rebase locally as above and push;
+  the conflict disappears once your branch is up to date.
+- The `verify-bundle` CI guarantees the committed bundle matches the sources, so
+  a forgotten `make package` fails CI rather than shipping a stale bundle.
+  Maintainers can also comment `/regenerate-bundle` on a PR to auto-fix it.
 
 ### Tools
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Use bash for all shell commands (required for pipefail and other bash features)
 SHELL := /bin/bash
 
-.PHONY: all test test-unit test-integration test-e2e format lint build build-all build/pkg install package clean \
+.PHONY: all test test-unit test-integration test-e2e format lint build build-all build/pkg install package clean setup-git \
         build-demo build-demo-grpc build-demo-http format/go format/yaml lint/go lint/yaml \
         lint/action lint/makefile lint/license-header lint/license-header/fix lint/dockerfile actionlint yamlfmt gotestfmt ratchet ratchet/pin \
         ratchet/update ratchet/check golangci-lint embedmd checkmake hadolint help docs check-embed check-api-sync check-golden-files \
@@ -157,6 +157,13 @@ build-all: build/pkg build/instrumentation package ## Build the instrumentation 
 		env GOOS=$$GOOS GOARCH=$$GOARCH $(GO_BUILD_CMD) -o dist/$(BINARY_NAME)-$$GOOS-$$GOARCH$$EXT ./$(TOOL_DIR); \
 	done
 	@echo "All builds completed. Artifacts in dist/"
+
+.PHONY: setup-git
+setup-git: ## Register the git merge driver so otelc-bundle.tgz stops blocking rebases/merges
+	@git config merge.otelc-bundle.name "Keep current otelc-bundle.tgz (regenerate with make package)"
+	@git config merge.otelc-bundle.driver ".github/scripts/merge-bundle.sh %A"
+	@echo "Configured git merge driver 'otelc-bundle'. Rebase/merge no longer stops on the bundle;"
+	@echo "run 'make package' afterwards to refresh tool/data/otelc-bundle.tgz."
 
 install: package ## Install otelc to $$GOPATH/bin (auto-packages instrumentation)
 	@echo "Installing otelc..."


### PR DESCRIPTION
## Problem

`tool/data/otelc-bundle.tgz` is a binary archive embedded into `otelc` via `//go:embed`, so it must stay committed for `go install go.opentelemetry.io/otelc/tool/cmd/otelc@latest` to work. But because it is binary, git cannot 3-way merge it — so almost every branch that touches `pkg/` or `instrumentation/` conflicts with `main` on this one file and halts an otherwise-clean rebase.

## Solution

Add a custom `otelc-bundle` git merge driver, registered once per clone via `make setup-git`:

- **`.gitattributes`** — routes the bundle to `merge=otelc-bundle` (still treated as binary: `-text -diff`).
- **`.github/scripts/merge-bundle.sh`** — on conflict, keeps the current ("ours") bundle and exits 0 so the rebase/merge runs to completion without stopping, printing a reminder to regenerate.
- **`Makefile`** — `make setup-git` registers the driver in `.git/config`.
- **`CONTRIBUTING.md`** — documents the one-time setup and the post-rebase `make package` step.

With it configured, resolving a stale bundle is:

```sh
git fetch origin main
git rebase origin/main   # no longer halts on the bundle
make package             # regenerate from the merged sources
git add tool/data/otelc-bundle.tgz && git commit --amend --no-edit
git push --force-with-lease
```

### Why the driver does not regenerate the bundle itself

I first implemented in-driver `make package`, but verified it is **incorrect**: when git invokes a merge driver it has not yet materialized the *other* merged source files into the working tree, so `make package` reads stale sources and drops the incoming changes (reproduced: a merge of two source-editing branches produced a bundle missing one side's change, which `verify-bundle` would then reject). Regenerating after the rebase/merge completes is the only reliable point, so the driver keeps "ours" and `verify-bundle` CI continues to enforce that the committed bundle matches the sources.

## Testing

- Simulated a real rebase conflict between two branches that each modify sources: rebase now completes with exit 0 and no manual conflict resolution; after `make package` the bundle contains both sides' changes and passes the `verify-bundle` check.
- `make setup-git` and `make -n setup-git` verified.