### PR TITLE
test(util): use cross-platform go executable in TestRunCmd

### DIFF
--- a/tool/util/sys_test.go
+++ b/tool/util/sys_test.go
@@ -20,13 +20,13 @@ func TestRunCmd(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name:      "simple echo command",
-			args:      []string{"echo", "hello"},
+			name:      "simple executable command",
+			args:      []string{"go", "version"},
 			expectErr: false,
 		},
 		{
 			name:      "command with multiple arguments",
-			args:      []string{"echo", "hello", "world"},
+			args:      []string{"go", "env", "GOOS"},
 			expectErr: false,
 		},
 		{


### PR DESCRIPTION
## Description

Replaced `echo` with the cross-platform `go` toolchain executable (`go version`, `go env GOOS`) in `TestRunCmd` unit test cases in `tool/util/sys_test.go`.

## Motivation

On Windows systems, `echo` is a shell built-in command in `cmd.exe` and `powershell.exe` rather than a standalone executable binary present in `%PATH%`. Running `go test ./tool/util/...` on Windows caused `TestRunCmd` to fail with `exec: "echo": executable file not found in %PATH%`.

Using `go` toolchain invocations makes the test suite completely cross-platform across Windows, Linux, and macOS.

Fixes #939

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))
