### PR TITLE
fix(toolexec): avoid in-place slice mutation in stripCompleteFlag

### DIFF
--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -86,7 +87,8 @@ func (ip *InstrumentPhase) keepForDebug(name string) {
 func stripCompleteFlag(args []string) []string {
 	for i, arg := range args {
 		if arg == "-complete" {
-			return append(args[:i], args[i+1:]...)
+			res := slices.Clone(args)
+			return slices.Delete(res, i, i+1)
 		}
 	}
 	return args

--- a/tool/internal/instrument/toolexec_test.go
+++ b/tool/internal/instrument/toolexec_test.go
@@ -61,8 +61,13 @@ func TestStripCompleteFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy of original args to verify they are not mutated
+			origArgs := make([]string, len(tt.args))
+			copy(origArgs, tt.args)
+
 			result := stripCompleteFlag(tt.args)
 			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, origArgs, tt.args, "original slice should not be mutated")
 		})
 	}
 }


### PR DESCRIPTION
Fixes #989

Removes the in-place slice mutation in stripCompleteFlag by cloning the input slice via slices.Clone and then deleting the -complete flag using slices.Delete, instead of using ppend(args[:i], args[i+1:]...) which mutates the shared backing array.

Added a test case asserting the original input slice is unchanged after the call.