### PR TITLE
test(e2e): assert client span is the trace root in dbclient propagation tests

### DIFF
--- a/test/e2e/grpcserver_dbclient_test.go
+++ b/test/e2e/grpcserver_dbclient_test.go
@@ -58,4 +58,5 @@ func TestGRPCServerDBClient(t *testing.T) {
 	)
 	require.Equal(t, grpcClientSpan.SpanID(), grpcServerSpan.ParentSpanID(), "gRPC server parent must be gRPC client")
 	require.Equal(t, grpcServerSpan.SpanID(), sqlClientSpan.ParentSpanID(), "SQL client parent must be gRPC server")
+	require.True(t, grpcClientSpan.ParentSpanID().IsEmpty(), "gRPC client span must be the trace root")
 }

--- a/test/e2e/httpserver_dbclient_test.go
+++ b/test/e2e/httpserver_dbclient_test.go
@@ -58,4 +58,5 @@ func TestHTTPServerDBClient(t *testing.T) {
 	)
 	require.Equal(t, httpClientSpan.SpanID(), httpServerSpan.ParentSpanID(), "HTTP server parent must be HTTP client")
 	require.Equal(t, httpServerSpan.SpanID(), sqlClientSpan.ParentSpanID(), "SQL client parent must be HTTP server")
+	require.True(t, httpClientSpan.ParentSpanID().IsEmpty(), "HTTP client span must be the trace root")
 }


### PR DESCRIPTION
Fixes #960

Adds assertions to TestHTTPServerDBClient and TestGRPCServerDBClient ensuring that the initiating client span is the trace root (ParentSpanID().IsEmpty()).