### PR TITLE
fix(tool/rule): validate required target field during rule loading

### DIFF
--- a/tool/internal/rule/base.go
+++ b/tool/internal/rule/base.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"go.opentelemetry.io/otelc/tool/ex"
 	"go.opentelemetry.io/otelc/tool/util"
 )
 
@@ -105,10 +104,7 @@ func (ibr *InstBaseRule) GetVersion() string  { return ibr.Version }
 func (ibr *InstBaseRule) GetWhere() *WhereDef { return ibr.Where }
 
 func (ibr *InstBaseRule) validateBase() error {
-	if strings.TrimSpace(ibr.Target) == "" {
-		return ex.Newf("target cannot be empty")
-	}
-	return nil
+	return ValidateTarget(ibr.Target)
 }
 
 // InstRuleSet represents a collection of instrumentation rules that apply to a

--- a/tool/internal/rule/base.go
+++ b/tool/internal/rule/base.go
@@ -108,6 +108,10 @@ func (ibr *InstBaseRule) GetTarget() string   { return ibr.Target }
 func (ibr *InstBaseRule) GetVersion() string  { return ibr.Version }
 func (ibr *InstBaseRule) GetWhere() *WhereDef { return ibr.Where }
 
+func (ibr *InstBaseRule) validateBase() error {
+	return ValidateTarget(ibr.Target)
+}
+
 // InstRuleSet represents a collection of instrumentation rules that apply to a
 // single Go package within a specific module. It acts as a container for rules,
 // organizing them by file and by the specific functions or structs they target.

--- a/tool/internal/rule/base.go
+++ b/tool/internal/rule/base.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"go.opentelemetry.io/otelc/tool/ex"
 	"go.opentelemetry.io/otelc/tool/util"
 )
 
@@ -102,6 +103,13 @@ func (ibr *InstBaseRule) GetName() string     { return ibr.Name }
 func (ibr *InstBaseRule) GetTarget() string   { return ibr.Target }
 func (ibr *InstBaseRule) GetVersion() string  { return ibr.Version }
 func (ibr *InstBaseRule) GetWhere() *WhereDef { return ibr.Where }
+
+func (ibr *InstBaseRule) validateBase() error {
+	if strings.TrimSpace(ibr.Target) == "" {
+		return ex.Newf("target cannot be empty")
+	}
+	return nil
+}
 
 // InstRuleSet represents a collection of instrumentation rules that apply to a
 // single Go package within a specific module. It acts as a container for rules,

--- a/tool/internal/rule/call_rule.go
+++ b/tool/internal/rule/call_rule.go
@@ -126,6 +126,9 @@ func NewInstCallRule(data []byte, name string) (*InstCallRule, error) {
 }
 
 func (r *InstCallRule) validate() error {
+	if err := r.validateBase(); err != nil {
+		return err
+	}
 	// FunctionCall format already validated in NewInstCallRule
 	if strings.TrimSpace(r.FunctionCall) == "" {
 		return ex.Newf("function_call cannot be empty")

--- a/tool/internal/rule/call_rule_test.go
+++ b/tool/internal/rule/call_rule_test.go
@@ -23,6 +23,7 @@ func TestNewInstCallRule(t *testing.T) {
 		{
 			name: "replace only",
 			yaml: `
+target: main
 function_call: net/http.Get
 replace: "wrapper({{ . }})"
 `,
@@ -38,6 +39,7 @@ replace: "wrapper({{ . }})"
 		{
 			name: "append_args only",
 			yaml: `
+target: main
 function_call: net/http.Get
 append_args: ["ctx"]
 `,
@@ -52,6 +54,7 @@ append_args: ["ctx"]
 		{
 			name: "append_args with variadic_type",
 			yaml: `
+target: main
 function_call: google.golang.org/grpc.Dial
 append_args: ["myOpt"]
 variadic_type: "grpc.DialOption"
@@ -65,6 +68,7 @@ variadic_type: "grpc.DialOption"
 		{
 			name: "both replace and append_args",
 			yaml: `
+target: main
 function_call: net/http.Get
 replace: "wrapper({{ . }})"
 append_args: ["ctx"]
@@ -78,6 +82,7 @@ append_args: ["ctx"]
 		{
 			name: "name from YAML overrides argument",
 			yaml: `
+target: main
 name: yaml_name
 function_call: net/http.Get
 replace: "wrapper({{ . }})"
@@ -90,6 +95,7 @@ replace: "wrapper({{ . }})"
 		{
 			name: "invalid function_call format",
 			yaml: `
+target: main
 function_call: NoPackagePath
 replace: "wrapper({{ . }})"
 `,
@@ -100,6 +106,7 @@ replace: "wrapper({{ . }})"
 		{
 			name: "neither replace nor append_args",
 			yaml: `
+target: main
 function_call: net/http.Get
 `,
 			ruleName:    "bad",
@@ -109,6 +116,7 @@ function_call: net/http.Get
 		{
 			name: "replace without placeholder",
 			yaml: `
+target: main
 function_call: net/http.Get
 replace: "noPlaceholder()"
 `,
@@ -119,6 +127,7 @@ replace: "noPlaceholder()"
 		{
 			name: "empty append_args entry",
 			yaml: `
+target: main
 function_call: net/http.Get
 append_args: [""]
 `,
@@ -129,6 +138,7 @@ append_args: [""]
 		{
 			name: "whitespace-only append_args entry",
 			yaml: `
+target: main
 function_call: net/http.Get
 append_args: ["   "]
 `,
@@ -139,6 +149,7 @@ append_args: ["   "]
 		{
 			name: "invalid replace syntax",
 			yaml: `
+target: main
 function_call: net/http.Get
 replace: "wrapper({{ . }}) {{ unclosed"
 `,
@@ -151,6 +162,28 @@ replace: "wrapper({{ . }}) {{ unclosed"
 			yaml:     `{bad yaml [`,
 			ruleName: "bad",
 			wantErr:  true,
+		},
+		{
+			name: "empty target",
+			yaml: `
+function_call: net/http.Get
+target: ""
+replace: "wrapper({{ . }})"
+`,
+			ruleName:    "bad",
+			wantErr:     true,
+			errContains: "target cannot be empty",
+		},
+		{
+			name: "whitespace-only target",
+			yaml: `
+function_call: net/http.Get
+target: "   "
+replace: "wrapper({{ . }})"
+`,
+			ruleName:    "bad",
+			wantErr:     true,
+			errContains: "target cannot be empty",
 		},
 	}
 

--- a/tool/internal/rule/decl_rule.go
+++ b/tool/internal/rule/decl_rule.go
@@ -80,6 +80,9 @@ var validDeclKinds = map[string]bool{ //nolint:gochecknoglobals // private looku
 }
 
 func (r *InstDeclRule) validate() error {
+	if err := r.validateBase(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(r.Identifier) == "" {
 		return ex.Newf("identifier cannot be empty")
 	}

--- a/tool/internal/rule/decl_rule.go
+++ b/tool/internal/rule/decl_rule.go
@@ -82,6 +82,9 @@ var validDeclKinds = map[string]bool{ //nolint:gochecknoglobals // private looku
 }
 
 func (r *InstDeclRule) validate() error {
+	if err := r.validateBase(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(r.Identifier) == "" {
 		return ex.Newf("identifier cannot be empty")
 	}

--- a/tool/internal/rule/decl_rule_test.go
+++ b/tool/internal/rule/decl_rule_test.go
@@ -246,6 +246,28 @@ replace: "int"
 			ruleName: "bad_rule",
 			wantErr:  true,
 		},
+		{
+			name: "empty target",
+			yaml: `
+target: ""
+identifier: SomeDecl
+replace: "42"
+`,
+			ruleName:    "bad_rule",
+			wantErr:     true,
+			errContains: "target cannot be empty",
+		},
+		{
+			name: "whitespace-only target",
+			yaml: `
+target: "   "
+identifier: SomeDecl
+replace: "42"
+`,
+			ruleName:    "bad_rule",
+			wantErr:     true,
+			errContains: "target cannot be empty",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/internal/rule/decl_rule_test.go
+++ b/tool/internal/rule/decl_rule_test.go
@@ -305,6 +305,28 @@ wrap: "(func(t *http.Transport) *http.Transport { return t })({{ . }})"
 			ruleName: "bad_rule",
 			wantErr:  true,
 		},
+		{
+			name: "empty target",
+			yaml: `
+target: ""
+identifier: SomeDecl
+replace: "42"
+`,
+			ruleName:    "bad_rule",
+			wantErr:     true,
+			errContains: "target cannot be empty",
+		},
+		{
+			name: "whitespace-only target",
+			yaml: `
+target: "   "
+identifier: SomeDecl
+replace: "42"
+`,
+			ruleName:    "bad_rule",
+			wantErr:     true,
+			errContains: "target cannot be empty",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/internal/rule/directive_rule.go
+++ b/tool/internal/rule/directive_rule.go
@@ -38,6 +38,9 @@ func NewInstDirectiveRule(data []byte, name string) (*InstDirectiveRule, error) 
 }
 
 func (r *InstDirectiveRule) validate() error {
+	if err := r.validateBase(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(r.Directive) == "" {
 		return ex.Newf("directive cannot be empty")
 	}

--- a/tool/internal/rule/directive_rule.go
+++ b/tool/internal/rule/directive_rule.go
@@ -37,6 +37,9 @@ func NewInstDirectiveRule(data []byte, name string) (*InstDirectiveRule, error) 
 }
 
 func (r *InstDirectiveRule) validate() error {
+	if err := r.validateBase(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(r.Directive) == "" {
 		return ex.Newf("directive cannot be empty")
 	}

--- a/tool/internal/rule/directive_rule_test.go
+++ b/tool/internal/rule/directive_rule_test.go
@@ -85,6 +85,26 @@ target: main
 			ruleName:    "prefix-directive",
 			expectError: true,
 		},
+		{
+			name: "empty target",
+			yamlContent: `
+directive: "otelc:span"
+target: ""
+template: "_ = 0"
+`,
+			ruleName:    "empty-target",
+			expectError: true,
+		},
+		{
+			name: "whitespace-only target",
+			yamlContent: `
+directive: "otelc:span"
+target: "   "
+template: "_ = 0"
+`,
+			ruleName:    "whitespace-target",
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/internal/rule/file_rule.go
+++ b/tool/internal/rule/file_rule.go
@@ -44,6 +44,9 @@ func NewInstFileRule(data []byte, name string) (*InstFileRule, error) {
 }
 
 func (r *InstFileRule) validate() error {
+	if err := r.validateBase(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(r.File) == "" {
 		return ex.Newf("file cannot be empty")
 	}

--- a/tool/internal/rule/file_rule_test.go
+++ b/tool/internal/rule/file_rule_test.go
@@ -41,6 +41,24 @@ path: github.com/example/pkg
 			yaml:    `target: example.com/pkg\nfile: my_file.go`,
 			wantErr: true,
 		},
+		{
+			name: "empty target",
+			yaml: `
+file: my_file.go
+target: ""
+path: github.com/example/pkg
+`,
+			wantErr: true,
+		},
+		{
+			name: "whitespace-only target",
+			yaml: `
+file: my_file.go
+target: "   "
+path: github.com/example/pkg
+`,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/internal/rule/func_rule.go
+++ b/tool/internal/rule/func_rule.go
@@ -82,6 +82,9 @@ func NewInstFuncRule(data []byte, name string) (*InstFuncRule, error) {
 }
 
 func (r *InstFuncRule) validate() error {
+	if err := r.validateBase(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(r.Func) == "" {
 		return ex.Newf("func cannot be empty")
 	}

--- a/tool/internal/rule/func_rule_test.go
+++ b/tool/internal/rule/func_rule_test.go
@@ -143,6 +143,16 @@ param: string
 			yaml:    `func: MyFunc\ntarget: example.com/pkg\nbefore: MyBefore`,
 			wantErr: true,
 		},
+		{
+			name:    "empty target",
+			yaml:    "func: MyFunc\ntarget: \"\"\nbefore: MyBefore\npath: example.com/pkg",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace-only target",
+			yaml:    "func: MyFunc\ntarget: \"   \"\nbefore: MyBefore\npath: example.com/pkg",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/internal/rule/raw_rule.go
+++ b/tool/internal/rule/raw_rule.go
@@ -51,6 +51,9 @@ func NewInstRawRule(data []byte, name string) (*InstRawRule, error) {
 }
 
 func (r *InstRawRule) validate() error {
+	if err := r.validateBase(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(r.Raw) == "" {
 		return ex.Newf("raw cannot be empty")
 	}

--- a/tool/internal/rule/raw_rule.go
+++ b/tool/internal/rule/raw_rule.go
@@ -49,6 +49,9 @@ func NewInstRawRule(data []byte, name string) (*InstRawRule, error) {
 }
 
 func (r *InstRawRule) validate() error {
+	if err := r.validateBase(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(r.Raw) == "" {
 		return ex.Newf("raw cannot be empty")
 	}

--- a/tool/internal/rule/raw_rule_test.go
+++ b/tool/internal/rule/raw_rule_test.go
@@ -106,6 +106,18 @@ placement: after
 			yaml:    "target: main\n  bad: [unterminated",
 			wantErr: true,
 		},
+		{
+			name:    "empty target is rejected",
+			ruleID:  "raw9",
+			yaml:    "target: \"\"\nfunc: Bar\nraw: println()",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace-only target is rejected",
+			ruleID:  "raw10",
+			yaml:    "target: \"   \"\nfunc: Bar\nraw: println()",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/internal/rule/raw_rule_test.go
+++ b/tool/internal/rule/raw_rule_test.go
@@ -125,6 +125,18 @@ raw: "println({{ .FuncArgument 0 }})"
 			yaml:    "target: main\nfunc: Bar\nraw: \"println({{ FuncArgument 0 )\"",
 			wantErr: true,
 		},
+		{
+			name:    "empty target is rejected",
+			ruleID:  "raw9",
+			yaml:    "target: \"\"\nfunc: Bar\nraw: println()",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace-only target is rejected",
+			ruleID:  "raw10",
+			yaml:    "target: \"   \"\nfunc: Bar\nraw: println()",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/internal/rule/struct_rule.go
+++ b/tool/internal/rule/struct_rule.go
@@ -48,6 +48,9 @@ func NewInstStructRule(data []byte, name string) (*InstStructRule, error) {
 }
 
 func (r *InstStructRule) validate() error {
+	if err := r.validateBase(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(r.Struct) == "" {
 		return ex.Newf("struct cannot be empty")
 	}

--- a/tool/internal/rule/struct_rule_test.go
+++ b/tool/internal/rule/struct_rule_test.go
@@ -85,6 +85,18 @@ new_field:
 			yaml:    "target: main\n  bad: [unterminated",
 			wantErr: true,
 		},
+		{
+			name:    "empty target is rejected",
+			ruleID:  "struct6",
+			yaml:    "target: \"\"\nstruct: MyStruct",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace-only target is rejected",
+			ruleID:  "struct7",
+			yaml:    "target: \"   \"\nstruct: MyStruct",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/internal/rule/target_glob.go
+++ b/tool/internal/rule/target_glob.go
@@ -32,15 +32,18 @@ func IsGlobTarget(target string) bool {
 	return strings.ContainsAny(target, globMeta)
 }
 
-// ValidateTarget rejects malformed glob targets at load time so that a bad rule
-// fails loudly during parsing rather than silently matching nothing during the
-// setup phase. Pattern syntax is bmatcuk/doublestar's; see
-// https://github.com/bmatcuk/doublestar#patterns for the full grammar.
+// ValidateTarget rejects an empty target and malformed glob targets at load
+// time so that a bad rule fails loudly during parsing rather than silently
+// matching nothing (or landing under exactRules[""] and never matching any
+// real import path) during the setup phase. Pattern syntax is
+// bmatcuk/doublestar's; see https://github.com/bmatcuk/doublestar#patterns
+// for the full grammar.
 //
-// An empty target is rejected upstream by the rule loader (parseRuleFromYaml)
-// before it reaches ValidateTarget; a non-glob target is a literal import path
-// and is always valid.
+// A non-glob, non-empty target is a literal import path and is always valid.
 func ValidateTarget(target string) error {
+	if strings.TrimSpace(target) == "" {
+		return ex.Newf("target cannot be empty")
+	}
 	if strings.Contains(strings.ToLower(target), TargetRoot) && target != TargetRoot {
 		return ex.Newf("target %q must be exactly %q", target, TargetRoot)
 	}

--- a/tool/internal/rule/target_glob_test.go
+++ b/tool/internal/rule/target_glob_test.go
@@ -59,8 +59,12 @@ func TestValidateTarget(t *testing.T) {
 	}{
 		// Exact targets are never glob-validated.
 		{name: "exact path", target: "example.com/svc"},
-		{name: "empty path", target: ""},
 		{name: "root target", target: "$root"},
+
+		// Empty (or whitespace-only) targets are always rejected: they are the
+		// sole package selector, and an empty one would silently never match.
+		{name: "empty path", target: "", wantErr: true},
+		{name: "whitespace-only path", target: "   ", wantErr: true},
 
 		// Valid glob patterns.
 		{name: "single segment star", target: "example.com/svc/*"},

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -73,22 +73,13 @@ func parseRuleFromYaml(content []byte) ([]rule.InstRule, error) {
 				return nil, ex.Wrap(err1)
 			}
 
+			// target is the sole package selector and is required (docs/rules.md).
+			// Each rule type validates it (empty check plus glob syntax) via
+			// InstBaseRule.validateBase during construction below, so no further
+			// target validation is needed here.
 			r, err2 := createRuleFromFields(raw, name, flatFields)
 			if err2 != nil {
 				return nil, err2
-			}
-			// target is the sole package selector and is required (docs/rules.md).
-			// An empty or whitespace-only target would land under exactRules[""]
-			// and silently never match any real import path, so reject it loudly
-			// at load time instead.
-			if strings.TrimSpace(r.GetTarget()) == "" {
-				return nil, ex.Newf("rule %q has an empty target; target is required", name)
-			}
-			// Reject ambiguous/invalid glob targets at load time so a bad rule
-			// fails loudly during parsing rather than silently matching nothing
-			// during the setup phase.
-			if err3 := rule.ValidateTarget(r.GetTarget()); err3 != nil {
-				return nil, ex.Wrapf(err3, "rule %q", name)
 			}
 			if err3 := util.ValidateVersionRange(r.GetVersion()); err3 != nil {
 				return nil, ex.Wrapf(err3, "rule %q", name)

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -76,22 +76,13 @@ func parseRuleFromYaml(content []byte) ([]rule.InstRule, error) {
 				return nil, ex.Wrap(err1)
 			}
 
+			// target is the sole package selector and is required (docs/rules.md).
+			// Each rule type validates it (empty check plus glob syntax) via
+			// InstBaseRule.validateBase during construction below, so no further
+			// target validation is needed here.
 			r, err2 := createRuleFromFields(raw, name, flatFields)
 			if err2 != nil {
 				return nil, err2
-			}
-			// target is the sole package selector and is required (docs/rules.md).
-			// An empty or whitespace-only target would land under exactRules[""]
-			// and silently never match any real import path, so reject it loudly
-			// at load time instead.
-			if strings.TrimSpace(r.GetTarget()) == "" {
-				return nil, ex.Newf("rule %q has an empty target; target is required", name)
-			}
-			// Reject ambiguous/invalid glob targets at load time so a bad rule
-			// fails loudly during parsing rather than silently matching nothing
-			// during the setup phase.
-			if err3 := rule.ValidateTarget(r.GetTarget()); err3 != nil {
-				return nil, ex.Wrapf(err3, "rule %q", name)
 			}
 			if err3 := util.ValidateVersionRange(r.GetVersion()); err3 != nil {
 				return nil, ex.Wrapf(err3, "rule %q", name)

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -1488,7 +1488,8 @@ func TestMatchDeps_InvalidGlobTargetRejected(t *testing.T) {
 
 func TestMatchDeps_EmptyTargetRejected(t *testing.T) {
 	// target is required: an empty (or whitespace-only) target would land under
-	// exactRules[""] and silently never match, so the loader must reject it at
+	// exactRules[""] and silently never match, so rule.ValidateTarget (invoked
+	// via InstBaseRule.validateBase during rule construction) must reject it at
 	// load time rather than accepting a rule that can never fire.
 	dir := t.TempDir()
 	ruleFile := filepath.Join(dir, "empty.yaml")
@@ -1509,7 +1510,7 @@ func TestMatchDeps_EmptyTargetRejected(t *testing.T) {
 
 	_, err = sp.matchDeps(context.Background(), deps, nil)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "empty target")
+	require.ErrorContains(t, err, "target cannot be empty")
 }
 
 func TestMatchDeps_NoMatchesWarning(t *testing.T) {

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -1522,7 +1522,8 @@ func TestMatchDeps_InvalidGlobTargetRejected(t *testing.T) {
 
 func TestMatchDeps_EmptyTargetRejected(t *testing.T) {
 	// target is required: an empty (or whitespace-only) target would land under
-	// exactRules[""] and silently never match, so the loader must reject it at
+	// exactRules[""] and silently never match, so rule.ValidateTarget (invoked
+	// via InstBaseRule.validateBase during rule construction) must reject it at
 	// load time rather than accepting a rule that can never fire.
 	dir := t.TempDir()
 	ruleFile := filepath.Join(dir, "empty.yaml")
@@ -1543,7 +1544,7 @@ func TestMatchDeps_EmptyTargetRejected(t *testing.T) {
 
 	_, err = sp.matchDeps(context.Background(), deps, nil)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "empty target")
+	require.ErrorContains(t, err, "target cannot be empty")
 }
 
 func TestMatchDeps_NoMatchesWarning(t *testing.T) {


### PR DESCRIPTION
## Description

When loading instrumentation rules from YAML, `validate()` methods in `tool/internal/rule` validated specific fields like `func`, `path`, `raw`, `struct`, `directive`, `file`, etc., but failed to validate that `target` is non-empty. If a YAML rule configuration omitted the `target` field, constructors like `NewInstFuncRule` or `NewInstCallRule` succeeded, passing setup validation and failing silently later at package matching time.

This PR adds a `validateBase()` method in `tool/internal/rule/base.go` to validate that `r.Target` is non-empty and non-whitespace, and invokes `validateBase()` from the `validate()` method of all rule implementations (`InstFuncRule`, `InstRawRule`, `InstStructRule`, `InstCallRule`, `InstDeclRule`, `InstDirectiveRule`, `InstFileRule`).

Additionally, unit tests were updated and added across `tool/internal/rule/*_test.go` (including creating `raw_rule_test.go` and `struct_rule_test.go`) to ensure all rule constructors return validation errors when `target` is missing or whitespace.

## Motivation

Ensures malformed rules missing a required `target` field fail early with a clear validation error during rule loading instead of failing silently later during package matching.

Fixes #796

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))
