### PR TITLE
fix(tool/instrument): safely handle non-value AST nodes in decl rules

### DIFF
--- a/tool/internal/instrument/apply_decl.go
+++ b/tool/internal/instrument/apply_decl.go
@@ -45,7 +45,10 @@ func (ip *InstrumentPhase) applyDeclRule(ctx context.Context, r *rule.InstDeclRu
 		return err
 	}
 
-	spec := util.AssertType[*dst.ValueSpec](node)
+	spec, ok := node.(*dst.ValueSpec)
+	if !ok {
+		return ex.Newf("declaration %q (kind: %q) is not a var or const declaration", r.Identifier, r.Kind)
+	}
 
 	if r.Wrap != "" {
 		if err := wrapDeclValues(spec, r.Wrap); err != nil {

--- a/tool/internal/instrument/apply_decl_test.go
+++ b/tool/internal/instrument/apply_decl_test.go
@@ -175,3 +175,27 @@ func TestApplyDeclRule_WrapExpression_NoInitializer(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "wrap requires an existing initializer")
 }
+
+func TestApplyDeclRule_EmptyKind_FunctionTarget(t *testing.T) {
+	file := &dst.File{
+		Name: &dst.Ident{Name: "main"},
+		Decls: []dst.Decl{
+			&dst.FuncDecl{
+				Name: &dst.Ident{Name: "DefaultHandler"},
+				Type: &dst.FuncType{},
+			},
+		},
+	}
+	r := &rule.InstDeclRule{
+		InstBaseRule: rule.InstBaseRule{Name: "replace_handler"},
+		Kind:         "",
+		Identifier:   "DefaultHandler",
+		Replace:      "CustomHandler",
+	}
+
+	err := newTestPhase().applyDeclRule(context.Background(), r, file)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not a var or const declaration")
+}
+

--- a/tool/internal/instrument/apply_decl_test.go
+++ b/tool/internal/instrument/apply_decl_test.go
@@ -198,4 +198,3 @@ func TestApplyDeclRule_EmptyKind_FunctionTarget(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "is not a var or const declaration")
 }
-


### PR DESCRIPTION
## Description

When an `InstDeclRule` is defined with an empty or omitted `kind`, rule validation permits it. However, at apply time, if the targeted identifier in the package happens to be a top-level function (`*dst.FuncDecl`) or type declaration (`*dst.GenDecl`), `ast.FindNamedDecl(root, identifier, "")` returns that node.

Previously, `applyDeclRule` executed an unconditional type assertion `util.AssertType[*dst.ValueSpec](node)`, which immediately fatals with an assertion error (`expected *dst.ValueSpec, got *dst.FuncDecl`).

This PR replaces the unconditional assertion with a checked type assertion returning a descriptive error when the matched node is not a `var` or `const` value spec, and adds test coverage in `apply_decl_test.go`.

## Motivation

Fixes #813

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [x] Documentation updated (if applicable)
