### PR TITLE
fix(tool/internal/ast): return standard zero-value token.Position for unmapped nodes in FindPosition

### DIFF
--- a/tool/internal/ast/parser.go
+++ b/tool/internal/ast/parser.go
@@ -84,10 +84,11 @@ func (ap *AstParser) ParseSource(source string) (*dst.File, error) {
 }
 
 // FindPosition finds the source position of a node in the AST.
+// It returns a zero-value token.Position{} when the node is unmapped.
 func (ap *AstParser) FindPosition(node dst.Node) token.Position {
 	astNode := ap.dec.Ast.Nodes[node]
 	if astNode == nil {
-		return token.Position{Filename: "", Line: -1, Column: -1} // Invalid
+		return token.Position{}
 	}
 	return ap.fset.Position(astNode.Pos())
 }

--- a/tool/internal/ast/parser_extra_test.go
+++ b/tool/internal/ast/parser_extra_test.go
@@ -4,6 +4,7 @@
 package ast
 
 import (
+	"go/token"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,8 +48,8 @@ func TestFindPosition(t *testing.T) {
 	t.Run("unknown node returns invalid position", func(t *testing.T) {
 		// A node the decorator never saw maps to no AST node.
 		pos := p.FindPosition(Ident("orphan"))
-		assert.Equal(t, -1, pos.Line)
-		assert.Equal(t, -1, pos.Column)
+		assert.Equal(t, token.Position{}, pos)
+		assert.False(t, pos.IsValid())
 	})
 }
 


### PR DESCRIPTION
## Description
AstParser.FindPosition in tool/internal/ast/parser.go previously returned token.Position{Filename: "", Line: -1, Column: -1} when a node was absent from the decoration AST node map.

In standard Go (go/token), an invalid position is conventionally represented by the zero value token.Position{} (Line: 0, Column: 0). Returning -1 for Line and Column violates standard Go token.Position conventions and causes pos.IsValid() (which checks Line > 0) or diagnostic formatters to produce unexpected negative coordinates.

Fixes #1009 
## Changes Made
Updated AstParser.FindPosition in tool/internal/ast/parser.go to return token.Position{} when astNode == nil.
Updated unit test in tool/internal/ast/parser_extra_test.go to assert token.Position{} and !pos.IsValid().

## Verification
golangci-lint: 0 issues
go test ./tool/internal/ast/...: All tests pass cleanly.