### PR TITLE
fix(tool/internal/setup): add mutex to StateManager to prevent concurrent map access data race

### DIFF
--- a/tool/internal/setup/state.go
+++ b/tool/internal/setup/state.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"go.opentelemetry.io/otelc/tool/ex"
 	"go.opentelemetry.io/otelc/tool/util"
@@ -29,8 +30,9 @@ const (
 // Files that do not exist when tracked are recorded and removed during Revert if
 // they are later created.
 //
-// StateManager is not safe for concurrent use.
+// StateManager is safe for concurrent use.
 type StateManager struct {
+	mu    sync.Mutex
 	files map[string]bool // true = existed when tracked
 }
 
@@ -167,24 +169,32 @@ func (s *StateManager) Track(path string) error {
 	}
 
 	abs = filepath.Clean(abs)
+
+	s.mu.Lock()
 	if _, ok := s.files[abs]; ok {
+		s.mu.Unlock()
 		return nil
 	}
 
 	// If the file doesn't exist, mark it for removal
 	if !util.PathExists(abs) {
 		s.files[abs] = false
-		return s.Commit()
+		err = s.commitLocked()
+		s.mu.Unlock()
+		return err
 	}
 
 	// If the file exists, snapshot it
 	dst := filepath.Join(util.GetBuildTemp(stateDir), stateSnapshotPath(abs))
 	if err = util.CopyFile(abs, dst); err != nil {
+		s.mu.Unlock()
 		return ex.Wrapf(err, "failed to snapshot %s", abs)
 	}
 
 	s.files[abs] = true
-	return s.Commit()
+	err = s.commitLocked()
+	s.mu.Unlock()
+	return err
 }
 
 // Commit persists the tracked state to disk so it can be restored by a future
@@ -194,6 +204,12 @@ func (s *StateManager) Track(path string) error {
 // Track calls Commit automatically; calling it directly is only needed to
 // re-persist after external changes.
 func (s *StateManager) Commit() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.commitLocked()
+}
+
+func (s *StateManager) commitLocked() error {
 	if len(s.files) == 0 {
 		return nil
 	}
@@ -232,6 +248,9 @@ func (s *StateManager) Commit() error {
 // successful Revert: the state is consumed, and leaving it behind would let a
 // later `otelc cleanup` re-apply snapshots from a finished build.
 func (s *StateManager) Discard() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if len(s.files) == 0 {
 		return nil
 	}
@@ -251,6 +270,9 @@ func (s *StateManager) Discard() error {
 // Files that originally existed are restored from their snapshots. Files that
 // did not exist when tracked are removed if they exist.
 func (s *StateManager) Revert() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if len(s.files) == 0 {
 		return nil
 	}
@@ -273,3 +295,4 @@ func (s *StateManager) Revert() error {
 
 	return err
 }
+

--- a/tool/internal/setup/state.go
+++ b/tool/internal/setup/state.go
@@ -171,30 +171,26 @@ func (s *StateManager) Track(path string) error {
 	abs = filepath.Clean(abs)
 
 	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if _, ok := s.files[abs]; ok {
-		s.mu.Unlock()
 		return nil
 	}
 
 	// If the file doesn't exist, mark it for removal
 	if !util.PathExists(abs) {
 		s.files[abs] = false
-		err = s.commitLocked()
-		s.mu.Unlock()
-		return err
+		return s.commitLocked()
 	}
 
 	// If the file exists, snapshot it
 	dst := filepath.Join(util.GetBuildTemp(stateDir), stateSnapshotPath(abs))
 	if err = util.CopyFile(abs, dst); err != nil {
-		s.mu.Unlock()
 		return ex.Wrapf(err, "failed to snapshot %s", abs)
 	}
 
 	s.files[abs] = true
-	err = s.commitLocked()
-	s.mu.Unlock()
-	return err
+	return s.commitLocked()
 }
 
 // Commit persists the tracked state to disk so it can be restored by a future
@@ -295,4 +291,3 @@ func (s *StateManager) Revert() error {
 
 	return err
 }
-

--- a/tool/internal/setup/state_test.go
+++ b/tool/internal/setup/state_test.go
@@ -5,9 +5,11 @@ package setup
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -441,3 +443,37 @@ func TestStateManagerCommitIsAtomicAndSorted(t *testing.T) {
 	assert.Equal(t, string(first), string(second), "manifest serialization must be deterministic")
 	assert.False(t, util.PathExists(util.GetBuildTemp(stateFileName)+".tmp"), "no temp file left behind")
 }
+
+func TestStateManagerConcurrentTrack(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	s := NewStateManager()
+	const numGoroutines = 20
+	const filesPerGoroutine = 10
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(routineID int) {
+			defer wg.Done()
+			for j := 0; j < filesPerGoroutine; j++ {
+				filename := filepath.Join(tmp, fmt.Sprintf("file_%d_%d.txt", routineID, j))
+				if j%2 == 0 {
+					_ = os.WriteFile(filename, []byte("data"), 0o644)
+				}
+				_ = s.Track(filename)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	s.mu.Lock()
+	fileCount := len(s.files)
+	s.mu.Unlock()
+
+	assert.Equal(t, numGoroutines*filesPerGoroutine, fileCount)
+}
+

--- a/tool/internal/setup/state_test.go
+++ b/tool/internal/setup/state_test.go
@@ -446,7 +446,7 @@ func TestStateManagerCommitIsAtomicAndSorted(t *testing.T) {
 
 func TestStateManagerConcurrentTrack(t *testing.T) {
 	tmp := t.TempDir()
-	t.Chdir(tmp)
+	t.Setenv(util.EnvOtelcWorkDir, tmp)
 
 	s := NewStateManager()
 	const numGoroutines = 20
@@ -461,9 +461,9 @@ func TestStateManagerConcurrentTrack(t *testing.T) {
 			for j := range filesPerGoroutine {
 				filename := filepath.Join(tmp, fmt.Sprintf("file_%d_%d.txt", routineID, j))
 				if j%2 == 0 {
-					_ = os.WriteFile(filename, []byte("data"), 0o644)
+					assert.NoError(t, os.WriteFile(filename, []byte("data"), 0o644))
 				}
-				_ = s.Track(filename)
+				assert.NoError(t, s.Track(filename))
 			}
 		}(i)
 	}

--- a/tool/internal/setup/state_test.go
+++ b/tool/internal/setup/state_test.go
@@ -455,10 +455,10 @@ func TestStateManagerConcurrentTrack(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		go func(routineID int) {
 			defer wg.Done()
-			for j := 0; j < filesPerGoroutine; j++ {
+			for j := range filesPerGoroutine {
 				filename := filepath.Join(tmp, fmt.Sprintf("file_%d_%d.txt", routineID, j))
 				if j%2 == 0 {
 					_ = os.WriteFile(filename, []byte("data"), 0o644)
@@ -476,4 +476,3 @@ func TestStateManagerConcurrentTrack(t *testing.T) {
 
 	assert.Equal(t, numGoroutines*filesPerGoroutine, fileCount)
 }
-


### PR DESCRIPTION
Fixes #962 
### Description
`StateManager` in `tool/internal/setup/state.go` tracks file states during build setup and cleanup phases. While previously documented as not safe for concurrent use, `StateManager` instances can be attached to `context.Context` (via `ContextWithStateManager`) and passed across concurrent execution flows. Simultaneous calls to `s.Track()` mutate the `s.files` map without synchronization, leading to potential data races and runtime map concurrent write panics.

### Changes
- Added a `sync.Mutex` field (`mu`) to `StateManager`.
- Synchronized all accesses to `s.files` across `Track()`, `Commit()`, `Discard()`, and `Revert()`.
- Added helper `commitLocked()` to handle internal commit calls during tracking without deadlock/double locking.
- Added concurrent unit test `TestStateManagerConcurrentTrack` in `state_test.go`.