### PR TITLE
refactor(tool/internal/ast): simplify tokenize in directive.go by eliminating redundant strings.Builder error checks

### DIFF
--- a/tool/internal/ast/directive.go
+++ b/tool/internal/ast/directive.go
@@ -169,33 +169,23 @@ func FindFuncsByDirective(file *dst.File, directive string) []*dst.FuncDecl {
 func tokenize(input string) ([]string, error) {
 	var tokens []string
 	var current strings.Builder
-	var err error
 	inQuote := false
 	escaped := false
 
 	for _, ch := range input {
 		if escaped {
-			_, err = current.WriteRune(ch)
-			if err != nil {
-				return nil, ex.Wrapf(err, "failed to write rune")
-			}
+			current.WriteRune(ch)
 			escaped = false
 			continue
 		}
 		if ch == '\\' && inQuote {
-			_, err = current.WriteRune(ch)
-			if err != nil {
-				return nil, ex.Wrapf(err, "failed to write rune")
-			}
+			current.WriteRune(ch)
 			escaped = true
 			continue
 		}
 		if ch == '"' {
 			inQuote = !inQuote
-			_, err = current.WriteRune(ch)
-			if err != nil {
-				return nil, ex.Wrapf(err, "failed to write rune")
-			}
+			current.WriteRune(ch)
 			continue
 		}
 		if unicode.IsSpace(ch) && !inQuote {
@@ -205,10 +195,7 @@ func tokenize(input string) ([]string, error) {
 			}
 			continue
 		}
-		_, err = current.WriteRune(ch)
-		if err != nil {
-			return nil, ex.Wrapf(err, "failed to write rune")
-		}
+		current.WriteRune(ch)
 	}
 	if inQuote {
 		return nil, ex.New("unclosed double quote")


### PR DESCRIPTION
## Description
In `tool/internal/ast/directive.go`, `tokenize` checked errors returned by `current.WriteRune(ch)` (`strings.Builder`).

Since `strings.Builder.WriteRune` is guaranteed by the Go standard library specification to never return an error, checking `err != nil` 4 times per character in the tokenization loop created dead branches and redundant code.

Fixes #997 
## Changes Made
Simplified `tokenize` in `tool/internal/ast/directive.go` by calling `current.WriteRune(ch)` directly without checking `err`.
Cleaned up dead branches in rune tokenization logic.

## Verification
golangci-lint: 0 issues
go test ./tool/internal/ast/...: All tests pass cleanly.