### PR TITLE
fix(tool): handle unchecked error return values in setup package test files

### DIFF
--- a/tool/internal/setup/cleanup_test.go
+++ b/tool/internal/setup/cleanup_test.go
@@ -28,7 +28,7 @@ func TestCleanup(t *testing.T) {
 				// track otelc.runtime.go in the state manager so it is removed when Cleanup is called
 				stateManager := NewStateManager()
 				otelcRuntimeGoPath := filepath.Join(dir, OtelcRuntimeFile)
-				stateManager.Track(otelcRuntimeGoPath)
+				require.NoError(t, stateManager.Track(otelcRuntimeGoPath))
 				mustWriteFile(t, otelcRuntimeGoPath, "package main \n\n// dummy runtime file")
 				// The instrumentation package is extracted inside .otelc-build/pkg/,
 				// not at the project root. It is removed as part of .otelc-build/ cleanup.
@@ -55,7 +55,7 @@ func TestCleanup(t *testing.T) {
 				t.Helper()
 				stateManager := NewStateManager()
 				otelcRuntimeGoPath := filepath.Join(dir, OtelcRuntimeFile)
-				stateManager.Track(otelcRuntimeGoPath)
+				require.NoError(t, stateManager.Track(otelcRuntimeGoPath))
 				mustWriteFile(t, otelcRuntimeGoPath, "package main\n\n// dummy runtime file")
 				return ContextWithStateManager(t.Context(), stateManager)
 			},

--- a/tool/internal/setup/pin_test.go
+++ b/tool/internal/setup/pin_test.go
@@ -825,7 +825,7 @@ func TestUpdatePinnedProjects_InvalidRule(t *testing.T) {
 func TestGeneratePinnedProjects(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv(util.EnvOtelcWorkDir, dir)
-	os.MkdirAll(util.GetBuildTempDir(), 0o755) // ensure .otelc-build exists
+	require.NoError(t, os.MkdirAll(util.GetBuildTempDir(), 0o755)) // ensure .otelc-build exists
 
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "go.mod"),

--- a/tool/internal/setup/sync_test.go
+++ b/tool/internal/setup/sync_test.go
@@ -121,8 +121,8 @@ func TestWriteGoMod(t *testing.T) {
 
 	// Create a modfile
 	mf := &modfile.File{}
-	mf.AddModuleStmt("example.com/test")
-	mf.AddGoStmt("1.21")
+	require.NoError(t, mf.AddModuleStmt("example.com/test"))
+	require.NoError(t, mf.AddGoStmt("1.21"))
 	err := mf.AddRequire("github.com/stretchr/testify", "v1.8.4")
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description

This PR fixes `golangci-lint` (`errcheck`) errors in test files within the `tool/internal/setup` package by wrapping unhandled function call return values with `require.NoError(t, ...)`.

Specifically:
- Wrapped `stateManager.Track(otelcRuntimeGoPath)` in `cleanup_test.go` (lines 31, 58).
- Wrapped `os.MkdirAll(util.GetBuildTempDir(), 0o755)` in `pin_test.go` (line 828).
- Wrapped `mf.AddModuleStmt(...)` and `mf.AddGoStmt(...)` in `sync_test.go` (lines 124, 125).

## Motivation

Running `golangci-lint` on `main` reported `errcheck` violations for unhandled errors in test setups. Resolving these ensures that `make lint` and CI linter checks pass cleanly without warnings.

Fixes #1005

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [x] Documentation updated (if applicable)
- [x] OpenTelemetry Registry updated (if applicable)
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
