### PR TITLE
docs: mention Git line-ending setup for Windows/WSL contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,16 @@ This project uses several tools for development. Most tools will be automaticall
 
 ### Getting Started
 
+> **Windows/WSL contributors:** make sure `core.autocrlf` is `false` before
+> cloning (`git config --global core.autocrlf false`). CI runs on Windows as
+> well as Linux and macOS, and a clone with `core.autocrlf` enabled checks out
+> source files with CRLF line endings. That changes how blank lines are
+> preserved when the AST-based code generator writes output, which then fails
+> to match the (LF) golden files under `testdata/golden`, even though the
+> generated code is correct. If you already cloned with `autocrlf` on, re-clone
+> after changing the setting rather than trying to fix the line endings of an
+> existing checkout.
+
 1. Clone the repository:
 
    ```sh


### PR DESCRIPTION
## Description

Adds a short note to the "Getting Started" section of `CONTRIBUTING.md` telling Windows/WSL contributors to set `core.autocrlf false` before cloning.

## Motivation

CI runs on Windows in addition to Linux and macOS, but a clone made with the common Windows Git default (`core.autocrlf=true`) checks out source files with CRLF line endings. That changes how blank lines are preserved when the AST-based code generator in `tool/internal/instrument` writes output, so the generated code stops matching the (LF) golden files under `testdata/golden` even though the generation logic itself is correct. This wasn't documented anywhere, so a new contributor has no way to know their `autocrlf` setting is the cause of otherwise-unexplained golden-file failures.

Fixes #834

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [x] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
- [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
