### PR TITLE
test(tool): enforce api.tmpl stays in sync with pkg/hook/context.go

### DIFF
--- a/pkg/hook/context.go
+++ b/pkg/hook/context.go
@@ -3,7 +3,7 @@
 
 package hook
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/api.tmpl
+++ b/tool/internal/instrument/api.tmpl
@@ -3,7 +3,7 @@
 
 package hook
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/api_tmpl_test.go
+++ b/tool/internal/instrument/api_tmpl_test.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package instrument
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// api.tmpl is a hand-copied version of this file.
+const hookContextSourcePath = "../../../pkg/hook/context.go"
+
+// api.tmpl must be a byte-for-byte copy of pkg/hook/context.go, or generated
+// hook code ends up with a HookContext that doesn't match the real one.
+func TestAPITemplateMatchesHookContext(t *testing.T) {
+	want, err := os.ReadFile(hookContextSourcePath)
+	require.NoError(t, err, "reading %s", hookContextSourcePath)
+
+	assert.Equal(t, string(want), templateAPI, "api.tmpl has drifted from pkg/hook/context.go")
+}

--- a/tool/internal/instrument/testdata/golden/after-only/after_only.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/after-only/after_only.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/all-of-filter-empty/all_of_filter_empty.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/all-of-filter-empty/all_of_filter_empty.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/all-of-filter-match/all_of_filter_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/all-of-filter-match/all_of_filter_match.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/before-only/before_only.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/before-only/before_only.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/combined-rules/combined_rules.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/combined-rules/combined_rules.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/dedup-identical-rules/dedup_identical_rules.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/dedup-identical-rules/dedup_identical_rules.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/ellipsis-syntax/ellipsis_syntax.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/ellipsis-syntax/ellipsis_syntax.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/func-and-raw-rules/func_and_raw_rules.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/func-and-raw-rules/func_and_raw_rules.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/func-rule-only/func_rule_only.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/func-rule-only/func_rule_only.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/func-sig-argument-type/func_sig_argument_type.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/func-sig-argument-type/func_sig_argument_type.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/func-sig-contains/func_sig_contains.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/func-sig-contains/func_sig_contains.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/func-sig-last-result-type/func_sig_last_result_type.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/func-sig-last-result-type/func_sig_last_result_type.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/func-sig-result-type/func_sig_result_type.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/func-sig-result-type/func_sig_result_type.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/func-signature/func_signature.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/func-signature/func_signature.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/generic-functions/generic_functions.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/generic-functions/generic_functions.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/has-package-combo-match/has_package_combo_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/has-package-combo-match/has_package_combo_match.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/has-package-match/has_package_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/has-package-match/has_package_match.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/is-test-filter-match/is_test_filter_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-match/is_test_filter_match.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/is-test-filter-true-match/is_test_filter_true_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/is-test-filter-true-match/is_test_filter_true_match.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/method-receiver/method_receiver.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/method-receiver/method_receiver.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/multiple-func-rules/multiple_func_rules.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/multiple-func-rules/multiple_func_rules.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/multiple-hooks-single-func/multi_hook.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/multiple-hooks-single-func/multi_hook.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/not-filter-match/not_filter_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/not-filter-match/not_filter_match.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/one-of-filter-match/one_of_filter_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/one-of-filter-match/one_of_filter_match.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/opt-multiple-funcs/opt_multiple_funcs.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/opt-multiple-funcs/opt_multiple_funcs.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/target-glob-deep-match/target_glob_deep_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/target-glob-deep-match/target_glob_deep_match.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/target-glob-match/target_glob_match.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/target-glob-match/target_glob_match.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/underscore-param-and-return/underscore_param_and_return.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/underscore-param-and-return/underscore_param_and_return.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/underscore-return-syntax/underscore_return_syntax.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/underscore-return-syntax/underscore_return_syntax.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/underscore-syntax/underscore_syntax.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/underscore-syntax/underscore_syntax.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)

--- a/tool/internal/instrument/testdata/golden/unnamed-param/unnamed_param.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/unnamed-param/unnamed_param.otelc.globals.go.golden
@@ -6,7 +6,7 @@ var (
 	OtelPrintStackImpl func([]byte)  = nil
 )
 
-// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+// !!! This file must stay byte-for-byte identical to tool/internal/instrument/api.tmpl (enforced by TestAPITemplateMatchesHookContext in tool/internal/instrument/api_tmpl_test.go).
 type HookContext interface {
 	// Set the skip call flag, can be used to skip the original function call
 	SetSkipCall(bool)


### PR DESCRIPTION

<!--
Thank you for contributing to OpenTelemetry Go Compile Instrumentation!

INSTRUCTIONS:
1. Fill in the description and motivation sections below
2. Complete the checklist before submitting
3. Ensure PR title follows conventional commits format (enforced by CI)

PR TITLE FORMAT (required):
  type(scope): description

  Types: chore, doc, docs, feat, fix, release, refactor, test
  Scopes: tool, pkg, demo, test, docs

  Examples:
  - feat(pkg): add gRPC client instrumentation
  - fix(tool): resolve hook signature matching issue
  - docs(api): update instrumenter interface documentation
  - refactor(pkg): simplify attribute extractor composition

BEFORE SUBMITTING:
  make format  # Format Go code and YAML files
  make lint    # Run all linters
  make test    # Run all tests (unit + integration + e2e)

If your PR adds a new user-facing instrumentation, please also submit a corresponding OpenTelemetry Registry PR:
https://opentelemetry.io/ecosystem/registry/adding/

For detailed contribution guidelines, see CONTRIBUTING.md
For available make targets, run: make help
-->

## Description

api.tmpl is a hand-copied version of pkg/hook/context.go, embedded and copied into every generated globals file. Nothing enforced the two stayed identical the !!! comment was just a convention.
## Motivation

Adds TestAPITemplateMatchesHookContext to check they're byte-for-byte equal, updates the !!! comment to point at the test, and regenerates golden fixtures (the comment is embedded in generated output, so it touched all of them).

Fixes #899

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [ ] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
