### PR TITLE
fix(tool/internal/ast): avoid panic in typename.matches for unsupported AST node types

### DIFF
--- a/tool/internal/ast/typename.go
+++ b/tool/internal/ast/typename.go
@@ -4,13 +4,11 @@
 package ast
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/dave/dst"
 
 	"go.opentelemetry.io/otelc/tool/ex"
-	"go.opentelemetry.io/otelc/tool/util"
 )
 
 // typeNameRe parses type-name strings of the form [*][pkg.]Name.
@@ -69,7 +67,6 @@ func (t parsedTypeName) matches(node dst.Expr) bool {
 	default:
 		// Unsupported AST node types (chan, func, map, slice, array, interface
 		// literals) cannot be matched by type-name filters.
-		util.Unimplemented(fmt.Sprintf("signature filter: unsupported type node %T", node))
 		return false
 	}
 }

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -114,6 +114,30 @@ func TestTypeNameMatches(t *testing.T) {
 			node:    &dst.InterfaceType{Methods: &dst.FieldList{}},
 			want:    true,
 		},
+		{
+			name:    "unsupported array type node returns false without panic",
+			typeStr: "string",
+			node:    &dst.ArrayType{Elt: &dst.Ident{Name: "string"}},
+			want:    false,
+		},
+		{
+			name:    "unsupported map type node returns false without panic",
+			typeStr: "string",
+			node:    &dst.MapType{Key: &dst.Ident{Name: "string"}, Value: &dst.Ident{Name: "int"}},
+			want:    false,
+		},
+		{
+			name:    "unsupported chan type node returns false without panic",
+			typeStr: "int",
+			node:    &dst.ChanType{Value: &dst.Ident{Name: "int"}},
+			want:    false,
+		},
+		{
+			name:    "unsupported func type node returns false without panic",
+			typeStr: "error",
+			node:    &dst.FuncType{},
+			want:    false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -143,6 +167,8 @@ func TestFieldListContainsType(t *testing.T) {
 				},
 			},
 			{Type: &dst.Ident{Name: "error"}},
+			{Type: &dst.ArrayType{Elt: &dst.Ident{Name: "byte"}}},
+			{Type: &dst.MapType{Key: &dst.Ident{Name: "string"}, Value: &dst.Ident{Name: "string"}}},
 		},
 	}
 


### PR DESCRIPTION
Fixes #954

### Summary
Fixes `parsedTypeName.matches` in `tool/internal/ast/typename.go` to return `false` instead of calling `util.Unimplemented(...)` (which panics) when evaluating unsupported AST node types like `dst.ArrayType`, `dst.MapType`, `dst.ChanType`, and `dst.FuncType`.

### Changes
- Removed call to `util.Unimplemented(...)` in default branch of `parsedTypeName.matches`.
- - Added unit tests covering unsupported AST types (`ArrayType`, `MapType`, `ChanType`, `FuncType`) in `typename_test.go` to verify they return `false` without panicking.