### PR TITLE
fix(setup): close file handle on stale lock verification in tryAcquire

### DIFF
--- a/tool/internal/setup/lock.go
+++ b/tool/internal/setup/lock.go
@@ -143,10 +143,12 @@ func tryAcquire(path string) (*flock.Flock, bool, bool, error) {
 	current, err := lockFileIsCurrent(path, lock)
 	if err != nil {
 		_ = lock.Unlock()
+		_ = lock.Close()
 		return nil, false, leftover, err
 	}
 	if !current {
 		_ = lock.Unlock()
+		_ = lock.Close()
 		return nil, false, leftover, nil
 	}
 	return lock, true, leftover, nil

--- a/tool/internal/setup/lock_nonwindows_test.go
+++ b/tool/internal/setup/lock_nonwindows_test.go
@@ -8,7 +8,9 @@ package setup
 import (
 	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
@@ -24,31 +26,47 @@ func TestIsTransientLockFileError(t *testing.T) {
 
 func TestTryAcquireStaleLockCleanup(t *testing.T) {
 	lockTestDir(t)
+	tmpDir := t.TempDir()
 	path := buildLockPath()
 
-	// Handle A locks original file
+	// 1. Verify lockFileIsCurrent returns false for stale lock handles
 	lockA := flock.New(path)
 	acquiredA, err := lockA.TryLock()
 	require.NoError(t, err)
 	require.True(t, acquiredA)
 
-	// Remove original file on disk to simulate deletion race (supported on POSIX)
 	require.NoError(t, os.Remove(path))
 
-	// Handle B creates and locks a new file at the same path
 	lockB := flock.New(path)
 	acquiredB, err := lockB.TryLock()
 	require.NoError(t, err)
 	require.True(t, acquiredB)
 
-	// lockA is now stale because path points to lockB's inode
 	current, err := lockFileIsCurrent(path, lockA)
 	require.NoError(t, err)
 	assert.False(t, current, "stale lock handle must not be current")
 
 	_ = lockA.Unlock()
 	_ = lockA.Close()
-
 	_ = lockB.Unlock()
 	_ = lockB.Close()
+
+	// 2. Directly invoke tryAcquire under unlinked file condition to exercise
+	// the !current cleanup path inside tryAcquire.
+	raceFile := filepath.Join(tmpDir, "racefile.lock")
+	require.NoError(t, os.WriteFile(raceFile, []byte("data"), 0o644))
+
+	go func() {
+		time.Sleep(1 * time.Millisecond)
+		_ = os.Remove(raceFile)
+	}()
+
+	l, acq, _, err := tryAcquire(raceFile)
+	require.NoError(t, err)
+	if !acq {
+		assert.Nil(t, l, "tryAcquire must return nil handle on stale lock cleanup")
+	} else {
+		_ = l.Unlock()
+		_ = l.Close()
+	}
 }

--- a/tool/internal/setup/lock_nonwindows_test.go
+++ b/tool/internal/setup/lock_nonwindows_test.go
@@ -7,8 +7,11 @@ package setup
 
 import (
 	"io/fs"
+	"os"
 	"testing"
 
+	"github.com/gofrs/flock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,4 +20,35 @@ func TestIsTransientLockFileError(t *testing.T) {
 	// stat failure other than fs.ErrNotExist stays fatal.
 	require.False(t, isTransientLockFileError(fs.ErrPermission))
 	require.False(t, isTransientLockFileError(nil))
+}
+
+func TestTryAcquireStaleLockCleanup(t *testing.T) {
+	lockTestDir(t)
+	path := buildLockPath()
+
+	// Handle A locks original file
+	lockA := flock.New(path)
+	acquiredA, err := lockA.TryLock()
+	require.NoError(t, err)
+	require.True(t, acquiredA)
+
+	// Remove original file on disk to simulate deletion race (supported on POSIX)
+	require.NoError(t, os.Remove(path))
+
+	// Handle B creates and locks a new file at the same path
+	lockB := flock.New(path)
+	acquiredB, err := lockB.TryLock()
+	require.NoError(t, err)
+	require.True(t, acquiredB)
+
+	// lockA is now stale because path points to lockB's inode
+	current, err := lockFileIsCurrent(path, lockA)
+	require.NoError(t, err)
+	assert.False(t, current, "stale lock handle must not be current")
+
+	_ = lockA.Unlock()
+	_ = lockA.Close()
+
+	_ = lockB.Unlock()
+	_ = lockB.Close()
 }

--- a/tool/internal/setup/lock_test.go
+++ b/tool/internal/setup/lock_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -148,36 +147,5 @@ func TestAcquireBuildLockMissingWorkDirIsNoop(t *testing.T) {
 	require.NoError(t, err)
 	release()
 	assert.False(t, util.PathExists(missing), "no-op acquisition must not create the work dir")
-}
-
-func TestTryAcquireStaleLockCleanup(t *testing.T) {
-	lockTestDir(t)
-	path := buildLockPath()
-
-	// Handle A locks original file
-	lockA := flock.New(path)
-	acquiredA, err := lockA.TryLock()
-	require.NoError(t, err)
-	require.True(t, acquiredA)
-
-	// Remove original file on disk to simulate deletion race
-	require.NoError(t, os.Remove(path))
-
-	// Handle B creates and locks a new file at the same path
-	lockB := flock.New(path)
-	acquiredB, err := lockB.TryLock()
-	require.NoError(t, err)
-	require.True(t, acquiredB)
-
-	// lockA is now stale because path points to lockB's inode
-	current, err := lockFileIsCurrent(path, lockA)
-	require.NoError(t, err)
-	assert.False(t, current, "stale lock handle must not be current")
-
-	_ = lockA.Unlock()
-	_ = lockA.Close()
-
-	_ = lockB.Unlock()
-	_ = lockB.Close()
 }
 

--- a/tool/internal/setup/lock_test.go
+++ b/tool/internal/setup/lock_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -148,3 +149,35 @@ func TestAcquireBuildLockMissingWorkDirIsNoop(t *testing.T) {
 	release()
 	assert.False(t, util.PathExists(missing), "no-op acquisition must not create the work dir")
 }
+
+func TestTryAcquireStaleLockCleanup(t *testing.T) {
+	lockTestDir(t)
+	path := buildLockPath()
+
+	// Handle A locks original file
+	lockA := flock.New(path)
+	acquiredA, err := lockA.TryLock()
+	require.NoError(t, err)
+	require.True(t, acquiredA)
+
+	// Remove original file on disk to simulate deletion race
+	require.NoError(t, os.Remove(path))
+
+	// Handle B creates and locks a new file at the same path
+	lockB := flock.New(path)
+	acquiredB, err := lockB.TryLock()
+	require.NoError(t, err)
+	require.True(t, acquiredB)
+
+	// lockA is now stale because path points to lockB's inode
+	current, err := lockFileIsCurrent(path, lockA)
+	require.NoError(t, err)
+	assert.False(t, current, "stale lock handle must not be current")
+
+	_ = lockA.Unlock()
+	_ = lockA.Close()
+
+	_ = lockB.Unlock()
+	_ = lockB.Close()
+}
+

--- a/tool/internal/setup/lock_test.go
+++ b/tool/internal/setup/lock_test.go
@@ -148,4 +148,3 @@ func TestAcquireBuildLockMissingWorkDirIsNoop(t *testing.T) {
 	release()
 	assert.False(t, util.PathExists(missing), "no-op acquisition must not create the work dir")
 }
-


### PR DESCRIPTION
## Description
In `tool/internal/setup/lock.go`, `tryAcquire` attempts to acquire the build lock using `flock.New(path)`. After acquiring the lock, `lockFileIsCurrent` checks whether the held lock handle matches the file at `path` on disk.

If `lockFileIsCurrent` returns `!current` or returns an error, `tryAcquire` calls `_ = lock.Unlock()`. However, `lock.Unlock()` in `gofrs/flock` releases the flock advisory lock mechanism but leaves the underlying file handle (`os.File`) open. Omitting `lock.Close()` causes open file descriptor leaks when stale lock retries occur.

Fixes #926

## Fix Details
- Added `_ = lock.Close()` when `lockFileIsCurrent` returns an error or `!current` in `tryAcquire`.
- Ran unit test suite in `tool/internal/setup` (100% PASS).

## Checklist
- [x] PR title follows conventional commits format: `fix(setup): ...` 
- [x] Code formatted & linters pass
- [x] Tests pass