### PR TITLE
docs: mention Git line-ending setup for Windows/WSL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,22 @@ This project uses several tools for development. Most tools will be automaticall
 - [Git](https://git-scm.com/)
 - Make (usually pre-installed on macOS and Linux)
 
+#### Windows / WSL note (line endings)
+
+On Windows (including WSL clones managed by Windows Git), Git often defaults to
+`core.autocrlf=true`. That converts checked-out files to CRLF and can break
+golden-file tests under `tool/internal/instrument` (diffs that drop blank lines
+even when logic is correct).
+
+Before cloning this repository, disable CRLF conversion:
+
+```sh
+git config --global core.autocrlf false
+```
+
+If you already cloned with `core.autocrlf` enabled, set it to `false` and
+re-clone (or refresh the working tree) so source files use LF line endings.
+
 ### Getting Started
 
 1. Clone the repository:


### PR DESCRIPTION
## Summary
- Document that Windows/WSL contributors should set `core.autocrlf false` before cloning.
- Notes that CRLF can break golden-file tests under `tool/internal/instrument`.

## Motivation
Fixes #834

## Test plan
- [ ] Docs render correctly on GitHub