### PR TITLE
chore(test): add multi-process e2e for gRPC→SQL propagation

### DIFF
--- a/test/e2e/grpcserver_dbclient_test.go
+++ b/test/e2e/grpcserver_dbclient_test.go
@@ -1,0 +1,61 @@
+//go:build e2e
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+
+	"go.opentelemetry.io/otelc/test/testutil"
+)
+
+func TestGRPCServerDBClient(t *testing.T) {
+	f := testutil.NewTestFixture(t)
+
+	frontPort := testutil.FreePort(t)
+	addr := fmt.Sprintf("127.0.0.1:%d", frontPort)
+
+	f.BuildAndStart("grpcserverdbclient", fmt.Sprintf("-front-port=%d", frontPort))
+	testutil.WaitForTCP(t, addr)
+
+	f.BuildAndRun("grpcclient", "-addr", addr, "-name", "test")
+
+	// BuildAndRun returns once the client exits, but the server span ends after
+	// the response is written, so it may still be in flight. Wait for all three.
+	f.WaitForSpans(3)
+
+	// One distributed trace with three spans:
+	// gRPC client -> gRPC server -> SQL client
+	f.RequireTraceCount(1)
+	f.RequireSpansPerTrace(3)
+
+	grpcClientSpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsClient,
+		testutil.HasAttribute(string(semconv.RPCSystemKey), "grpc"),
+	)
+	grpcServerSpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsServer,
+		testutil.HasAttribute(string(semconv.RPCSystemKey), "grpc"),
+		testutil.HasAttribute(string(semconv.RPCGRPCStatusCodeKey), int64(0)),
+	)
+	sqlClientSpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsClient,
+		testutil.HasAttribute(string(semconv.DBOperationNameKey), "SELECT"),
+	)
+
+	require.Equal(t, grpcClientSpan.TraceID(), grpcServerSpan.TraceID(), "gRPC client and server must share a trace ID")
+	require.Equal(
+		t,
+		grpcServerSpan.TraceID(),
+		sqlClientSpan.TraceID(),
+		"gRPC server and SQL client must share a trace ID",
+	)
+	require.Equal(t, grpcClientSpan.SpanID(), grpcServerSpan.ParentSpanID(), "gRPC server parent must be gRPC client")
+	require.Equal(t, grpcServerSpan.SpanID(), sqlClientSpan.ParentSpanID(), "SQL client parent must be gRPC server")
+}


### PR DESCRIPTION
## Description
Adds a multi-process E2E test that drives an instrumented `grpcclient` against `grpcserverdbclient` and asserts one distributed trace with three spans: gRPC client → gRPC server → SQL client (shared trace ID and parent/child links). Pins a successful RPC outcome via `rpc.grpc.status_code=0`.

## Motivation
`grpcserverdbclient` was only covered by an in-process integration test with an uninstrumented client. Per `docs/testing.md`, E2E should verify cross-process propagation across multiple instrumented processes.
Fixes #947

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]
[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.