### PR TITLE
chore(test): add multi-process e2e for HTTP→Kafka propagation

### DIFF
--- a/test/apps/httpserverkafkaclient/main.go
+++ b/test/apps/httpserverkafkaclient/main.go
@@ -46,8 +46,7 @@ func main() {
 
 	topic := "test-topic-http"
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/produce", func(w http.ResponseWriter, r *http.Request) {
+	produce := func(w http.ResponseWriter, r *http.Request) {
 		ensureTopic(r.Context(), topic)
 
 		writer := &kafka.Writer{
@@ -71,7 +70,13 @@ func main() {
 
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("frontend produced message to kafka"))
-	})
+	}
+
+	mux := http.NewServeMux()
+	// /produce is kept for the existing integration test; /hello lets the
+	// e2e test reuse test/apps/httpclient, which always requests /hello.
+	mux.HandleFunc("/produce", produce)
+	mux.HandleFunc("/hello", produce)
 
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%d", *frontPort),

--- a/test/e2e/httpserver_kafkaclient_test.go
+++ b/test/e2e/httpserver_kafkaclient_test.go
@@ -1,0 +1,88 @@
+//go:build e2e
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+
+	"go.opentelemetry.io/otelc/test/testutil"
+)
+
+// TestHTTPServerKafkaClient is a multi-process E2E test that verifies trace
+// context propagation across three hops: an instrumented HTTP client calls
+// httpserverkafkaclient's HTTP server, which in turn produces a message to a
+// real Kafka broker. All three spans (HTTP client, HTTP server, Kafka
+// producer) must land in one distributed trace.
+func TestHTTPServerKafkaClient(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("kafka testcontainer not supported on windows")
+	}
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+
+	brokers := startKafkaContainer(t)
+
+	f := testutil.NewTestFixture(t)
+	f.SetEnv("KAFKA_BROKERS", strings.Join(brokers, ","))
+
+	frontPort := testutil.FreePort(t)
+	addr := fmt.Sprintf("http://127.0.0.1:%d", frontPort)
+
+	f.BuildAndStart("httpserverkafkaclient", fmt.Sprintf("-front-port=%d", frontPort))
+	testutil.WaitForTCP(t, fmt.Sprintf("127.0.0.1:%d", frontPort))
+
+	f.BuildAndRun("httpclient", "-addr", addr, "-name", "test")
+
+	// BuildAndRun returns once the client exits, but the server span ends
+	// after the response is written and the producer span ends after the
+	// broker ack, so both may still be in flight.
+	f.WaitForSpans(3)
+
+	// One distributed trace with three spans:
+	// HTTP client -> HTTP server -> Kafka producer
+	f.RequireTraceCount(1)
+	f.RequireSpansPerTrace(3)
+
+	httpClientSpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsClient,
+		testutil.HasAttributeContaining(string(semconv.URLFullKey), "/hello"),
+	)
+	httpServerSpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsServer,
+		testutil.HasAttribute(string(semconv.URLPathKey), "/hello"),
+		testutil.HasAttribute(string(semconv.HTTPResponseStatusCodeKey), int64(200)),
+	)
+	kafkaProducerSpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsProducer,
+		testutil.HasName("test-topic-http send"),
+	)
+
+	attrs := testutil.Attrs(kafkaProducerSpan)
+	require.Equal(t, "kafka", attrs["messaging.system"])
+	require.Equal(t, "test-topic-http", attrs["messaging.destination.name"])
+
+	require.Equal(t, httpClientSpan.TraceID(), httpServerSpan.TraceID(), "HTTP client and server must share a trace ID")
+	require.Equal(
+		t,
+		httpServerSpan.TraceID(),
+		kafkaProducerSpan.TraceID(),
+		"HTTP server and Kafka producer must share a trace ID",
+	)
+	require.Equal(t, httpClientSpan.SpanID(), httpServerSpan.ParentSpanID(), "HTTP server parent must be HTTP client")
+	require.Equal(
+		t,
+		httpServerSpan.SpanID(),
+		kafkaProducerSpan.ParentSpanID(),
+		"Kafka producer parent must be HTTP server",
+	)
+	require.True(t, httpClientSpan.ParentSpanID().IsEmpty(), "HTTP client span must be the trace root")
+}


### PR DESCRIPTION
## Summary

Closes #969.

Adds `test/e2e/httpserver_kafkaclient_test.go`: an instrumented `httpclient` calls `httpserverkafkaclient`'s HTTP server, which produces to a real Kafka broker via `testcontainers`. Verifies **cross-process** propagation (previously only covered by an integration test using an uninstrumented `http.DefaultClient`).

- One distributed trace, three spans: HTTP client → HTTP server → Kafka producer
- Asserts shared trace ID and parent/child span links across the chain
- Pins a successful HTTP outcome (`http.response.status_code=200`)
- Mirrors `test/e2e/httpserver_dbclient_test.go` (structure) and `test/e2e/kafka_test.go` (Kafka container setup, Windows/Docker skip guards) — reuses `startKafkaContainer` from the latter since both live in the same `e2e` package
- No new instrumentation needed; HTTP client/server and Kafka producer instrumentation already exist

### Small app tweak

`test/apps/httpclient` always requests `/hello`, but `httpserverkafkaclient` only served `/produce`. Extracted the existing handler into a `produce` closure and registered it on both `/produce` (unchanged, keeps the existing integration test passing) and `/hello` (new, used by this e2e test). No new app added.

## Test plan

- [x] `gofmt -l` clean on both changed files
- [x] `go build` / `go vet` clean for `test/apps/httpserverkafkaclient` and `test/e2e` (with `-tags e2e`)
- [x] `go test -tags e2e -list '.*' ./e2e/...` discovers `TestHTTPServerKafkaClient`
- [ ] Full run requires Docker (Kafka testcontainer), not available in my local sandbox — relying on CI to execute it
- [x] Existing `test/integration/httpserver_kafkaclient_test.go` (`/produce` path) is untouched by this change