### PR TITLE
fix(instrumentation): remove duplicate command name suffix in redis query statement

### DIFF
--- a/instrumentation/github.com/redis/go-redis/v9/hook.go
+++ b/instrumentation/github.com/redis/go-redis/v9/hook.go
@@ -152,11 +152,6 @@ func getRedisV9Statement(cmd redis.Cmder) string {
 		b = append(b, err.Error()...)
 	}
 
-	if cmd, ok := cmd.(*redis.Cmd); ok {
-		b = append(b, ": "...)
-		b = redisV9AppendArg(b, cmd.Name())
-	}
-
 	return string(b)
 }
 

--- a/instrumentation/github.com/redis/go-redis/v9/hook_test.go
+++ b/instrumentation/github.com/redis/go-redis/v9/hook_test.go
@@ -33,54 +33,54 @@ func TestGetRedisV9Statement(t *testing.T) {
 	tests := []struct {
 		name     string
 		cmd      redis.Cmder
-		contains string
+		expected string
 	}{
 		{
 			name:     "GET command",
 			cmd:      redis.NewCmd(context.Background(), "get", "mykey"),
-			contains: "get mykey",
+			expected: "get mykey",
 		},
 		{
 			name:     "SET command with value",
 			cmd:      redis.NewCmd(context.Background(), "set", "mykey", "myvalue"),
-			contains: "set mykey myvalue",
+			expected: "set mykey myvalue",
 		},
 		{
 			name:     "HSET command",
 			cmd:      redis.NewCmd(context.Background(), "hset", "myhash", "field1", "value1"),
-			contains: "hset myhash field1 value1",
+			expected: "hset myhash field1 value1",
 		},
 		{
 			name:     "DEL command",
 			cmd:      redis.NewCmd(context.Background(), "del", "key1", "key2"),
-			contains: "del key1 key2",
+			expected: "del key1 key2",
 		},
 		{
 			name:     "command with nil arg",
 			cmd:      redis.NewCmd(context.Background(), "set", nil),
-			contains: "set <nil>",
+			expected: "set <nil>",
 		},
 		{
 			name:     "command with int arg",
 			cmd:      redis.NewCmd(context.Background(), "expire", "mykey", 60),
-			contains: "expire mykey 60",
+			expected: "expire mykey 60",
 		},
 		{
 			name:     "command with bool arg true",
 			cmd:      redis.NewCmd(context.Background(), "set", "mykey", true),
-			contains: "set mykey true",
+			expected: "set mykey true",
 		},
 		{
 			name:     "command with bool arg false",
 			cmd:      redis.NewCmd(context.Background(), "set", "mykey", false),
-			contains: "set mykey false",
+			expected: "set mykey false",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := getRedisV9Statement(tt.cmd)
-			assert.Contains(t, result, tt.contains)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION

## Description

This PR fixes a bug in `getRedisV9Statement` where a duplicate command name suffix (e.g. `: get` or `: pipeline`) was appended to the `db.query.text` span attribute for `*redis.Cmd` instances and pipeline operations.

Key changes:
- Removed the redundant `if cmd, ok := cmd.(*redis.Cmd); ok` block in [`instrumentation/github.com/redis/go-redis/v9/hook.go`](file:///c:/Users/Vishal/Code_File/Projects/opentelemetry-go-compile-instrumentation/instrumentation/github.com/redis/go-redis/v9/hook.go#L155-L158). `cmd.Args()` already includes the command name as its first element.
- Updated `TestGetRedisV9Statement` in [`hook_test.go`](file:///c:/Users/Vishal/Code_File/Projects/opentelemetry-go-compile-instrumentation/instrumentation/github.com/redis/go-redis/v9/hook_test.go#L83) to use exact string equality (`assert.Equal`) instead of substring matching (`assert.Contains`).

## Motivation

Generic Redis commands (such as `rdb.Do` or `redis.NewCmd`) and pipeline hooks produced corrupted `db.query.text` attributes (e.g. `"get mykey: get"` instead of `"get mykey"`, `"pipeline get/set/: pipeline"` instead of `"pipeline get/set/"`). This fix ensures clean, spec-compliant Redis telemetry.

Fixes #918

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [x] Documentation updated (if applicable)
- [x] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))
