### PR TITLE
test: fix Windows test failures due to POSIX shell assumptions

### DIFF
--- a/tool/internal/setup/find_test.go
+++ b/tool/internal/setup/find_test.go
@@ -5,6 +5,7 @@ package setup
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +16,20 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otelc/tool/util"
 )
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	plan := os.Getenv("GO_HELPER_BUILD_PLAN")
+	if plan != "" {
+		fmt.Fprintln(os.Stderr, plan)
+	}
+	if os.Getenv("GO_HELPER_BUILD_FAILS") == "1" {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
 
 func TestParseCdDir(t *testing.T) {
 	tests := []struct {
@@ -380,19 +395,24 @@ echo nothing useful
 			t.Setenv(util.EnvOtelcWorkDir, tempDir)
 
 			execCommandContext = func(
-				_ context.Context,
+				ctx context.Context,
 				name string,
 				args ...string,
 			) *exec.Cmd {
 				assert.Equal(t, "go", name)
 				assert.Equal(t, tt.expectedGoCmd, args)
 
-				script := "cat <<'EOF' >&2\n" + tt.buildPlan + "\nEOF\n"
+				exe, err := os.Executable()
+				require.NoError(t, err)
+				cmd := exec.CommandContext(ctx, exe, "-test.run=^TestHelperProcess$")
+				cmd.Env = append(os.Environ(),
+					"GO_WANT_HELPER_PROCESS=1",
+					"GO_HELPER_BUILD_PLAN="+tt.buildPlan,
+				)
 				if tt.buildFails {
-					script += "\nexit 1\n"
+					cmd.Env = append(cmd.Env, "GO_HELPER_BUILD_FAILS=1")
 				}
-
-				return exec.Command("sh", "-c", script)
+				return cmd
 			}
 
 			subcommand := tt.subcommand

--- a/tool/internal/setup/find_test.go
+++ b/tool/internal/setup/find_test.go
@@ -394,6 +394,9 @@ echo nothing useful
 
 			t.Setenv(util.EnvOtelcWorkDir, tempDir)
 
+			exe, err := os.Executable()
+			require.NoError(t, err)
+
 			execCommandContext = func(
 				ctx context.Context,
 				name string,
@@ -402,8 +405,6 @@ echo nothing useful
 				assert.Equal(t, "go", name)
 				assert.Equal(t, tt.expectedGoCmd, args)
 
-				exe, err := os.Executable()
-				require.NoError(t, err)
 				cmd := exec.CommandContext(ctx, exe, "-test.run=^TestHelperProcess$")
 				cmd.Env = append(os.Environ(),
 					"GO_WANT_HELPER_PROCESS=1",

--- a/tool/util/sys_test.go
+++ b/tool/util/sys_test.go
@@ -20,13 +20,13 @@ func TestRunCmd(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name:      "simple echo command",
-			args:      []string{"echo", "hello"},
+			name:      "simple go command",
+			args:      []string{"go", "version"},
 			expectErr: false,
 		},
 		{
 			name:      "command with multiple arguments",
-			args:      []string{"echo", "hello", "world"},
+			args:      []string{"go", "env", "GOOS"},
 			expectErr: false,
 		},
 		{


### PR DESCRIPTION
Fixes #920

### What changed
Two test files assumed POSIX-only shell tooling that does not exist on Windows:

- `tool/internal/setup/find_test.go`: `TestListBuildPlan` mocked
  `execCommandContext` with `exec.Command("sh", "-c", script)`.
  On Windows there is no `sh`, so all 6 sub-tests failed.

- `tool/util/sys_test.go`: `TestRunCmd` used `echo` as the test
  command. `echo` is a shell built-in on Windows and is not
  exec-able as a standalone binary.

### How it was fixed

**find_test.go** — adopted the standard [TestHelperProcess pattern]
used in the Go standard library: the test binary re-invokes itself
with a dedicated helper function that reads the desired build plan and
exit behavior from environment variables (`GO_WANT_HELPER_PROCESS`,
`GO_HELPER_BUILD_PLAN`, `GO_HELPER_BUILD_FAILS`). No `sh` required.

**sys_test.go** — replaced `echo` with `go version` / `go env GOOS`,
which are always available wherever Go is installed.

### Testing
- `go test -v -run "TestListBuildPlan|TestRunCmd" ./tool/internal/setup/... ./tool/util/...`
  passes on Windows (all 9 targeted sub-tests pass).
- `go test ./tool/util/...` passes fully on Windows.

