### PR TITLE
fix(tool): resolve canFlattenTJump panic on unnamed HookContext parameter

### DIFF
--- a/tool/internal/instrument/optimize.go
+++ b/tool/internal/instrument/optimize.go
@@ -203,8 +203,18 @@ func removeAfterTrampolineDecl(targetFile *dst.File, tjump *TJump) error {
 // 1. SetSkipCall is never called (so skip is always false)
 // 2. The HookContext parameter is only used as a receiver for method calls
 func canFlattenTJump(hookFunc *dst.FuncDecl) bool {
+	if hookFunc.Type == nil || hookFunc.Type.Params == nil || len(hookFunc.Type.Params.List) == 0 {
+		return true
+	}
+	firstParam := hookFunc.Type.Params.List[0]
+	if len(firstParam.Names) == 0 {
+		// If the parameter is unnamed, it cannot be referenced in the body
+		// Thus it doesn't escape and SetSkipCall cannot be called.
+		return true
+	}
+
 	// The hook context parameter is always the first parameter of the hook function.
-	hookContextParam := hookFunc.Type.Params.List[0].Names[0].Name
+	hookContextParam := firstParam.Names[0].Name
 
 	// Check if the hook function references SetSkipCall on the hook context.
 	// If found, the trampoline-jump-if cannot be flattened. Match the bare

--- a/tool/internal/instrument/optimize_test.go
+++ b/tool/internal/instrument/optimize_test.go
@@ -504,6 +504,24 @@ func TestFlattenTJump(t *testing.T) {
 			validate:      nil,
 		},
 		{
+			name: "can flatten with unnamed HookContext param",
+			hookSrc: `package main
+			func hookFunc(HookContext, string) {
+			}`,
+			canFlatten:    true,
+			removedOnExit: false,
+			validate:      nil,
+		},
+		{
+			name: "can flatten with no parameters",
+			hookSrc: `package main
+			func hookFunc() {
+			}`,
+			canFlatten:    true,
+			removedOnExit: false,
+			validate:      nil,
+		},
+		{
 			name: "flatten despite unrelated identifier substring",
 			hookSrc: `package main
 			func hookFunc(ctx HookContext, arg1 string) {


### PR DESCRIPTION
## Description

This PR fixes a runtime panic in `canFlattenTJump` (`tool/internal/instrument/optimize.go`) when a `Before` hook function declares its `HookContext` parameter without an explicit name (e.g., `func(HookContext, string)`).

In Go's `dst` AST representation, unnamed parameters result in `len(field.Names) == 0`. We now check for empty `Names` before attempting to access `Names[0]`. Unnamed parameters cannot be referenced in the function body and are guaranteed not to escape, so `canFlattenTJump` safely returns `true`.

## Motivation

Prevents `otelc build` from crashing with `panic: runtime error: index out of range [0] with length 0` when encountering valid Go hook functions declared with unnamed parameters.

Fixes #788

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [x] Documentation updated (if applicable)
- [x] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))
