### PR TITLE
fix(instrumentation): make openai getProviderName deterministic

### DIFF
--- a/instrumentation/github.com/openai/openai-go/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/middleware.go
@@ -25,36 +25,43 @@ const (
 	maxResponseBodySize = 4 << 20 // 4 MB
 )
 
-var providerMapping = map[string]string{
-	"openai.com":         "openai",
-	"azure.com":          "azure",
-	"anthropic.com":      "anthropic",
-	"dashscope.aliyuncs": "qwen",
-	"volces.com":         "ark",
-	"ark.cn":             "ark",
-	"hunyuan":            "tencent",
-	"tencentcloudapi":    "tencent",
-	"googleapis.com":     "google",
-	"generativelanguage": "google",
-	"deepseek.com":       "deepseek",
-	"moonshot":           "moonshot",
-	"zhipuai.cn":         "zhipu",
-	"bigmodel.cn":        "zhipu",
-	"baidu.com":          "baidu",
-	"minimax":            "minimax",
-	"siliconflow":        "siliconflow",
-	"together":           "together",
-	"mistral":            "mistral",
-	"groq.com":           "groq",
-	"ollama":             "ollama",
-	"localhost":          "local",
-	"127.0.0.1":          "local",
+// providerRules is ordered, not a map: getProviderName does first-match-wins
+// substring matching, and Go randomizes map iteration order on every range.
+// A host matching more than one keyword (e.g. behind a gateway that embeds
+// several provider names) must still resolve to the same provider every time.
+var providerRules = []struct {
+	keyword  string
+	provider string
+}{
+	{"openai.com", "openai"},
+	{"azure.com", "azure"},
+	{"anthropic.com", "anthropic"},
+	{"dashscope.aliyuncs", "qwen"},
+	{"volces.com", "ark"},
+	{"ark.cn", "ark"},
+	{"hunyuan", "tencent"},
+	{"tencentcloudapi", "tencent"},
+	{"googleapis.com", "google"},
+	{"generativelanguage", "google"},
+	{"deepseek.com", "deepseek"},
+	{"moonshot", "moonshot"},
+	{"zhipuai.cn", "zhipu"},
+	{"bigmodel.cn", "zhipu"},
+	{"baidu.com", "baidu"},
+	{"minimax", "minimax"},
+	{"siliconflow", "siliconflow"},
+	{"together", "together"},
+	{"mistral", "mistral"},
+	{"groq.com", "groq"},
+	{"ollama", "ollama"},
+	{"localhost", "local"},
+	{"127.0.0.1", "local"},
 }
 
 func getProviderName(host string) string {
-	for keyword, provider := range providerMapping {
-		if strings.Contains(host, keyword) {
-			return provider
+	for _, rule := range providerRules {
+		if strings.Contains(host, rule.keyword) {
+			return rule.provider
 		}
 	}
 	return "openai"

--- a/instrumentation/github.com/openai/openai-go/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/middleware_test.go
@@ -52,6 +52,18 @@ func TestGetProviderName(t *testing.T) {
 	}
 }
 
+// TestGetProviderNameDeterministic guards against a regression to map-based
+// matching: a host that contains more than one provider keyword must resolve
+// to the same provider on every call, not vary with Go's randomized map
+// iteration order.
+func TestGetProviderNameDeterministic(t *testing.T) {
+	host := "litellm-gateway.mistral-together-proxy.internal"
+	want := getProviderName(host)
+	for i := 0; i < 50; i++ {
+		assert.Equal(t, want, getProviderName(host))
+	}
+}
+
 func TestOperationName(t *testing.T) {
 	assert.Equal(t, "chat", operationName(opChat))
 	assert.Equal(t, "text_completion", operationName(opCompletion))

--- a/instrumentation/github.com/openai/openai-go/v2/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/v2/middleware.go
@@ -25,36 +25,43 @@ const (
 	maxResponseBodySize = 4 << 20 // 4 MB
 )
 
-var providerMapping = map[string]string{
-	"openai.com":         "openai",
-	"azure.com":          "azure",
-	"anthropic.com":      "anthropic",
-	"dashscope.aliyuncs": "qwen",
-	"volces.com":         "ark",
-	"ark.cn":             "ark",
-	"hunyuan":            "tencent",
-	"tencentcloudapi":    "tencent",
-	"googleapis.com":     "google",
-	"generativelanguage": "google",
-	"deepseek.com":       "deepseek",
-	"moonshot":           "moonshot",
-	"zhipuai.cn":         "zhipu",
-	"bigmodel.cn":        "zhipu",
-	"baidu.com":          "baidu",
-	"minimax":            "minimax",
-	"siliconflow":        "siliconflow",
-	"together":           "together",
-	"mistral":            "mistral",
-	"groq.com":           "groq",
-	"ollama":             "ollama",
-	"localhost":          "local",
-	"127.0.0.1":          "local",
+// providerRules is ordered, not a map: getProviderName does first-match-wins
+// substring matching, and Go randomizes map iteration order on every range.
+// A host matching more than one keyword (e.g. behind a gateway that embeds
+// several provider names) must still resolve to the same provider every time.
+var providerRules = []struct {
+	keyword  string
+	provider string
+}{
+	{"openai.com", "openai"},
+	{"azure.com", "azure"},
+	{"anthropic.com", "anthropic"},
+	{"dashscope.aliyuncs", "qwen"},
+	{"volces.com", "ark"},
+	{"ark.cn", "ark"},
+	{"hunyuan", "tencent"},
+	{"tencentcloudapi", "tencent"},
+	{"googleapis.com", "google"},
+	{"generativelanguage", "google"},
+	{"deepseek.com", "deepseek"},
+	{"moonshot", "moonshot"},
+	{"zhipuai.cn", "zhipu"},
+	{"bigmodel.cn", "zhipu"},
+	{"baidu.com", "baidu"},
+	{"minimax", "minimax"},
+	{"siliconflow", "siliconflow"},
+	{"together", "together"},
+	{"mistral", "mistral"},
+	{"groq.com", "groq"},
+	{"ollama", "ollama"},
+	{"localhost", "local"},
+	{"127.0.0.1", "local"},
 }
 
 func getProviderName(host string) string {
-	for keyword, provider := range providerMapping {
-		if strings.Contains(host, keyword) {
-			return provider
+	for _, rule := range providerRules {
+		if strings.Contains(host, rule.keyword) {
+			return rule.provider
 		}
 	}
 	return "openai"

--- a/instrumentation/github.com/openai/openai-go/v2/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/v2/middleware_test.go
@@ -52,6 +52,18 @@ func TestGetProviderName(t *testing.T) {
 	}
 }
 
+// TestGetProviderNameDeterministic guards against a regression to map-based
+// matching: a host that contains more than one provider keyword must resolve
+// to the same provider on every call, not vary with Go's randomized map
+// iteration order.
+func TestGetProviderNameDeterministic(t *testing.T) {
+	host := "litellm-gateway.mistral-together-proxy.internal"
+	want := getProviderName(host)
+	for i := 0; i < 50; i++ {
+		assert.Equal(t, want, getProviderName(host))
+	}
+}
+
 func TestOperationName(t *testing.T) {
 	assert.Equal(t, "chat", operationName(opChat))
 	assert.Equal(t, "text_completion", operationName(opCompletion))

--- a/instrumentation/github.com/openai/openai-go/v3/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/v3/middleware.go
@@ -25,36 +25,43 @@ const (
 	maxResponseBodySize = 4 << 20 // 4 MB
 )
 
-var providerMapping = map[string]string{
-	"openai.com":         "openai",
-	"azure.com":          "azure",
-	"anthropic.com":      "anthropic",
-	"dashscope.aliyuncs": "qwen",
-	"volces.com":         "ark",
-	"ark.cn":             "ark",
-	"hunyuan":            "tencent",
-	"tencentcloudapi":    "tencent",
-	"googleapis.com":     "google",
-	"generativelanguage": "google",
-	"deepseek.com":       "deepseek",
-	"moonshot":           "moonshot",
-	"zhipuai.cn":         "zhipu",
-	"bigmodel.cn":        "zhipu",
-	"baidu.com":          "baidu",
-	"minimax":            "minimax",
-	"siliconflow":        "siliconflow",
-	"together":           "together",
-	"mistral":            "mistral",
-	"groq.com":           "groq",
-	"ollama":             "ollama",
-	"localhost":          "local",
-	"127.0.0.1":          "local",
+// providerRules is ordered, not a map: getProviderName does first-match-wins
+// substring matching, and Go randomizes map iteration order on every range.
+// A host matching more than one keyword (e.g. behind a gateway that embeds
+// several provider names) must still resolve to the same provider every time.
+var providerRules = []struct {
+	keyword  string
+	provider string
+}{
+	{"openai.com", "openai"},
+	{"azure.com", "azure"},
+	{"anthropic.com", "anthropic"},
+	{"dashscope.aliyuncs", "qwen"},
+	{"volces.com", "ark"},
+	{"ark.cn", "ark"},
+	{"hunyuan", "tencent"},
+	{"tencentcloudapi", "tencent"},
+	{"googleapis.com", "google"},
+	{"generativelanguage", "google"},
+	{"deepseek.com", "deepseek"},
+	{"moonshot", "moonshot"},
+	{"zhipuai.cn", "zhipu"},
+	{"bigmodel.cn", "zhipu"},
+	{"baidu.com", "baidu"},
+	{"minimax", "minimax"},
+	{"siliconflow", "siliconflow"},
+	{"together", "together"},
+	{"mistral", "mistral"},
+	{"groq.com", "groq"},
+	{"ollama", "ollama"},
+	{"localhost", "local"},
+	{"127.0.0.1", "local"},
 }
 
 func getProviderName(host string) string {
-	for keyword, provider := range providerMapping {
-		if strings.Contains(host, keyword) {
-			return provider
+	for _, rule := range providerRules {
+		if strings.Contains(host, rule.keyword) {
+			return rule.provider
 		}
 	}
 	return "openai"

--- a/instrumentation/github.com/openai/openai-go/v3/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/v3/middleware_test.go
@@ -52,6 +52,18 @@ func TestGetProviderName(t *testing.T) {
 	}
 }
 
+// TestGetProviderNameDeterministic guards against a regression to map-based
+// matching: a host that contains more than one provider keyword must resolve
+// to the same provider on every call, not vary with Go's randomized map
+// iteration order.
+func TestGetProviderNameDeterministic(t *testing.T) {
+	host := "litellm-gateway.mistral-together-proxy.internal"
+	want := getProviderName(host)
+	for i := 0; i < 50; i++ {
+		assert.Equal(t, want, getProviderName(host))
+	}
+}
+
 func TestOperationName(t *testing.T) {
 	assert.Equal(t, "chat", operationName(opChat))
 	assert.Equal(t, "text_completion", operationName(opCompletion))


### PR DESCRIPTION
## Description

`getProviderName()` in the OpenAI GenAI instrumentation picks a provider by scanning `providerMapping`, a `map[string]string` of hostname keywords, and returning the first substring match it finds. Go doesn't guarantee map iteration order, so a host that happens to contain more than one keyword can get tagged with a different `gen_ai.provider.name` on different calls for the exact same request.

## Motivation

This logic is duplicated identically across the v1, v2, and v3 middleware files, so the same nondeterminism exists in all three. Fixed it by replacing the map with an ordered slice of keyword/provider pairs, so "first match wins" is actually well-defined instead of depending on map iteration order.

Added a test (`TestGetProviderNameDeterministic`) that repeats the lookup 50 times against a host matching two keywords (`mistral` and `together`) and checks the result stays constant, in addition to the existing `TestGetProviderName` cases.


---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [ ] Linters pass: `make lint` (golangci-lint on this machine is built against an older Go than the module targets; CI will run this)
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))
