### PR TITLE
docs: fix otelc demo path in getting-started and net/http README typo

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ No manual code changes required.
 
    ```bash
    cd demo/app/basic
-   ../../otelc go build
+   ../../../otelc go build
    ./basic
    ```
 

--- a/instrumentation/net/http/README.md
+++ b/instrumentation/net/http/README.md
@@ -271,7 +271,7 @@ Service A: HTTP GET
 ```go
 func BeforeRoundTrip(ictx hook.HookContext, transport *http.Transport, req *http.Request) {
     // 1. Check if instrumentation is enabled
-    // 2. Filter out OTel exporter requests (prevent infinite loops)inst.HookContext
+    // 2. Filter out OTel exporter requests (prevent infinite loops)
     // 3. Build NetHttpRequest from http.Request
     // 4. Start instrumentation span
     // 5. Inject trace context into headers


### PR DESCRIPTION
## Summary
- Fix the relative path to `otelc` in the quick-start demo in `docs/getting-started.md`. After `make build`, `otelc` sits at the repo root; from `demo/app/basic` that's three levels up (`../../../otelc`), not two.
- Remove a stray `inst.HookContext` fragment merged onto the end of a comment line in the `BeforeRoundTrip` example in `instrumentation/net/http/README.md`.

Fixes #771

## Test plan
- Docs-only change, no code affected.
- Verified the corrected quick-start command by checking the actual location of the `otelc` binary relative to `demo/app/basic` after `make build`.
- Visually confirmed the comment in `instrumentation/net/http/README.md` now reads correctly as a 7-step list.