### PR TITLE
fix(tool/setup): close file handle when bundle extraction copy fails

### DIFF
--- a/tool/internal/setup/extract.go
+++ b/tool/internal/setup/extract.go
@@ -63,6 +63,7 @@ func extract(tarReader *tar.Reader, header *tar.Header, targetPath string) error
 
 		_, err = io.CopyN(file, tarReader, header.Size)
 		if err != nil {
+			_ = file.Close()
 			return ex.Wrap(err)
 		}
 		err = file.Close()

--- a/tool/internal/setup/extract_test.go
+++ b/tool/internal/setup/extract_test.go
@@ -107,6 +107,41 @@ func TestExtract_TruncatesExistingFile(t *testing.T) {
 	require.Equal(t, string(newContent), string(bs))
 }
 
+func TestExtract_ClosesFileOnCopyError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	targetPath := filepath.Join(tmpDir, "rules.yaml")
+
+	// Build a tar header that promises more bytes than the tar stream
+	// actually contains, so io.CopyN fails partway through the copy.
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+
+	err := tw.WriteHeader(&tar.Header{
+		Name:     "rules.yaml",
+		Mode:     0o644,
+		Size:     100,
+		Typeflag: tar.TypeReg,
+	})
+	require.NoError(t, err)
+
+	_, err = tw.Write([]byte("short"))
+	require.NoError(t, err)
+
+	tr := tar.NewReader(bytes.NewReader(tarBuf.Bytes()))
+
+	header, err := tr.Next()
+	require.NoError(t, err)
+
+	err = extract(tr, header, targetPath)
+	require.Error(t, err)
+
+	// If extract() left the destination file open, removing it here
+	// fails on Windows (the OS refuses to delete a file that still has
+	// an open handle in this process).
+	require.NoError(t, os.Remove(targetPath))
+}
+
 func TestExtract_Directory(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Description

`extract()` in `tool/internal/setup/extract.go` opens the destination file for a regular tar entry, then copies the entry's bytes into it with `io.CopyN`. The file handle was only closed on the success path — if `io.CopyN` returned an error (truncated/corrupt bundle stream, disk full mid-write, unexpected EOF), the function returned immediately and the open `*os.File` leaked for the rest of the process.

This closes the file on the copy-error path too, mirroring the existing `_ = dstFile.Close()` pattern already used in `util.CopyFile` for the same situation.

Also adds `TestExtract_ClosesFileOnCopyError`, which builds a tar entry whose declared size is larger than the bytes actually written, so `io.CopyN` fails partway through. Without the fix, this test fails on Windows because `os.Remove` on the target file returns "used by another process" while the leaked handle is still open in-process; with the fix it passes.

## Motivation

Every `otelc setup`/build run extracts the built-in instrumentation bundle through this code path (`extractOtelcBundle` → `extractGZip` → `extract`), so a corrupted or truncated bundle would leak a file descriptor with no cleanup. #530 fixed truncation of previously-extracted files in this same function but didn't add close-on-error handling for the copy step.

Fixes #859

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [x] This PR has content that I did not fully write myself.
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
