### PR TITLE
fix(tool): implement isSetup check to skip redundant setup

### DIFF
--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -62,8 +62,7 @@ func keepForDebug(ctx context.Context, srcPath string) {
 
 // This function can be used to check if the setup has been completed.
 func isSetup() bool {
-	// TODO: Implement Task
-	return false
+	return util.PathExists(util.GetMatchedRuleFile())
 }
 
 // flagsWithPathValues contains flags that accept a value from "go build" command.

--- a/tool/internal/setup/setup_test.go
+++ b/tool/internal/setup/setup_test.go
@@ -547,3 +547,23 @@ func TestExtractBuildFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSetup(t *testing.T) {
+	setupTestModule(t, []string{})
+
+	// Initially, setup should not be completed
+	assert.False(t, isSetup())
+
+	// Create matched.json inside .otelc-build/
+	matchedFile := util.GetMatchedRuleFile()
+	require.NoError(t, os.MkdirAll(filepath.Dir(matchedFile), 0o755))
+	require.NoError(t, os.WriteFile(matchedFile, []byte("[]"), 0o644))
+
+	// Now it should return true
+	assert.True(t, isSetup())
+
+	// Clean up and it should return false again
+	require.NoError(t, os.Remove(matchedFile))
+	assert.False(t, isSetup())
+}
+


### PR DESCRIPTION
Implement the isSetup() helper in tool/internal/setup/setup.go to check if the setup phase has already been run and completed, by verifying if matched.json exists in the build temporary directory. Also, add a TestIsSetup unit test in setup_test.go to cover this.

Fixes #817 

## Description

- Implements `isSetup()` in `tool/internal/setup/setup.go` by verifying the existence of `matched.json` via `util.PathExists()`.
- Appends `TestIsSetup` to `tool/internal/setup/setup_test.go` to validate both initial and completed setup states.

## Motivation

The `isSetup()` check was previously unimplemented (returning `false` by default). This change allows the CLI to detect when setup has already completed successfully (indicated by the presence of the matched rules output file `matched.json`) and skip the setup phase on subsequent runs.

Fixes # <!-- Add the issue number here once you create it on GitHub -->

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format` (All Go code formatted successfully)
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test` (All local unit tests build and pass)
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))
