### PR TITLE
fix(pkg): handle nil client options in MongoDB client hooks

### DIFF
--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/client_hook.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/client_hook.go
@@ -41,6 +41,9 @@ func BeforeConnect(ictx hook.HookContext, ctx context.Context, opts ...*options.
 
 	// Inject monitor to all existing options
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		if opt.Monitor == nil {
 			opt.SetMonitor(monitor)
 		}
@@ -67,6 +70,9 @@ func BeforeNewClient(ictx hook.HookContext, opts ...*options.ClientOptions) {
 
 	// Inject monitor to all existing options
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		if opt.Monitor == nil {
 			opt.SetMonitor(monitor)
 		}

--- a/instrumentation/go.mongodb.org/mongo-driver/mongo/client_hook_test.go
+++ b/instrumentation/go.mongodb.org/mongo-driver/mongo/client_hook_test.go
@@ -127,6 +127,19 @@ func TestBeforeConnect(t *testing.T) {
 
 		assert.Nil(t, mockCtx.GetParam(1), "param 1 (opts) should be left untouched when instrumentation is disabled")
 	})
+
+	t.Run("does not panic on nil options", func(t *testing.T) {
+		t.Setenv("OTEL_GO_ENABLED_INSTRUMENTATIONS", "MONGODB")
+
+		mockCtx := hooktest.NewMockHookContext(t.Context())
+
+		BeforeConnect(mockCtx, t.Context(), nil)
+
+		newOpts, ok := mockCtx.GetParam(1).([]*options.ClientOptions)
+		require.True(t, ok, "param 1 should be updated with a []*options.ClientOptions")
+		require.Len(t, newOpts, 1)
+		assert.Nil(t, newOpts[0], "first option should still be nil")
+	})
 }
 
 func TestBeforeNewClient(t *testing.T) {
@@ -182,5 +195,18 @@ func TestBeforeNewClient(t *testing.T) {
 		BeforeNewClient(mockCtx)
 
 		assert.Equal(t, 0, mockCtx.GetParamCount(), "no param should be set when instrumentation is disabled")
+	})
+
+	t.Run("does not panic on nil options", func(t *testing.T) {
+		t.Setenv("OTEL_GO_ENABLED_INSTRUMENTATIONS", "MONGODB")
+
+		mockCtx := hooktest.NewMockHookContext()
+
+		BeforeNewClient(mockCtx, nil)
+
+		newOpts, ok := mockCtx.GetParam(0).([]*options.ClientOptions)
+		require.True(t, ok, "param 0 should be updated with a []*options.ClientOptions")
+		require.Len(t, newOpts, 1)
+		assert.Nil(t, newOpts[0], "first option should still be nil")
 	})
 }


### PR DESCRIPTION
Assisted-by: Gemini

## Description

This PR adds nil checks to the options slice loops inside `BeforeConnect` and `BeforeNewClient` in `instrumentation/go.mongodb.org/mongo-driver/mongo/client_hook.go`. It also adds defensive unit tests to `client_hook_test.go` covering nil options.

## Motivation

Prevent runtime nil pointer dereference panics when MongoDB client functions are called with explicit nil parameters.

Fixes #945 

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable)
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
    