### PR TITLE
test(apps/grpcserverdbclient): bind gRPC frontend to loopback instead of all interfaces

### DIFF
--- a/test/apps/grpcserverdbclient/main.go
+++ b/test/apps/grpcserverdbclient/main.go
@@ -47,9 +47,9 @@ func main() {
 	}
 	defer db.Close()
 
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *frontPort))
+	lis, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", *frontPort))
 	if err != nil {
-		log.Fatalf("failed to listen on frontPort: %v", err)
+		log.Fatalf("failed to listen: %v", err)
 	}
 	grpcServer := grpc.NewServer()
 	pb.RegisterGreeterServer(grpcServer, &server{db: db})


### PR DESCRIPTION
Fixes [#961](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/961)

Updates test/apps/grpcserverdbclient/main.go to bind its gRPC server listener specifically to loopback (127.0.0.1) instead of all network interfaces (0.0.0.0).