### PR TITLE
fix(tool/setup): check file.Close() error in SetupPhase.store

### DIFF
--- a/tool/internal/setup/store.go
+++ b/tool/internal/setup/store.go
@@ -91,17 +91,22 @@ func (sp *SetupPhase) store(ctx context.Context, matched []*rule.InstRuleSet, mo
 	if err != nil {
 		return ex.Wrapf(err, "failed to create file %s", f)
 	}
-	defer file.Close()
 
 	bs, err := json.Marshal(matched)
 	if err != nil {
+		_ = file.Close()
 		return ex.Wrapf(err, "failed to marshal rules to JSON")
 	}
 
-	_, err = file.Write(bs)
-	if err != nil {
+	if _, err = file.Write(bs); err != nil {
+		_ = file.Close()
 		return ex.Wrapf(err, "failed to write JSON to file %s", f)
 	}
+
+	if err = file.Close(); err != nil {
+		return ex.Wrapf(err, "failed to close file %s", f)
+	}
+
 	sp.Info("Stored matched sets", "path", f)
 	return nil
 }


### PR DESCRIPTION
## Description

`SetupPhase.store()` opened `matched.json` with `os.Create` and relied on a bare `defer file.Close()`, never checking its return value, then wrote the JSON via `file.Write`. This adds an explicit `Close()` error check on the success path, and closes best-effort before returning on the earlier marshal/write error paths.

## Motivation

Closing a writable file is what actually flushes buffered data to disk. If that flush fails (disk full, quota, a network filesystem hiccup) after a successful `Write()`, the error was silently discarded and `store()` still returned `nil`, so the caller believed the write succeeded while the on-disk file could be corrupted or incomplete.

This isn't just an internal artifact: `docs/configuration.md`'s "Verifying Your Configuration" section explicitly tells users to inspect `matched.json` directly to confirm their instrumentation rules matched as expected. A silently corrupted file here is misleading in exactly the workflow the docs recommend.

Fixes #870

## Testing

Added `TestStore`, verifying a full round-trip (write, close, read back, unmarshal) succeeds and produces valid JSON. `go test ./...` and scoped `golangci-lint` pass clean for the affected package.

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable)