### PR TITLE
refactor(tool/rule): central registry of valid selectors and modifiers

### DIFF
--- a/tool/internal/rule/normalize.go
+++ b/tool/internal/rule/normalize.go
@@ -10,48 +10,6 @@ import (
 	"go.opentelemetry.io/otelc/tool/util"
 )
 
-// Structured top-level keys.
-const (
-	KeyWhere = "where"
-	KeyDo    = "do"
-)
-
-// where selectors (hoisted to flat by normalizeWhere).
-const (
-	SelTarget       = "target"
-	SelVersion      = "version"
-	SelFunc         = "func"
-	SelRecv         = "recv"
-	SelStruct       = "struct"
-	SelFunctionCall = "function_call"
-	SelDirective    = "directive"
-	SelKind         = "kind"
-	SelIdentifier   = "identifier"
-
-	// Signature match-narrowing selectors for func rules (see InstFuncRule).
-	SelSignature         = "signature"
-	SelSignatureContains = "signature_contains"
-	SelResult            = "result"
-	SelLastResult        = "last_result"
-	SelParam             = "param"
-
-	// Raw match-narrowing selector for raw rules (see InstRawRule).
-	SelPattern   = "pattern"
-	SelPlacement = "placement"
-)
-
-// where sub-groups / combinators (preserved nested under flat).
-const (
-	WhereFile = "file"
-	CombAllOf = "all-of"
-	CombOneOf = "one-of"
-	CombNot   = "not"
-)
-
-// RawField is the modifier-output key produced by normalize for raw rules.
-// It is not a where selector; exposed here so match.go can share the literal.
-const RawField = "raw"
-
 // Normalize detects the structured target/version + where + do format defined
 // in ADR-0003 and expands it into one or more flat rule maps expected by the
 // existing rule constructors. If the fields map contains neither "where" nor
@@ -159,6 +117,9 @@ func normalizeWhere(common, where map[string]any) (map[string]any, error) {
 
 	normalized := make(map[string]any)
 	for key, value := range where {
+		if !IsValidSelector(key) {
+			return nil, ex.Newf("unsupported where key %q", key)
+		}
 		switch key {
 		case SelFunc, SelRecv, SelStruct, SelFunctionCall, SelDirective, SelKind, SelIdentifier,
 			SelSignature, SelSignatureContains, SelResult, SelLastResult, SelParam,
@@ -172,6 +133,8 @@ func normalizeWhere(common, where map[string]any) (map[string]any, error) {
 		case CombAllOf, CombOneOf, CombNot:
 			normalized[key] = value
 		default:
+			// IsValidSelector includes target/version, which are rejected above,
+			// and any future registry entry must be handled explicitly here.
 			return nil, ex.Newf("unsupported where key %q", key)
 		}
 	}
@@ -211,7 +174,10 @@ func normalizeDoSequence(items []any) ([]map[string]any, error) {
 		if len(modifierMap) != 1 {
 			return nil, ex.Newf("do[%d] must contain exactly one modifier key", idx)
 		}
-		for _, modifierRaw := range modifierMap {
+		for modifierName, modifierRaw := range modifierMap {
+			if !IsValidModifier(modifierName) {
+				return nil, ex.Newf("do[%d]: unsupported modifier %q", idx, modifierName)
+			}
 			modifierFields, hasModifierFields := modifierRaw.(map[string]any)
 			if !hasModifierFields {
 				return nil, ex.Newf("do[%d] modifier payload must be a map", idx)
@@ -233,7 +199,10 @@ func normalizeDoMap(modifier map[string]any) ([]map[string]any, error) {
 				"use the sequence form for multiple modifiers",
 		)
 	}
-	for _, modifierRaw := range modifier {
+	for modifierName, modifierRaw := range modifier {
+		if !IsValidModifier(modifierName) {
+			return nil, ex.Newf("unsupported modifier %q", modifierName)
+		}
 		modifierFields, ok := modifierRaw.(map[string]any)
 		if !ok {
 			return nil, ex.Newf("do modifier payload must be a map")

--- a/tool/internal/rule/normalize_test.go
+++ b/tool/internal/rule/normalize_test.go
@@ -405,6 +405,36 @@ func TestNormalize_Errors(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "unsupported do modifier map form",
+			fields: map[string]any{
+				"target": "database/sql",
+				"where": map[string]any{
+					"func": "Open",
+				},
+				"do": map[string]any{
+					"inject_hook": map[string]any{
+						"before": "BeforeOpen",
+					},
+				},
+			},
+		},
+		{
+			name: "unsupported do modifier sequence form",
+			fields: map[string]any{
+				"target": "database/sql",
+				"where": map[string]any{
+					"func": "Open",
+				},
+				"do": []any{
+					map[string]any{
+						"raw_inject": map[string]any{
+							"raw": "_ = 1",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/internal/rule/schema.go
+++ b/tool/internal/rule/schema.go
@@ -12,7 +12,7 @@ type Selector string
 // per docs/rules.md, declares the rule type.
 type Modifier string
 
-// Point selectors that may appear under where (or as legacy flat fields).
+// Selector keys in the structured rule schema (where selectors, file/combinator keys, plus top-level target/version).
 const (
 	SelectorTarget            Selector = "target"
 	SelectorVersion           Selector = "version"
@@ -74,7 +74,7 @@ const (
 	CombNot   = string(SelectorNot)
 
 	// RawField is the modifier-output key produced by normalize for raw rules
-	// (inject_code payload). It is not a where selector; match.go shares it.
+	// (inject_code payload). It is not a where selector; tool/internal/setup/match.go shares it.
 	RawField = "raw"
 )
 
@@ -88,40 +88,27 @@ const (
 // file group, and combinators). target/version are intentionally included so
 // IsValidSelector can distinguish "known but misplaced" from "unknown";
 // normalizeWhere still rejects them inside where.
-var selectors = map[Selector]struct{}{
-	SelectorTarget:            {},
-	SelectorVersion:           {},
-	SelectorFunc:              {},
-	SelectorRecv:              {},
-	SelectorStruct:            {},
-	SelectorFunctionCall:      {},
-	SelectorDirective:         {},
-	SelectorKind:              {},
-	SelectorIdentifier:        {},
-	SelectorSignature:         {},
-	SelectorSignatureContains: {},
-	SelectorResult:            {},
-	SelectorLastResult:        {},
-	SelectorParam:             {},
-	SelectorPattern:           {},
-	SelectorPlacement:         {},
-	SelectorFile:              {},
-	SelectorAllOf:             {},
-	SelectorOneOf:             {},
-	SelectorNot:               {},
+
+//nolint:gochecknoglobals // lookup set derived from AllSelectors(); intentionally package-level so IsValidSelector can query it without reconstruction
+var selectors = toSet(AllSelectors())
+
+// toSet builds a lookup set from an ordered slice, so the set can never
+// drift from the slice it is derived from.
+func toSet[T comparable](items []T) map[T]struct{} {
+	set := make(map[T]struct{}, len(items))
+	for _, item := range items {
+		set[item] = struct{}{}
+	}
+	return set
 }
 
-var modifiers = map[Modifier]struct{}{
-	ModifierInjectHooks:     {},
-	ModifierInjectCode:      {},
-	ModifierAddStructFields: {},
-	ModifierAddFile:         {},
-	ModifierWrapCall:        {},
-	ModifierExpandDirective: {},
-	ModifierAssignValue:     {},
-}
+//nolint:gochecknoglobals // lookup set derived from AllModifiers(); intentionally package-level so IsValidModifier can query it without reconstruction
+var modifiers = toSet(AllModifiers())
 
-// IsValidSelector reports whether s is a known where-clause key.
+// IsValidSelector reports whether s is part of the rule schema's selector
+// vocabulary. This includes target/version, which are valid selectors but
+// are rejected specifically when used inside a where block — see
+// normalizeWhere.
 func IsValidSelector(s string) bool {
 	_, ok := selectors[Selector(s)]
 	return ok

--- a/tool/internal/rule/schema.go
+++ b/tool/internal/rule/schema.go
@@ -1,0 +1,173 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rule
+
+// Selector is a where-clause key recognized by the structured rule schema
+// (ADR-0003). Point selectors are hoisted to flat fields by Normalize; file
+// and combinator keys stay nested under where.
+type Selector string
+
+// Modifier is a do-clause key that names the instrumentation action and,
+// per docs/rules.md, declares the rule type.
+type Modifier string
+
+// Point selectors that may appear under where (or as legacy flat fields).
+const (
+	SelectorTarget            Selector = "target"
+	SelectorVersion           Selector = "version"
+	SelectorFunc              Selector = "func"
+	SelectorRecv              Selector = "recv"
+	SelectorStruct            Selector = "struct"
+	SelectorFunctionCall      Selector = "function_call"
+	SelectorDirective         Selector = "directive"
+	SelectorKind              Selector = "kind"
+	SelectorIdentifier        Selector = "identifier"
+	SelectorSignature         Selector = "signature"
+	SelectorSignatureContains Selector = "signature_contains"
+	SelectorResult            Selector = "result"
+	SelectorLastResult        Selector = "last_result"
+	SelectorParam             Selector = "param"
+	SelectorPattern           Selector = "pattern"
+	SelectorPlacement         Selector = "placement"
+	SelectorFile              Selector = "file"
+	SelectorAllOf             Selector = "all-of"
+	SelectorOneOf             Selector = "one-of"
+	SelectorNot               Selector = "not"
+)
+
+// do modifiers (docs/rules.md § modifier names → rule types).
+const (
+	ModifierInjectHooks     Modifier = "inject_hooks"
+	ModifierInjectCode      Modifier = "inject_code"
+	ModifierAddStructFields Modifier = "add_struct_fields"
+	ModifierAddFile         Modifier = "add_file"
+	ModifierWrapCall        Modifier = "wrap_call"
+	ModifierExpandDirective Modifier = "expand_directive"
+	ModifierAssignValue     Modifier = "assign_value"
+)
+
+// String forms used as YAML / map keys. Existing call sites (normalize,
+// match) keep using these aliases so the registry is a single source of truth
+// without forcing every consumer onto the typed Selector/Modifier APIs.
+const (
+	SelTarget            = string(SelectorTarget)
+	SelVersion           = string(SelectorVersion)
+	SelFunc              = string(SelectorFunc)
+	SelRecv              = string(SelectorRecv)
+	SelStruct            = string(SelectorStruct)
+	SelFunctionCall      = string(SelectorFunctionCall)
+	SelDirective         = string(SelectorDirective)
+	SelKind              = string(SelectorKind)
+	SelIdentifier        = string(SelectorIdentifier)
+	SelSignature         = string(SelectorSignature)
+	SelSignatureContains = string(SelectorSignatureContains)
+	SelResult            = string(SelectorResult)
+	SelLastResult        = string(SelectorLastResult)
+	SelParam             = string(SelectorParam)
+	SelPattern           = string(SelectorPattern)
+	SelPlacement         = string(SelectorPlacement)
+
+	WhereFile = string(SelectorFile)
+	CombAllOf = string(SelectorAllOf)
+	CombOneOf = string(SelectorOneOf)
+	CombNot   = string(SelectorNot)
+
+	// RawField is the modifier-output key produced by normalize for raw rules
+	// (inject_code payload). It is not a where selector; match.go shares it.
+	RawField = "raw"
+)
+
+// Structured top-level keys.
+const (
+	KeyWhere = "where"
+	KeyDo    = "do"
+)
+
+// selectors lists every key that may appear inside where (point selectors,
+// file group, and combinators). target/version are intentionally included so
+// IsValidSelector can distinguish "known but misplaced" from "unknown";
+// normalizeWhere still rejects them inside where.
+var selectors = map[Selector]struct{}{
+	SelectorTarget:            {},
+	SelectorVersion:           {},
+	SelectorFunc:              {},
+	SelectorRecv:              {},
+	SelectorStruct:            {},
+	SelectorFunctionCall:      {},
+	SelectorDirective:         {},
+	SelectorKind:              {},
+	SelectorIdentifier:        {},
+	SelectorSignature:         {},
+	SelectorSignatureContains: {},
+	SelectorResult:            {},
+	SelectorLastResult:        {},
+	SelectorParam:             {},
+	SelectorPattern:           {},
+	SelectorPlacement:         {},
+	SelectorFile:              {},
+	SelectorAllOf:             {},
+	SelectorOneOf:             {},
+	SelectorNot:               {},
+}
+
+var modifiers = map[Modifier]struct{}{
+	ModifierInjectHooks:     {},
+	ModifierInjectCode:      {},
+	ModifierAddStructFields: {},
+	ModifierAddFile:         {},
+	ModifierWrapCall:        {},
+	ModifierExpandDirective: {},
+	ModifierAssignValue:     {},
+}
+
+// IsValidSelector reports whether s is a known where-clause key.
+func IsValidSelector(s string) bool {
+	_, ok := selectors[Selector(s)]
+	return ok
+}
+
+// IsValidModifier reports whether s is a known do-clause modifier name.
+func IsValidModifier(s string) bool {
+	_, ok := modifiers[Modifier(s)]
+	return ok
+}
+
+// AllSelectors returns every registered where selector in a stable order.
+func AllSelectors() []Selector {
+	return []Selector{
+		SelectorTarget,
+		SelectorVersion,
+		SelectorFunc,
+		SelectorRecv,
+		SelectorStruct,
+		SelectorFunctionCall,
+		SelectorDirective,
+		SelectorKind,
+		SelectorIdentifier,
+		SelectorSignature,
+		SelectorSignatureContains,
+		SelectorResult,
+		SelectorLastResult,
+		SelectorParam,
+		SelectorPattern,
+		SelectorPlacement,
+		SelectorFile,
+		SelectorAllOf,
+		SelectorOneOf,
+		SelectorNot,
+	}
+}
+
+// AllModifiers returns every registered do modifier in a stable order.
+func AllModifiers() []Modifier {
+	return []Modifier{
+		ModifierInjectHooks,
+		ModifierInjectCode,
+		ModifierAddStructFields,
+		ModifierAddFile,
+		ModifierWrapCall,
+		ModifierExpandDirective,
+		ModifierAssignValue,
+	}
+}

--- a/tool/internal/rule/schema_test.go
+++ b/tool/internal/rule/schema_test.go
@@ -56,14 +56,47 @@ func TestAllModifiersComplete(t *testing.T) {
 }
 
 func TestStringAliasesMatchTypedConstants(t *testing.T) {
-	assert.Equal(t, string(SelectorFunc), SelFunc)
-	assert.Equal(t, string(SelectorFile), WhereFile)
-	assert.Equal(t, string(SelectorAllOf), CombAllOf)
-	assert.Equal(t, string(ModifierInjectHooks), "inject_hooks")
-	assert.Equal(t, string(ModifierInjectCode), "inject_code")
-	assert.Equal(t, string(ModifierAddStructFields), "add_struct_fields")
-	assert.Equal(t, string(ModifierAddFile), "add_file")
-	assert.Equal(t, string(ModifierWrapCall), "wrap_call")
-	assert.Equal(t, string(ModifierExpandDirective), "expand_directive")
-	assert.Equal(t, string(ModifierAssignValue), "assign_value")
+	selectorCases := []struct {
+		alias string
+		typed Selector
+	}{
+		{SelTarget, SelectorTarget},
+		{SelVersion, SelectorVersion},
+		{SelFunc, SelectorFunc},
+		{SelRecv, SelectorRecv},
+		{SelStruct, SelectorStruct},
+		{SelFunctionCall, SelectorFunctionCall},
+		{SelDirective, SelectorDirective},
+		{SelKind, SelectorKind},
+		{SelIdentifier, SelectorIdentifier},
+		{SelSignature, SelectorSignature},
+		{SelSignatureContains, SelectorSignatureContains},
+		{SelResult, SelectorResult},
+		{SelLastResult, SelectorLastResult},
+		{SelParam, SelectorParam},
+		{SelPattern, SelectorPattern},
+		{SelPlacement, SelectorPlacement},
+		{WhereFile, SelectorFile},
+		{CombAllOf, SelectorAllOf},
+		{CombOneOf, SelectorOneOf},
+		{CombNot, SelectorNot},
+	}
+	for _, c := range selectorCases {
+		assert.Equalf(t, string(c.typed), c.alias, "alias must equal string(%v)", c.typed)
+	}
+	modifierCases := []struct {
+		alias string
+		typed Modifier
+	}{
+		{"inject_hooks", ModifierInjectHooks},
+		{"inject_code", ModifierInjectCode},
+		{"add_struct_fields", ModifierAddStructFields},
+		{"add_file", ModifierAddFile},
+		{"wrap_call", ModifierWrapCall},
+		{"expand_directive", ModifierExpandDirective},
+		{"assign_value", ModifierAssignValue},
+	}
+	for _, c := range modifierCases {
+		assert.Equalf(t, string(c.typed), c.alias, "alias must equal string(%v)", c.typed)
+	}
 }

--- a/tool/internal/rule/schema_test.go
+++ b/tool/internal/rule/schema_test.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsValidSelector(t *testing.T) {
+	for _, sel := range AllSelectors() {
+		assert.Truef(t, IsValidSelector(string(sel)), "AllSelectors entry %q must be valid", sel)
+	}
+	assert.False(t, IsValidSelector("bogus"))
+	assert.False(t, IsValidSelector(""))
+	assert.False(t, IsValidSelector("inject_hooks")) // modifier, not selector
+}
+
+func TestIsValidModifier(t *testing.T) {
+	for _, mod := range AllModifiers() {
+		assert.Truef(t, IsValidModifier(string(mod)), "AllModifiers entry %q must be valid", mod)
+	}
+	assert.False(t, IsValidModifier("bogus"))
+	assert.False(t, IsValidModifier(""))
+	assert.False(t, IsValidModifier("inject_hook")) // typo of inject_hooks
+	assert.False(t, IsValidModifier("func"))        // selector, not modifier
+}
+
+func TestAllSelectorsComplete(t *testing.T) {
+	got := AllSelectors()
+	require.Len(t, got, len(selectors))
+	seen := make(map[Selector]struct{}, len(got))
+	for _, sel := range got {
+		_, dup := seen[sel]
+		assert.Falsef(t, dup, "duplicate selector %q in AllSelectors", sel)
+		seen[sel] = struct{}{}
+		_, registered := selectors[sel]
+		assert.Truef(t, registered, "AllSelectors entry %q missing from selectors map", sel)
+	}
+}
+
+func TestAllModifiersComplete(t *testing.T) {
+	got := AllModifiers()
+	require.Len(t, got, len(modifiers))
+	seen := make(map[Modifier]struct{}, len(got))
+	for _, mod := range got {
+		_, dup := seen[mod]
+		assert.Falsef(t, dup, "duplicate modifier %q in AllModifiers", mod)
+		seen[mod] = struct{}{}
+		_, registered := modifiers[mod]
+		assert.Truef(t, registered, "AllModifiers entry %q missing from modifiers map", mod)
+	}
+}
+
+func TestStringAliasesMatchTypedConstants(t *testing.T) {
+	assert.Equal(t, string(SelectorFunc), SelFunc)
+	assert.Equal(t, string(SelectorFile), WhereFile)
+	assert.Equal(t, string(SelectorAllOf), CombAllOf)
+	assert.Equal(t, string(ModifierInjectHooks), "inject_hooks")
+	assert.Equal(t, string(ModifierInjectCode), "inject_code")
+	assert.Equal(t, string(ModifierAddStructFields), "add_struct_fields")
+	assert.Equal(t, string(ModifierAddFile), "add_file")
+	assert.Equal(t, string(ModifierWrapCall), "wrap_call")
+	assert.Equal(t, string(ModifierExpandDirective), "expand_directive")
+	assert.Equal(t, string(ModifierAssignValue), "assign_value")
+}


### PR DESCRIPTION
## Summary
- Add `tool/internal/rule/schema.go` with `Selector`/`Modifier` types, constants, `IsValidSelector`/`IsValidModifier`, and `AllSelectors`/`AllModifiers`.
- Move existing `Sel*` / combinator string aliases onto that registry so call sites share one source of truth.
- Reject unknown `do` modifier keys at normalize time instead of silently dropping the modifier name.

## Motivation
Fixes #542. Prerequisite for the rule-schema linter (#543). Unknown modifiers previously fell through because `normalizeDo` discarded the modifier key and only kept the payload.

## Test plan
- [ ] CI: `tool/internal/rule` unit tests (schema + normalize unknown-modifier cases)
- [ ] Existing rule golden / setup parse paths still load known modifiers

## Notes for reviewers
- Modifier names match `docs/rules.md` (not the older names in the issue description).
- No constructor refactor (#541/#546 left untouched).
- `createRuleFromFields` still dispatches on flat field presence; this PR only adds the registry + validation.