### PR TITLE
test(tool): add unit tests to raise tool module coverage

### DIFF
--- a/tool/internal/ast/shared_extra_test.go
+++ b/tool/internal/ast/shared_extra_test.go
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ast
+
+import (
+	"testing"
+
+	"github.com/dave/dst"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otelc/tool/internal/rule"
+)
+
+func TestFindFuncDeclRawRule(t *testing.T) {
+	file := parseSharedFixture(t)
+
+	raw := &rule.InstRawRule{Func: "TopLevel"}
+	fn, ok, err := FindFuncDecl(file, raw)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, fn)
+	assert.Equal(t, "TopLevel", fn.Name.Name)
+}
+
+func TestFindFuncDeclRawRuleMissing(t *testing.T) {
+	file := parseSharedFixture(t)
+
+	raw := &rule.InstRawRule{Func: "Missing"}
+	fn, ok, err := FindFuncDecl(file, raw)
+	require.NoError(t, err)
+	require.False(t, ok)
+	assert.Nil(t, fn)
+}
+
+func TestFindFuncDeclFilterDef(t *testing.T) {
+	file := parseSharedFixture(t)
+
+	filter := &rule.FilterDef{HasFunc: "TopLevel"}
+	fn, ok, err := FindFuncDecl(file, filter)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, fn)
+	assert.Equal(t, "TopLevel", fn.Name.Name)
+}
+
+func TestFuncDeclMatchesFilters_SignatureParseError(t *testing.T) {
+	decl := makeFuncDecl(
+		[]*dst.Field{field(ident("string"))},
+		[]*dst.Field{field(ident("error"))},
+	)
+
+	_, err := funcDeclMatchesFilters(decl, &rule.InstFuncRule{
+		Signature: &rule.FuncSignature{Args: []string{"[]invalid"}},
+	})
+	require.Error(t, err)
+
+	_, err = funcDeclMatchesFilters(decl, &rule.InstFuncRule{
+		SignatureContains: &rule.FuncSignature{Args: []string{"[]invalid"}},
+	})
+	require.Error(t, err)
+
+	_, err = funcDeclMatchesFilters(decl, &rule.InstFuncRule{
+		SignatureContains: &rule.FuncSignature{Returns: []string{"[]invalid"}},
+	})
+	require.Error(t, err)
+}
+
+func TestFuncDeclMatchesFilters_LastResultNoResults(t *testing.T) {
+	decl := makeFuncDecl(nil, nil)
+
+	ok, err := funcDeclMatchesFilters(decl, &rule.InstFuncRule{LastResult: "error"})
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/tool/internal/instrument/call_template_extra_test.go
+++ b/tool/internal/instrument/call_template_extra_test.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package instrument
+
+import (
+	"testing"
+
+	"github.com/dave/dst"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileExpression_UnknownTemplateTag(t *testing.T) {
+	tmpl, err := newCallTemplate("wrapper({{ something }})")
+	require.NoError(t, err)
+
+	originalCall := &dst.CallExpr{
+		Fun: &dst.Ident{Name: "funcCall"},
+	}
+
+	result, err := tmpl.compileExpression(originalCall)
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestParseGoExpression_NonExpressionStatement(t *testing.T) {
+	_, err := parseGoExpression("return")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not parse as an expression statement")
+}
+
+func TestParseGoExpression_EmptyBody(t *testing.T) {
+	_, err := parseGoExpression("")
+	require.Error(t, err)
+}
+
+func TestParseGoTypeExpression_NoType(t *testing.T) {
+	// "var _ = 1" has no explicit type on the value spec, so the parsed shape
+	// must be rejected rather than silently producing a nil type.
+	_, err := parseGoTypeExpression("= 1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected spec shape")
+}

--- a/tool/internal/instrument/toolexec_extra_test.go
+++ b/tool/internal/instrument/toolexec_extra_test.go
@@ -288,8 +288,8 @@ func TestInterceptToolVersionWriteError(t *testing.T) {
 	f, err := os.Create(filepath.Join(t.TempDir(), "closed"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-	os.Stdout = f
-	t.Cleanup(func() { os.Stdout = oldStdout })
+	os.Stdout = f                               //nolint:reassign // interceptToolVersion writes to os.Stdout; replace it with a closed file to force a write error
+	t.Cleanup(func() { os.Stdout = oldStdout }) //nolint:reassign // restore the original os.Stdout
 
 	err = interceptToolVersion(ctx, []string{goCompileToolPath(t), "-V=full"})
 	require.Error(t, err)

--- a/tool/internal/instrument/toolexec_extra_test.go
+++ b/tool/internal/instrument/toolexec_extra_test.go
@@ -1,0 +1,297 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package instrument
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otelc/tool/internal/imports"
+	"go.opentelemetry.io/otelc/tool/util"
+)
+
+// goCompileToolPath returns the path to the toolchain's compile binary, which
+// answers the `-V=full` probe the same way a real toolexec sees it.
+func goCompileToolPath(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("go", "env", "GOTOOLDIR").Output()
+	require.NoError(t, err)
+	name := "compile"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(strings.TrimSpace(string(out)), name)
+}
+
+func TestKeepForDebugCopyError(t *testing.T) {
+	workDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, workDir)
+
+	ip := &InstrumentPhase{
+		logger:      slog.Default(),
+		compileArgs: []string{"-p", "example.com/mod/pkg"},
+	}
+	// The source file does not exist, so CopyFile fails. The failure is only
+	// logged as a warning because this is best-effort debugging output.
+	ip.keepForDebug(filepath.Join(workDir, "missing.go"))
+}
+
+func TestInterceptCompileImportCfgParseError(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	t.Setenv(util.EnvOtelcWorkDir, t.TempDir())
+
+	args := []string{
+		"compile",
+		"-o", filepath.Join(t.TempDir(), "out.a"),
+		"-importcfg", filepath.Join(t.TempDir(), "missing.importcfg"),
+		"-p", "main",
+	}
+	_, err := interceptCompile(ctx, args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing importcfg")
+}
+
+func TestUpdateImportConfigAddsResolvedImport(t *testing.T) {
+	workDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, workDir)
+	require.NoError(t, os.MkdirAll(util.GetBuildTempDir(), 0o755))
+
+	cfgPath := filepath.Join(workDir, "importcfg")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("packagefile context=/unused/context.a\n"), 0o644))
+
+	ip := &InstrumentPhase{
+		logger:           slog.Default(),
+		importConfigPath: cfgPath,
+		importConfig: imports.ImportConfig{
+			PackageFile: map[string]string{"context": "/unused/context.a"},
+		},
+	}
+	require.NoError(t, ip.updateImportConfig(t.Context(), map[string]string{"fmt": "fmt"}))
+
+	content, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "packagefile fmt=")
+}
+
+func TestUpdateImportConfigResolveError(t *testing.T) {
+	workDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, workDir)
+
+	cfgPath := filepath.Join(workDir, "importcfg")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(""), 0o644))
+
+	ip := &InstrumentPhase{
+		logger:           slog.Default(),
+		importConfigPath: cfgPath,
+		importConfig: imports.ImportConfig{
+			PackageFile: map[string]string{},
+		},
+	}
+	// The import path does not exist, so archive resolution fails.
+	err := ip.updateImportConfig(t.Context(), map[string]string{"example.invalid/nonexistent/pkg": "x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolving")
+}
+
+func TestUpdateImportConfigWriteError(t *testing.T) {
+	workDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, workDir)
+
+	// The parent directory does not exist, so the importcfg rewrite fails.
+	cfgPath := filepath.Join(workDir, "missing", "importcfg")
+	ip := &InstrumentPhase{
+		logger:           slog.Default(),
+		importConfigPath: cfgPath,
+		importConfig: imports.ImportConfig{
+			PackageFile: map[string]string{},
+		},
+	}
+	err := ip.updateImportConfig(t.Context(), map[string]string{"fmt": "fmt"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writing importcfg")
+}
+
+func TestUpdateImportConfigTrackError(t *testing.T) {
+	workDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, workDir)
+	// No .otelc-build directory is created, so the per-process tracking file
+	// write fails after the importcfg is updated. That failure is non-fatal.
+	cfgPath := filepath.Join(workDir, "importcfg")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(""), 0o644))
+
+	ip := &InstrumentPhase{
+		logger:           slog.Default(),
+		importConfigPath: cfgPath,
+		importConfig: imports.ImportConfig{
+			PackageFile: map[string]string{},
+		},
+	}
+	require.NoError(t, ip.updateImportConfig(t.Context(), map[string]string{"fmt": "fmt"}))
+}
+
+func TestTrackAddedImportsWriteError(t *testing.T) {
+	workDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, workDir)
+	// No .otelc-build directory exists, so the write fails.
+	err := trackAddedImports(map[string]string{"fmt": "/path/to/fmt.a"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writing imports file")
+}
+
+func TestCleanupImportTrackingFilesGlobError(t *testing.T) {
+	workDir := t.TempDir()
+	// '[' makes the glob pattern malformed, so filepath.Glob errors and the
+	// cleanup bails out.
+	t.Setenv(util.EnvOtelcWorkDir, filepath.Join(workDir, "bad[glob"))
+	CleanupImportTrackingFiles()
+}
+
+func TestLoadAddedImportsGlobError(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	t.Setenv(util.EnvOtelcWorkDir, filepath.Join(t.TempDir(), "bad[glob"))
+	_, err := loadAddedImports(ctx)
+	require.Error(t, err)
+}
+
+func TestLoadAddedImportsReadError(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	workDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, workDir)
+
+	buildDir := util.GetBuildTempDir()
+	require.NoError(t, os.MkdirAll(buildDir, 0o755))
+	// A directory matching the tracking-file pattern cannot be read.
+	require.NoError(t, os.Mkdir(filepath.Join(buildDir, "added_imports.1.json"), 0o755))
+
+	result, err := loadAddedImports(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func writeAddedImports(t *testing.T, packages map[string]string) {
+	t.Helper()
+	data, err := json.Marshal(packages)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(util.GetBuildTempDir(), "added_imports.1.json"), data, 0o644))
+}
+
+func TestInterceptLinkNoImportCfg(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	t.Setenv(util.EnvOtelcWorkDir, t.TempDir())
+
+	args := []string{"link", "-o", "exe", "-buildid", "id"}
+	result, err := interceptLink(ctx, args)
+	require.NoError(t, err)
+	assert.Equal(t, args, result)
+}
+
+func TestInterceptLinkLoadError(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	// A malformed glob pattern makes loadAddedImports fail; the link command
+	// is then passed through unchanged.
+	t.Setenv(util.EnvOtelcWorkDir, filepath.Join(t.TempDir(), "bad[glob"))
+
+	args := []string{"link", "-o", "exe", "-buildid", "id", "-importcfg", "importcfg.link"}
+	result, err := interceptLink(ctx, args)
+	require.NoError(t, err)
+	assert.Equal(t, args, result)
+}
+
+func TestInterceptLinkParseError(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	workDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, workDir)
+	require.NoError(t, os.MkdirAll(util.GetBuildTempDir(), 0o755))
+	writeAddedImports(t, map[string]string{"fmt": "/new/fmt.a"})
+
+	args := []string{"link", "-o", "exe", "-buildid", "id", "-importcfg", filepath.Join(workDir, "missing.link")}
+	_, err := interceptLink(ctx, args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing link importcfg")
+}
+
+func TestInterceptLinkUpdatesConfig(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	workDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, workDir)
+	require.NoError(t, os.MkdirAll(util.GetBuildTempDir(), 0o755))
+	writeAddedImports(t, map[string]string{"fmt": "/new/fmt.a"})
+
+	linkCfg := filepath.Join(workDir, "importcfg.link")
+	require.NoError(t, os.WriteFile(linkCfg, []byte(""), 0o644))
+
+	args := []string{"link", "-o", "exe", "-buildid", "id", "-importcfg", linkCfg}
+	result, err := interceptLink(ctx, args)
+	require.NoError(t, err)
+	assert.Equal(t, args, result)
+
+	content, err := os.ReadFile(linkCfg)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "packagefile fmt=/new/fmt.a")
+}
+
+func TestInterceptLinkAllImportsPresent(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	workDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, workDir)
+	require.NoError(t, os.MkdirAll(util.GetBuildTempDir(), 0o755))
+	writeAddedImports(t, map[string]string{"fmt": "/new/fmt.a"})
+
+	linkCfg := filepath.Join(workDir, "importcfg.link")
+	require.NoError(t, os.WriteFile(linkCfg, []byte("packagefile fmt=/old/fmt.a\n"), 0o644))
+
+	args := []string{"link", "-o", "exe", "-buildid", "id", "-importcfg", linkCfg}
+	result, err := interceptLink(ctx, args)
+	require.NoError(t, err)
+	assert.Equal(t, args, result)
+
+	content, err := os.ReadFile(linkCfg)
+	require.NoError(t, err)
+	assert.Equal(t, "packagefile fmt=/old/fmt.a\n", string(content))
+}
+
+func TestInterceptLinkWriteError(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	workDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, workDir)
+	require.NoError(t, os.MkdirAll(util.GetBuildTempDir(), 0o755))
+	writeAddedImports(t, map[string]string{"fmt": "/new/fmt.a"})
+
+	linkCfg := filepath.Join(workDir, "importcfg.link")
+	require.NoError(t, os.WriteFile(linkCfg, []byte("packagefile context=/old/context.a\n"), 0o644))
+	// Make the file read-only so the rewrite fails.
+	require.NoError(t, os.Chmod(linkCfg, 0o444))
+	t.Cleanup(func() { _ = os.Chmod(linkCfg, 0o600) })
+
+	args := []string{"link", "-o", "exe", "-buildid", "id", "-importcfg", linkCfg}
+	_, err := interceptLink(ctx, args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writing link importcfg")
+}
+
+func TestInterceptToolVersionWriteError(t *testing.T) {
+	ctx := util.ContextWithLogger(t.Context(), slog.Default())
+	t.Setenv(util.EnvOtelcWorkDir, t.TempDir())
+
+	// Replace os.Stdout with a closed file so the tool version line write fails.
+	oldStdout := os.Stdout
+	f, err := os.Create(filepath.Join(t.TempDir(), "closed"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	os.Stdout = f
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	err = interceptToolVersion(ctx, []string{goCompileToolPath(t), "-V=full"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writing tool version")
+}

--- a/tool/internal/profile/profile_extra_test.go
+++ b/tool/internal/profile/profile_extra_test.go
@@ -1,0 +1,183 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartCPUCreateFileError(t *testing.T) {
+	dir := t.TempDir()
+	// A directory occupying the CPU profile path makes os.Create fail.
+	path := filepath.Join(dir, fmt.Sprintf("otelc-cpu-%d.pprof", os.Getpid()))
+	require.NoError(t, os.Mkdir(path, 0o755))
+
+	_, err := Start(dir, []Type{CPU})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "create CPU profile")
+}
+
+func TestStartCPUProfileAlreadyRunning(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.CreateTemp(t.TempDir(), "cpu")
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, pprof.StartCPUProfile(f))
+	defer pprof.StopCPUProfile()
+
+	_, err = Start(dir, []Type{CPU})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "start CPU profile")
+}
+
+func TestStartTraceCreateFileError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, fmt.Sprintf("otelc-%d.trace", os.Getpid()))
+	require.NoError(t, os.Mkdir(path, 0o755))
+
+	_, err := Start(dir, []Type{Trace})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "create trace file")
+}
+
+func TestStartTraceAlreadyRunning(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.CreateTemp(t.TempDir(), "trace")
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, trace.Start(f))
+	defer trace.Stop()
+
+	_, err = Start(dir, []Type{Trace})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "start execution trace")
+}
+
+func TestStopCPUCloseError(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Start(dir, []Type{CPU})
+	require.NoError(t, err)
+	require.NotNil(t, s.cpuFile)
+	require.NoError(t, s.cpuFile.Close())
+
+	stopErr := s.Stop()
+	require.Error(t, stopErr)
+	require.ErrorContains(t, stopErr, "close CPU profile")
+}
+
+func TestStopTraceCloseError(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Start(dir, []Type{Trace})
+	require.NoError(t, err)
+	require.NotNil(t, s.traceFile)
+	require.NoError(t, s.traceFile.Close())
+
+	stopErr := s.Stop()
+	require.Error(t, stopErr)
+	require.ErrorContains(t, stopErr, "close trace file")
+}
+
+func TestWriteHeapProfileCreateError(t *testing.T) {
+	s := &Session{dir: t.TempDir()}
+	path := filepath.Join(s.dir, fmt.Sprintf("otelc-heap-%d.pprof", os.Getpid()))
+	require.NoError(t, os.Mkdir(path, 0o755))
+
+	err := s.writeHeapProfile()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "create heap profile")
+}
+
+func TestMergeTypeGlobError(t *testing.T) {
+	// An unclosed bracket in the directory name makes filepath.Glob fail.
+	dir := filepath.Join(t.TempDir(), "a[")
+	err := mergeType(context.Background(), dir, CPU)
+	require.Error(t, err)
+}
+
+func TestMergeReturnsMergeError(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "a[")
+	err := Merge(context.Background(), dir, []Type{CPU})
+	require.Error(t, err)
+}
+
+func TestMergeTypeCreateOutputError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "otelc-cpu-1.pprof"), []byte("data"), 0o644))
+	// The merged output path is blocked by a directory.
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "otelc-cpu.pprof"), 0o755))
+
+	err := mergeType(context.Background(), dir, CPU)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "create merged")
+}
+
+func TestMergeTypeGoToolFailsWithStderr(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "otelc-cpu-1.pprof"), []byte("data"), 0o644))
+
+	bin := t.TempDir()
+	if runtime.GOOS == "windows" {
+		script := filepath.Join(bin, "go.bat")
+		require.NoError(t, os.WriteFile(script, []byte("@echo merge failed 1>&2\r\nexit /b 1\r\n"), 0o644))
+	} else {
+		script := filepath.Join(bin, "go")
+		require.NoError(t, os.WriteFile(script, []byte("#!/bin/sh\nprintf 'merge failed\n' 1>&2\nexit 1\n"), 0o755))
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	err := mergeType(context.Background(), dir, CPU)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "merge failed")
+}
+
+func TestMergeTypeGoToolFailsWithoutStderr(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "otelc-cpu-1.pprof"), []byte("data"), 0o644))
+
+	bin := t.TempDir()
+	if runtime.GOOS == "windows" {
+		script := filepath.Join(bin, "go.bat")
+		require.NoError(t, os.WriteFile(script, []byte("@exit /b 1\r\n"), 0o644))
+	} else {
+		script := filepath.Join(bin, "go")
+		require.NoError(t, os.WriteFile(script, []byte("#!/bin/sh\nexit 1\n"), 0o755))
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	err := mergeType(context.Background(), dir, CPU)
+	require.Error(t, err)
+}
+
+func TestStopHeapWriteError(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Start(dir, []Type{Heap})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	path := filepath.Join(dir, fmt.Sprintf("otelc-heap-%d.pprof", os.Getpid()))
+	require.NoError(t, os.Mkdir(path, 0o755))
+
+	stopErr := s.Stop()
+	require.Error(t, stopErr)
+	require.ErrorContains(t, stopErr, "write heap profile")
+}
+
+func TestMergeTypeGoToolNotFound(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "otelc-cpu-1.pprof"), []byte("data"), 0o644))
+	t.Setenv("PATH", "")
+
+	err := mergeType(context.Background(), dir, CPU)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "merge cpu profiles")
+}

--- a/tool/internal/setup/setup_extra_test.go
+++ b/tool/internal/setup/setup_extra_test.go
@@ -1,0 +1,227 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dave/dst"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otelc/tool/internal/rule"
+	"go.opentelemetry.io/otelc/tool/util"
+)
+
+func TestCreateRuleFromFields_CallRule(t *testing.T) {
+	raw := []byte("target: example.com/x\nfunction_call: net/http.Get\nreplace: tracedGet({{ . }})\n")
+	fields := map[string]any{
+		"target":             "example.com/x",
+		rule.SelFunctionCall: "net/http.Get",
+		"replace":            "tracedGet({{ . }})",
+	}
+
+	r, err := createRuleFromFields(raw, "call-rule", fields)
+	require.NoError(t, err)
+	require.IsType(t, &rule.InstCallRule{}, r)
+}
+
+func TestCreateRuleFromFields_UnrecognizedSelector(t *testing.T) {
+	fields := map[string]any{"target": "example.com/x"}
+	_, err := createRuleFromFields(nil, "bad-rule", fields)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no recognised selector")
+}
+
+func TestParseRuleFromYaml_NormalizeError(t *testing.T) {
+	content := []byte(`bad:
+  target: main
+  where:
+    target: net/http
+    func: Open
+  do:
+    - inject_hooks:
+        before: BeforeOpen
+        path: example.com/hooks
+`)
+	_, err := parseRuleFromYaml(content)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "target must be top-level")
+}
+
+func TestRunMatch_CgoFiles(t *testing.T) {
+	dep := &Dependency{
+		ImportPath: "example.com/cgo",
+		CgoFiles:   map[string]string{"a.go": "header"},
+	}
+
+	sp := newTestSetupPhase()
+	set, err := sp.runMatch(context.Background(), dep, nil, nil)
+	require.NoError(t, err)
+	require.True(t, set.IsEmpty())
+}
+
+func TestRunMatch_VersionFilteredOut(t *testing.T) {
+	srcFile := writeGoSource(t, "v.go", "package v\n\nfunc Handler() {}\n")
+	dep := &Dependency{
+		ImportPath: "example.com/v",
+		Version:    "v1.0.0",
+		Sources:    []string{srcFile},
+		CgoFiles:   map[string]string{},
+	}
+	funcRule := &rule.InstFuncRule{
+		InstBaseRule: rule.InstBaseRule{
+			Name:    "vrule",
+			Target:  "example.com/v",
+			Version: "v2.0.0",
+		},
+		Func:   "Handler",
+		Before: "BeforeHandler",
+		Path:   "example.com/hooks",
+	}
+
+	sp := newTestSetupPhase()
+	set, err := sp.runMatch(context.Background(), dep, map[string][]rule.InstRule{"example.com/v": {funcRule}}, nil)
+	require.NoError(t, err)
+	require.True(t, set.IsEmpty())
+}
+
+func TestPreciseMatching_NoSources(t *testing.T) {
+	dep := &Dependency{ImportPath: "example.com/empty"}
+	funcRule := &rule.InstFuncRule{
+		InstBaseRule: rule.InstBaseRule{Name: "r", Target: "example.com/empty"},
+		Func:         "Foo",
+	}
+
+	sp := newTestSetupPhase()
+	set := rule.NewInstRuleSet(dep.ImportPath)
+	res, err := sp.preciseMatching(context.Background(), dep, []rule.InstRule{funcRule}, set)
+	require.NoError(t, err)
+	require.True(t, res.IsEmpty())
+}
+
+func TestPreciseMatching_CtxCancelled(t *testing.T) {
+	srcFile := writeGoSource(t, "c.go", "package c\n\nfunc Foo() {}\n")
+	dep := &Dependency{
+		ImportPath: "example.com/c",
+		Sources:    []string{srcFile},
+	}
+	funcRule := &rule.InstFuncRule{
+		InstBaseRule: rule.InstBaseRule{Name: "r", Target: "example.com/c"},
+		Func:         "Foo",
+		Before:       "BeforeFoo",
+		Path:         "example.com/hooks",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	sp := newTestSetupPhase()
+	set := rule.NewInstRuleSet(dep.ImportPath)
+	_, err := sp.preciseMatching(ctx, dep, []rule.InstRule{funcRule}, set)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestPreciseMatching_MatchOneRuleError(t *testing.T) {
+	srcFile := writeGoSource(t, "s.go", "package s\n\nfunc Foo(a string) error { return nil }\n")
+	dep := &Dependency{
+		ImportPath: "example.com/s",
+		Sources:    []string{srcFile},
+	}
+	badRule := &rule.InstFuncRule{
+		InstBaseRule: rule.InstBaseRule{Name: "bad", Target: "example.com/s"},
+		Func:         "Foo",
+		Signature:    &rule.FuncSignature{Args: []string{"[]invalid"}},
+	}
+
+	sp := newTestSetupPhase()
+	set := rule.NewInstRuleSet(dep.ImportPath)
+	_, err := sp.preciseMatching(context.Background(), dep, []rule.InstRule{badRule}, set)
+	require.Error(t, err)
+}
+
+func TestRulesFromDirWalkError(t *testing.T) {
+	_, err := rulesFromDir(filepath.Join(t.TempDir(), "missing"), false)
+	require.Error(t, err)
+}
+
+func TestLoadCustomRulesStatError(t *testing.T) {
+	t.Setenv(util.EnvOtelcRules, "")
+	_, err := loadCustomRules(filepath.Join(t.TempDir(), "nope.yaml"))
+	require.Error(t, err)
+}
+
+func TestMatchDeps_NoRules(t *testing.T) {
+	t.Setenv(util.EnvOtelcRules, "")
+
+	sp := newTestSetupPhase()
+	matched, err := sp.matchDeps(context.Background(), []*Dependency{{ImportPath: "example.com/x"}}, nil)
+	require.NoError(t, err)
+	require.Nil(t, matched)
+}
+
+func TestMatchDeps_RunMatchError(t *testing.T) {
+	ruleFile := filepath.Join(t.TempDir(), "r.yaml")
+	err := os.WriteFile(ruleFile, []byte(`h:
+  target: example.com/bad
+  func: Handler
+  before: BeforeHandler
+  path: "example.com/hooks"
+`), 0o644)
+	require.NoError(t, err)
+
+	badSrc := writeGoSource(t, "bad.go", "not valid go {{{")
+	sp := newTestSetupPhase()
+	sp.ruleConfig = ruleFile
+
+	_, err = sp.matchDeps(context.Background(), []*Dependency{
+		{ImportPath: "example.com/bad", Sources: []string{badSrc}, CgoFiles: map[string]string{}},
+	}, nil)
+	require.Error(t, err)
+}
+
+func TestFindToolFilesBothExist(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, ToolFileCanonical), []byte("package main"), 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, ToolFileAlias), []byte("package main"), 0o644)
+	require.NoError(t, err)
+
+	_, err = findToolFiles(map[string]bool{dir: true})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "only one instrumentation config file")
+}
+
+func TestLoadRules_FindToolFilesError(t *testing.T) {
+	t.Setenv(util.EnvOtelcRules, "")
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, ToolFileCanonical), []byte("package main"), 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, ToolFileAlias), []byte("package main"), 0o644)
+	require.NoError(t, err)
+
+	sp := newTestSetupPhase()
+	_, err = sp.loadRules(context.Background(), map[string]bool{dir: true})
+	require.Error(t, err)
+}
+
+func TestCollectImports_UnquoteError(t *testing.T) {
+	f := &dst.File{Imports: []*dst.ImportSpec{
+		{Name: &dst.Ident{Name: "_"}, Path: &dst.BasicLit{Value: `"badpath`}},
+	}}
+
+	_, err := collectImports("tool.go", f, map[string]bool{})
+	require.Error(t, err)
+}
+
+func TestWalkInstrumentationParseError(t *testing.T) {
+	err := walkInstrumentation(
+		context.Background(),
+		[]string{filepath.Join(t.TempDir(), "nope.go")},
+		func(v *InstrumentationVisit) (bool, error) { return false, nil },
+	)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Description

Adds unit tests to the tool module to raise its coverage toward the 70% project threshold. No production code changes.

- 	ool/internal/profile: start/stop error paths and go tool pprof -proto merge failure paths.
- 	ool/internal/ast: FindFuncDecl dispatch and signature-filter error paths.
- 	ool/internal/instrument: call template and Go-expression parse error paths; toolexec compile/link interception error paths, importcfg resolution/rewrite paths, and tool-version probe write failure.
- 	ool/internal/setup: rule creation/parsing, matching, rules discovery, and instrumentation-config walking error paths.

## Motivation

The codecov/project/pkg check on this repository requires 70% coverage. These tests cover previously unreported branches in the tool module, aligning with the approach taken in #893.

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: make format
- [x] Linters pass: make lint
- [x] Tests pass: make test
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.