### PR TITLE
fix(tool): allow importcfg lines larger than bufio scanner limit

### DIFF
--- a/tool/internal/imports/importcfg.go
+++ b/tool/internal/imports/importcfg.go
@@ -36,10 +36,20 @@ func ParseImportCfg(filename string) (ImportConfig, error) {
 	return parse(file)
 }
 
+// maxImportCfgLineSize is the maximum accepted length of a single importcfg
+// line. bufio.Scanner's default limit is bufio.MaxScanTokenSize (64 KiB),
+// which is too small for large build configurations.
+const maxImportCfgLineSize = 10 << 20 // 10 MiB
+
 // parse parses the importcfg data from the provided reader.
 func parse(r io.Reader) (ImportConfig, error) {
 	var reg ImportConfig
 	scanner := bufio.NewScanner(r)
+	// Allow importcfg lines larger than bufio.MaxScanTokenSize (64 KiB), which
+	// can occur in large build configurations with long package import paths
+	// or complex import maps. Without this, scanning fails with
+	// bufio.ErrTooLong ("token too long").
+	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), maxImportCfgLineSize)
 	scanner.Split(bufio.ScanLines)
 
 	for scanner.Scan() {

--- a/tool/internal/imports/importcfg_test.go
+++ b/tool/internal/imports/importcfg_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -179,6 +180,19 @@ func (r *errorReader) Read(p []byte) (int, error) {
 		return n, r.err
 	}
 	return n, nil
+}
+
+func TestParse_LongLine(t *testing.T) {
+	// Lines in importcfg files can exceed bufio.MaxScanTokenSize (64 KiB) in
+	// large build configurations with long package import paths or complex
+	// import maps. parse must not fail with bufio.ErrTooLong in that case.
+	longPath := "example.com/" + strings.Repeat("a", 128*1024)
+	input := "packagefile " + longPath + "=/path/to/pkg.a\n"
+
+	cfg, err := parse(bytes.NewReader([]byte(input)))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/path/to/pkg.a", cfg.PackageFile[longPath])
 }
 
 func TestParse_ScannerError(t *testing.T) {


### PR DESCRIPTION
## Description

`ParseImportCfg` (and the underlying `parse`) now configures its `bufio.Scanner` with a custom buffer whose maximum capacity is 10 MiB instead of the default `bufio.MaxScanTokenSize` (64 KiB). Importcfg files produced by large build configurations or mono-repos can contain individual directive lines longer than 64 KiB (long package import paths, complex import maps), which previously made scanning fail with `bufio.ErrTooLong` ("token too long") and broke builds.

## Motivation

Large importcfg lines are valid Go toolchain input and should be parsed instead of rejected. This change keeps `bufio.Scanner` semantics but lifts the arbitrary 64 KiB token limit to 10 MiB, which comfortably covers real-world importcfg lines while still bounding memory.

Adds `TestParse_LongLine`, a regression test that feeds a `packagefile` directive with a >128 KiB import path and verifies it parses correctly (it fails with `bufio.ErrTooLong` without this change).

Fixes #908

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.