### PR TITLE
test: enable build caching for E2E tests in CI

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -47,7 +47,16 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
         with:
           go-version-file: go.mod
+          cache-dependency-path: "**/go.mod"
+      - name: Restore otelc Go cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: test/.otelc-gocache
+          key: ${{ runner.os }}-amd64-otelc-gocache-e2e-coverage-${{ hashFiles('go.mod', '**/go.mod', '**/go.sum', 'Makefile',
+            'tool/**', 'pkg/**', 'instrumentation/**', 'test/apps/**') }}
       - run: make test-e2e/coverage
+        env:
+          OTELC_TEST_GOCACHE: ${{ github.workspace }}/test/.otelc-gocache
       - uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5.5.5
         with:
           fail_ci_if_error: true
@@ -78,9 +87,16 @@ jobs:
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # ratchet:arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Restore otelc Go cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: test/.otelc-gocache
+          key: ${{ runner.os }}-${{ matrix.platform.arch }}-otelc-gocache-e2e-${{ hashFiles('go.mod',
+            '**/go.mod', '**/go.sum', 'Makefile', 'tool/**', 'pkg/**', 'instrumentation/**', 'test/apps/**') }}
       - run: make test-e2e
         env:
           GOARCH: ${{ matrix.platform.arch }}
+          OTELC_TEST_GOCACHE: ${{ github.workspace }}/test/.otelc-gocache
 
   done:
     name: Done (E2E Tests)


### PR DESCRIPTION
## Description

Configure `actions/cache` and `OTELC_TEST_GOCACHE` environment variables for the E2E tests inside `.github/workflows/test-e2e.yaml` (both coverage and standard runs).

## Motivation

Currently, the E2E workflow (`test-e2e.yaml`) does not specify `OTELC_TEST_GOCACHE` or configure Go caching. This causes each E2E test to compile and build the test applications from scratch, leading to high compile/run times. Enabling build caching matches the configuration in integration tests and speeds up E2E runs in CI.

Fixes #959 (Part 4/4)

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [x] Documentation updated (if applicable)
- [x] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
