### PR TITLE
chore(test): add multi-process e2e for HTTP→Kafka propagation

### DIFF
--- a/test/apps/httpserverkafkaclient/main.go
+++ b/test/apps/httpserverkafkaclient/main.go
@@ -46,8 +46,7 @@ func main() {
 
 	topic := "test-topic-http"
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/produce", func(w http.ResponseWriter, r *http.Request) {
+	produce := func(w http.ResponseWriter, r *http.Request) {
 		ensureTopic(r.Context(), topic)
 
 		writer := &kafka.Writer{
@@ -71,7 +70,13 @@ func main() {
 
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("frontend produced message to kafka"))
-	})
+	}
+
+	mux := http.NewServeMux()
+	// /produce is kept for the existing integration test; /hello lets the
+	// e2e test reuse test/apps/httpclient, which always requests /hello.
+	mux.HandleFunc("/produce", produce)
+	mux.HandleFunc("/hello", produce)
 
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%d", *frontPort),

--- a/test/e2e/httpserver_kafkaclient_test.go
+++ b/test/e2e/httpserver_kafkaclient_test.go
@@ -1,0 +1,78 @@
+//go:build e2e
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+
+	"go.opentelemetry.io/otelc/test/testutil"
+)
+
+func TestHTTPServerKafkaClient(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("kafka testcontainer not supported on windows")
+	}
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+
+	brokers := startKafkaContainer(t)
+
+	f := testutil.NewTestFixture(t)
+	f.SetEnv("KAFKA_BROKERS", strings.Join(brokers, ","))
+
+	frontPort := testutil.FreePort(t)
+	addr := fmt.Sprintf("http://127.0.0.1:%d", frontPort)
+
+	f.BuildAndStart("httpserverkafkaclient", fmt.Sprintf("-front-port=%d", frontPort))
+	testutil.WaitForTCP(t, fmt.Sprintf("127.0.0.1:%d", frontPort))
+
+	f.BuildAndRun("httpclient", "-addr", addr, "-name", "test")
+
+	// BuildAndRun returns once the client exits, but the server span ends after
+	// the response is written and the producer span ends after the broker ack,
+	// so both may still be in flight. Wait for all three.
+	f.WaitForSpans(3)
+
+	// One distributed trace with three spans:
+	// HTTP client -> HTTP server -> Kafka producer
+	f.RequireTraceCount(1)
+	f.RequireSpansPerTrace(3)
+
+	httpClientSpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsClient,
+		testutil.HasAttributeContaining(string(semconv.URLFullKey), "/hello"),
+	)
+	httpServerSpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsServer,
+		testutil.HasAttribute(string(semconv.URLPathKey), "/hello"),
+		testutil.HasAttribute(string(semconv.HTTPResponseStatusCodeKey), int64(200)),
+	)
+	kafkaProducerSpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsProducer,
+		testutil.HasName("test-topic-http send"),
+	)
+
+	require.Equal(t, httpClientSpan.TraceID(), httpServerSpan.TraceID(), "HTTP client and server must share a trace ID")
+	require.Equal(
+		t,
+		httpServerSpan.TraceID(),
+		kafkaProducerSpan.TraceID(),
+		"HTTP server and Kafka producer must share a trace ID",
+	)
+	require.Equal(t, httpClientSpan.SpanID(), httpServerSpan.ParentSpanID(), "HTTP server parent must be HTTP client")
+	require.Equal(
+		t,
+		httpServerSpan.SpanID(),
+		kafkaProducerSpan.ParentSpanID(),
+		"Kafka producer parent must be HTTP server",
+	)
+}


### PR DESCRIPTION
## Description
Adds a multi-process E2E test: instrumented `httpclient` → `httpserverkafkaclient` → Kafka (testcontainers). Asserts one distributed trace with three spans (HTTP client, HTTP server, Kafka producer), shared trace ID, and parent/child links. Pins `http.response.status_code=200`.
Also registers `/hello` on `httpserverkafkaclient` (same produce logic as `/produce`) so the shared `httpclient` app can drive it. `/produce` is unchanged for the existing integration test.
## Motivation
`httpserverkafkaclient` was only covered by an integration test with an uninstrumented `http.DefaultClient`. Per `docs/testing.md`, E2E should verify cross-process propagation across multiple instrumented processes.
Fixes #969


## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]
[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
