### PR TITLE
fix(instrumentation): record penalties on openai completion requests

### DIFF
--- a/instrumentation/github.com/openai/openai-go/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/middleware.go
@@ -266,10 +266,12 @@ func parseChatRequest(body []byte) (string, []attribute.KeyValue) {
 
 func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	var req struct {
-		Model       string   `json:"model"`
-		MaxTokens   *int64   `json:"max_tokens,omitempty"`
-		Temperature *float64 `json:"temperature,omitempty"`
-		TopP        *float64 `json:"top_p,omitempty"`
+		Model            string   `json:"model"`
+		MaxTokens        *int64   `json:"max_tokens,omitempty"`
+		Temperature      *float64 `json:"temperature,omitempty"`
+		TopP             *float64 `json:"top_p,omitempty"`
+		FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+		PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return "", nil
@@ -284,6 +286,12 @@ func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	}
 	if req.TopP != nil {
 		attrs = append(attrs, semconv.GenAIRequestTopP(*req.TopP))
+	}
+	if req.FrequencyPenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestFrequencyPenalty(*req.FrequencyPenalty))
+	}
+	if req.PresencePenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestPresencePenalty(*req.PresencePenalty))
 	}
 	return req.Model, attrs
 }

--- a/instrumentation/github.com/openai/openai-go/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/middleware.go
@@ -294,10 +294,12 @@ func parseChatRequest(body []byte) (string, []attribute.KeyValue) {
 
 func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	var req struct {
-		Model       string   `json:"model"`
-		MaxTokens   *int64   `json:"max_tokens,omitempty"`
-		Temperature *float64 `json:"temperature,omitempty"`
-		TopP        *float64 `json:"top_p,omitempty"`
+		Model            string   `json:"model"`
+		MaxTokens        *int64   `json:"max_tokens,omitempty"`
+		Temperature      *float64 `json:"temperature,omitempty"`
+		TopP             *float64 `json:"top_p,omitempty"`
+		FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+		PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return "", nil
@@ -312,6 +314,12 @@ func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	}
 	if req.TopP != nil {
 		attrs = append(attrs, semconv.GenAIRequestTopP(*req.TopP))
+	}
+	if req.FrequencyPenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestFrequencyPenalty(*req.FrequencyPenalty))
+	}
+	if req.PresencePenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestPresencePenalty(*req.PresencePenalty))
 	}
 	return req.Model, attrs
 }

--- a/instrumentation/github.com/openai/openai-go/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/middleware_test.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	semconv "go.opentelemetry.io/otelc/instrumentation/github.com/openai/openai-go/semconv"
 )
 
 // setupTestMeter wires the package-level operationDuration histogram to a
@@ -310,4 +312,45 @@ func TestParseChatResponse_Valid(t *testing.T) {
 	assert.Equal(t, int64(10), resp.Usage.PromptTokens)
 	assert.Equal(t, int64(20), resp.Usage.CompletionTokens)
 	assert.Equal(t, "stop", resp.Choices[0].FinishReason)
+}
+
+// TestParseCompletionRequest_Penalties covers frequency_penalty and
+// presence_penalty on the legacy completions endpoint.
+//
+// CompletionNewParams carries both, and parseChatRequest already records them,
+// so previously a completions span silently lost two sampling parameters that
+// the chat path reported for an otherwise identical request.
+func TestParseCompletionRequest_Penalties(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-3.5-turbo-instruct",
+		"prompt":"hello",
+		"frequency_penalty":0.5,
+		"presence_penalty":-0.25
+	}`)
+
+	model, attrs := parseCompletionRequest(body)
+	assert.Equal(t, "gpt-3.5-turbo-instruct", model)
+
+	got := map[attribute.Key]attribute.Value{}
+	for _, a := range attrs {
+		got[a.Key] = a.Value
+	}
+
+	require.Contains(t, got, semconv.GenAIRequestFrequencyPenaltyKey)
+	assert.InDelta(t, 0.5, got[semconv.GenAIRequestFrequencyPenaltyKey].AsFloat64(), 1e-9)
+
+	require.Contains(t, got, semconv.GenAIRequestPresencePenaltyKey)
+	assert.InDelta(t, -0.25, got[semconv.GenAIRequestPresencePenaltyKey].AsFloat64(), 1e-9)
+}
+
+// Absent penalties must stay absent rather than being reported as zero, since
+// 0 is a meaningful value for both parameters.
+func TestParseCompletionRequest_PenaltiesOmitted(t *testing.T) {
+	body := []byte(`{"model":"gpt-3.5-turbo-instruct","prompt":"hello"}`)
+
+	_, attrs := parseCompletionRequest(body)
+	for _, a := range attrs {
+		assert.NotEqual(t, semconv.GenAIRequestFrequencyPenaltyKey, a.Key)
+		assert.NotEqual(t, semconv.GenAIRequestPresencePenaltyKey, a.Key)
+	}
 }

--- a/instrumentation/github.com/openai/openai-go/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/middleware_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+
+	semconv "go.opentelemetry.io/otelc/instrumentation/github.com/openai/openai-go/semconv"
 )
 
 func TestClassifyOperation(t *testing.T) {
@@ -127,4 +131,45 @@ func TestParseChatResponse_Valid(t *testing.T) {
 	assert.Equal(t, int64(10), resp.Usage.PromptTokens)
 	assert.Equal(t, int64(20), resp.Usage.CompletionTokens)
 	assert.Equal(t, "stop", resp.Choices[0].FinishReason)
+}
+
+// TestParseCompletionRequest_Penalties covers frequency_penalty and
+// presence_penalty on the legacy completions endpoint.
+//
+// CompletionNewParams carries both, and parseChatRequest already records them,
+// so previously a completions span silently lost two sampling parameters that
+// the chat path reported for an otherwise identical request.
+func TestParseCompletionRequest_Penalties(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-3.5-turbo-instruct",
+		"prompt":"hello",
+		"frequency_penalty":0.5,
+		"presence_penalty":-0.25
+	}`)
+
+	model, attrs := parseCompletionRequest(body)
+	assert.Equal(t, "gpt-3.5-turbo-instruct", model)
+
+	got := map[attribute.Key]attribute.Value{}
+	for _, a := range attrs {
+		got[a.Key] = a.Value
+	}
+
+	require.Contains(t, got, semconv.GenAIRequestFrequencyPenaltyKey)
+	assert.InDelta(t, 0.5, got[semconv.GenAIRequestFrequencyPenaltyKey].AsFloat64(), 1e-9)
+
+	require.Contains(t, got, semconv.GenAIRequestPresencePenaltyKey)
+	assert.InDelta(t, -0.25, got[semconv.GenAIRequestPresencePenaltyKey].AsFloat64(), 1e-9)
+}
+
+// Absent penalties must stay absent rather than being reported as zero, since
+// 0 is a meaningful value for both parameters.
+func TestParseCompletionRequest_PenaltiesOmitted(t *testing.T) {
+	body := []byte(`{"model":"gpt-3.5-turbo-instruct","prompt":"hello"}`)
+
+	_, attrs := parseCompletionRequest(body)
+	for _, a := range attrs {
+		assert.NotEqual(t, semconv.GenAIRequestFrequencyPenaltyKey, a.Key)
+		assert.NotEqual(t, semconv.GenAIRequestPresencePenaltyKey, a.Key)
+	}
 }

--- a/instrumentation/github.com/openai/openai-go/v2/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/v2/middleware.go
@@ -266,10 +266,12 @@ func parseChatRequest(body []byte) (string, []attribute.KeyValue) {
 
 func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	var req struct {
-		Model       string   `json:"model"`
-		MaxTokens   *int64   `json:"max_tokens,omitempty"`
-		Temperature *float64 `json:"temperature,omitempty"`
-		TopP        *float64 `json:"top_p,omitempty"`
+		Model            string   `json:"model"`
+		MaxTokens        *int64   `json:"max_tokens,omitempty"`
+		Temperature      *float64 `json:"temperature,omitempty"`
+		TopP             *float64 `json:"top_p,omitempty"`
+		FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+		PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return "", nil
@@ -284,6 +286,12 @@ func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	}
 	if req.TopP != nil {
 		attrs = append(attrs, semconv.GenAIRequestTopP(*req.TopP))
+	}
+	if req.FrequencyPenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestFrequencyPenalty(*req.FrequencyPenalty))
+	}
+	if req.PresencePenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestPresencePenalty(*req.PresencePenalty))
 	}
 	return req.Model, attrs
 }

--- a/instrumentation/github.com/openai/openai-go/v2/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/v2/middleware.go
@@ -294,10 +294,12 @@ func parseChatRequest(body []byte) (string, []attribute.KeyValue) {
 
 func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	var req struct {
-		Model       string   `json:"model"`
-		MaxTokens   *int64   `json:"max_tokens,omitempty"`
-		Temperature *float64 `json:"temperature,omitempty"`
-		TopP        *float64 `json:"top_p,omitempty"`
+		Model            string   `json:"model"`
+		MaxTokens        *int64   `json:"max_tokens,omitempty"`
+		Temperature      *float64 `json:"temperature,omitempty"`
+		TopP             *float64 `json:"top_p,omitempty"`
+		FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+		PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return "", nil
@@ -312,6 +314,12 @@ func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	}
 	if req.TopP != nil {
 		attrs = append(attrs, semconv.GenAIRequestTopP(*req.TopP))
+	}
+	if req.FrequencyPenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestFrequencyPenalty(*req.FrequencyPenalty))
+	}
+	if req.PresencePenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestPresencePenalty(*req.PresencePenalty))
 	}
 	return req.Model, attrs
 }

--- a/instrumentation/github.com/openai/openai-go/v2/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/v2/middleware_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+
+	semconv "go.opentelemetry.io/otelc/instrumentation/github.com/openai/openai-go/v2/semconv"
 )
 
 func TestClassifyOperation(t *testing.T) {
@@ -127,4 +131,45 @@ func TestParseChatResponse_Valid(t *testing.T) {
 	assert.Equal(t, int64(10), resp.Usage.PromptTokens)
 	assert.Equal(t, int64(20), resp.Usage.CompletionTokens)
 	assert.Equal(t, "stop", resp.Choices[0].FinishReason)
+}
+
+// TestParseCompletionRequest_Penalties covers frequency_penalty and
+// presence_penalty on the legacy completions endpoint.
+//
+// CompletionNewParams carries both, and parseChatRequest already records them,
+// so previously a completions span silently lost two sampling parameters that
+// the chat path reported for an otherwise identical request.
+func TestParseCompletionRequest_Penalties(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-3.5-turbo-instruct",
+		"prompt":"hello",
+		"frequency_penalty":0.5,
+		"presence_penalty":-0.25
+	}`)
+
+	model, attrs := parseCompletionRequest(body)
+	assert.Equal(t, "gpt-3.5-turbo-instruct", model)
+
+	got := map[attribute.Key]attribute.Value{}
+	for _, a := range attrs {
+		got[a.Key] = a.Value
+	}
+
+	require.Contains(t, got, semconv.GenAIRequestFrequencyPenaltyKey)
+	assert.InDelta(t, 0.5, got[semconv.GenAIRequestFrequencyPenaltyKey].AsFloat64(), 1e-9)
+
+	require.Contains(t, got, semconv.GenAIRequestPresencePenaltyKey)
+	assert.InDelta(t, -0.25, got[semconv.GenAIRequestPresencePenaltyKey].AsFloat64(), 1e-9)
+}
+
+// Absent penalties must stay absent rather than being reported as zero, since
+// 0 is a meaningful value for both parameters.
+func TestParseCompletionRequest_PenaltiesOmitted(t *testing.T) {
+	body := []byte(`{"model":"gpt-3.5-turbo-instruct","prompt":"hello"}`)
+
+	_, attrs := parseCompletionRequest(body)
+	for _, a := range attrs {
+		assert.NotEqual(t, semconv.GenAIRequestFrequencyPenaltyKey, a.Key)
+		assert.NotEqual(t, semconv.GenAIRequestPresencePenaltyKey, a.Key)
+	}
 }

--- a/instrumentation/github.com/openai/openai-go/v2/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/v2/middleware_test.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	semconv "go.opentelemetry.io/otelc/instrumentation/github.com/openai/openai-go/v2/semconv"
 )
 
 // setupTestMeter wires the package-level operationDuration histogram to a
@@ -309,4 +311,45 @@ func TestParseChatResponse_Valid(t *testing.T) {
 	assert.Equal(t, int64(10), resp.Usage.PromptTokens)
 	assert.Equal(t, int64(20), resp.Usage.CompletionTokens)
 	assert.Equal(t, "stop", resp.Choices[0].FinishReason)
+}
+
+// TestParseCompletionRequest_Penalties covers frequency_penalty and
+// presence_penalty on the legacy completions endpoint.
+//
+// CompletionNewParams carries both, and parseChatRequest already records them,
+// so previously a completions span silently lost two sampling parameters that
+// the chat path reported for an otherwise identical request.
+func TestParseCompletionRequest_Penalties(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-3.5-turbo-instruct",
+		"prompt":"hello",
+		"frequency_penalty":0.5,
+		"presence_penalty":-0.25
+	}`)
+
+	model, attrs := parseCompletionRequest(body)
+	assert.Equal(t, "gpt-3.5-turbo-instruct", model)
+
+	got := map[attribute.Key]attribute.Value{}
+	for _, a := range attrs {
+		got[a.Key] = a.Value
+	}
+
+	require.Contains(t, got, semconv.GenAIRequestFrequencyPenaltyKey)
+	assert.InDelta(t, 0.5, got[semconv.GenAIRequestFrequencyPenaltyKey].AsFloat64(), 1e-9)
+
+	require.Contains(t, got, semconv.GenAIRequestPresencePenaltyKey)
+	assert.InDelta(t, -0.25, got[semconv.GenAIRequestPresencePenaltyKey].AsFloat64(), 1e-9)
+}
+
+// Absent penalties must stay absent rather than being reported as zero, since
+// 0 is a meaningful value for both parameters.
+func TestParseCompletionRequest_PenaltiesOmitted(t *testing.T) {
+	body := []byte(`{"model":"gpt-3.5-turbo-instruct","prompt":"hello"}`)
+
+	_, attrs := parseCompletionRequest(body)
+	for _, a := range attrs {
+		assert.NotEqual(t, semconv.GenAIRequestFrequencyPenaltyKey, a.Key)
+		assert.NotEqual(t, semconv.GenAIRequestPresencePenaltyKey, a.Key)
+	}
 }

--- a/instrumentation/github.com/openai/openai-go/v3/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/v3/middleware.go
@@ -266,10 +266,12 @@ func parseChatRequest(body []byte) (string, []attribute.KeyValue) {
 
 func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	var req struct {
-		Model       string   `json:"model"`
-		MaxTokens   *int64   `json:"max_tokens,omitempty"`
-		Temperature *float64 `json:"temperature,omitempty"`
-		TopP        *float64 `json:"top_p,omitempty"`
+		Model            string   `json:"model"`
+		MaxTokens        *int64   `json:"max_tokens,omitempty"`
+		Temperature      *float64 `json:"temperature,omitempty"`
+		TopP             *float64 `json:"top_p,omitempty"`
+		FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+		PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return "", nil
@@ -284,6 +286,12 @@ func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	}
 	if req.TopP != nil {
 		attrs = append(attrs, semconv.GenAIRequestTopP(*req.TopP))
+	}
+	if req.FrequencyPenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestFrequencyPenalty(*req.FrequencyPenalty))
+	}
+	if req.PresencePenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestPresencePenalty(*req.PresencePenalty))
 	}
 	return req.Model, attrs
 }

--- a/instrumentation/github.com/openai/openai-go/v3/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/v3/middleware.go
@@ -294,10 +294,12 @@ func parseChatRequest(body []byte) (string, []attribute.KeyValue) {
 
 func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	var req struct {
-		Model       string   `json:"model"`
-		MaxTokens   *int64   `json:"max_tokens,omitempty"`
-		Temperature *float64 `json:"temperature,omitempty"`
-		TopP        *float64 `json:"top_p,omitempty"`
+		Model            string   `json:"model"`
+		MaxTokens        *int64   `json:"max_tokens,omitempty"`
+		Temperature      *float64 `json:"temperature,omitempty"`
+		TopP             *float64 `json:"top_p,omitempty"`
+		FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+		PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return "", nil
@@ -312,6 +314,12 @@ func parseCompletionRequest(body []byte) (string, []attribute.KeyValue) {
 	}
 	if req.TopP != nil {
 		attrs = append(attrs, semconv.GenAIRequestTopP(*req.TopP))
+	}
+	if req.FrequencyPenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestFrequencyPenalty(*req.FrequencyPenalty))
+	}
+	if req.PresencePenalty != nil {
+		attrs = append(attrs, semconv.GenAIRequestPresencePenalty(*req.PresencePenalty))
 	}
 	return req.Model, attrs
 }

--- a/instrumentation/github.com/openai/openai-go/v3/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/v3/middleware_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+
+	semconv "go.opentelemetry.io/otelc/instrumentation/github.com/openai/openai-go/v3/semconv"
 )
 
 func TestClassifyOperation(t *testing.T) {
@@ -127,4 +131,45 @@ func TestParseChatResponse_Valid(t *testing.T) {
 	assert.Equal(t, int64(10), resp.Usage.PromptTokens)
 	assert.Equal(t, int64(20), resp.Usage.CompletionTokens)
 	assert.Equal(t, "stop", resp.Choices[0].FinishReason)
+}
+
+// TestParseCompletionRequest_Penalties covers frequency_penalty and
+// presence_penalty on the legacy completions endpoint.
+//
+// CompletionNewParams carries both, and parseChatRequest already records them,
+// so previously a completions span silently lost two sampling parameters that
+// the chat path reported for an otherwise identical request.
+func TestParseCompletionRequest_Penalties(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-3.5-turbo-instruct",
+		"prompt":"hello",
+		"frequency_penalty":0.5,
+		"presence_penalty":-0.25
+	}`)
+
+	model, attrs := parseCompletionRequest(body)
+	assert.Equal(t, "gpt-3.5-turbo-instruct", model)
+
+	got := map[attribute.Key]attribute.Value{}
+	for _, a := range attrs {
+		got[a.Key] = a.Value
+	}
+
+	require.Contains(t, got, semconv.GenAIRequestFrequencyPenaltyKey)
+	assert.InDelta(t, 0.5, got[semconv.GenAIRequestFrequencyPenaltyKey].AsFloat64(), 1e-9)
+
+	require.Contains(t, got, semconv.GenAIRequestPresencePenaltyKey)
+	assert.InDelta(t, -0.25, got[semconv.GenAIRequestPresencePenaltyKey].AsFloat64(), 1e-9)
+}
+
+// Absent penalties must stay absent rather than being reported as zero, since
+// 0 is a meaningful value for both parameters.
+func TestParseCompletionRequest_PenaltiesOmitted(t *testing.T) {
+	body := []byte(`{"model":"gpt-3.5-turbo-instruct","prompt":"hello"}`)
+
+	_, attrs := parseCompletionRequest(body)
+	for _, a := range attrs {
+		assert.NotEqual(t, semconv.GenAIRequestFrequencyPenaltyKey, a.Key)
+		assert.NotEqual(t, semconv.GenAIRequestPresencePenaltyKey, a.Key)
+	}
 }

--- a/instrumentation/github.com/openai/openai-go/v3/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/v3/middleware_test.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	semconv "go.opentelemetry.io/otelc/instrumentation/github.com/openai/openai-go/v3/semconv"
 )
 
 // setupTestMeter wires the package-level operationDuration histogram to a
@@ -309,4 +311,45 @@ func TestParseChatResponse_Valid(t *testing.T) {
 	assert.Equal(t, int64(10), resp.Usage.PromptTokens)
 	assert.Equal(t, int64(20), resp.Usage.CompletionTokens)
 	assert.Equal(t, "stop", resp.Choices[0].FinishReason)
+}
+
+// TestParseCompletionRequest_Penalties covers frequency_penalty and
+// presence_penalty on the legacy completions endpoint.
+//
+// CompletionNewParams carries both, and parseChatRequest already records them,
+// so previously a completions span silently lost two sampling parameters that
+// the chat path reported for an otherwise identical request.
+func TestParseCompletionRequest_Penalties(t *testing.T) {
+	body := []byte(`{
+		"model":"gpt-3.5-turbo-instruct",
+		"prompt":"hello",
+		"frequency_penalty":0.5,
+		"presence_penalty":-0.25
+	}`)
+
+	model, attrs := parseCompletionRequest(body)
+	assert.Equal(t, "gpt-3.5-turbo-instruct", model)
+
+	got := map[attribute.Key]attribute.Value{}
+	for _, a := range attrs {
+		got[a.Key] = a.Value
+	}
+
+	require.Contains(t, got, semconv.GenAIRequestFrequencyPenaltyKey)
+	assert.InDelta(t, 0.5, got[semconv.GenAIRequestFrequencyPenaltyKey].AsFloat64(), 1e-9)
+
+	require.Contains(t, got, semconv.GenAIRequestPresencePenaltyKey)
+	assert.InDelta(t, -0.25, got[semconv.GenAIRequestPresencePenaltyKey].AsFloat64(), 1e-9)
+}
+
+// Absent penalties must stay absent rather than being reported as zero, since
+// 0 is a meaningful value for both parameters.
+func TestParseCompletionRequest_PenaltiesOmitted(t *testing.T) {
+	body := []byte(`{"model":"gpt-3.5-turbo-instruct","prompt":"hello"}`)
+
+	_, attrs := parseCompletionRequest(body)
+	for _, a := range attrs {
+		assert.NotEqual(t, semconv.GenAIRequestFrequencyPenaltyKey, a.Key)
+		assert.NotEqual(t, semconv.GenAIRequestPresencePenaltyKey, a.Key)
+	}
 }


### PR DESCRIPTION
## Description

`parseCompletionRequest` parsed only `model`, `max_tokens`, `temperature` and `top_p`. `CompletionNewParams` also carries `FrequencyPenalty` and `PresencePenalty`, serialised as `frequency_penalty` and `presence_penalty`:

```go
// openai-go/v3@v3.49.0 completion.go
FrequencyPenalty param.Opt[float64] `json:"frequency_penalty,omitzero"`
PresencePenalty  param.Opt[float64] `json:"presence_penalty,omitzero"`
```

`parseChatRequest` already records both. So for two otherwise identical requests, the chat span reports the sampling penalties and the legacy completions span silently does not.

Both attributes are already defined in `semconv` (`GenAIRequestFrequencyPenalty`, `GenAIRequestPresencePenalty`) and already emitted on the chat path, so this introduces no new attribute — the completions path just stopped short of the fields it was already shaped to read.

Parsed as `*float64` to match the surrounding fields, so an omitted penalty stays absent rather than being reported as `0` — `0` is a meaningful value for both parameters, and `omitempty` on a non-pointer would make "explicitly zero" and "not sent" indistinguishable.

Applied to v1, v2 and v3, which all had the same gap.

## Motivation

Anyone comparing chat and completions traffic on `gen_ai.request.frequency_penalty` or `gen_ai.request.presence_penalty` sees completions requests as if the penalties were never set. The gap is invisible in the span — nothing signals the attribute was dropped rather than unset.

I found this while reading the request-parsing paths, after building a benchmark harness that measures how tool and instrumentation shape affects an LLM agent's behaviour, where request-side sampling parameters are exactly the sort of thing you need recorded to compare runs.

## Testing

Two tests per version:

- `TestParseCompletionRequest_Penalties` — a completions body with `frequency_penalty: 0.5` and `presence_penalty: -0.25` produces both attributes with those values.
- `TestParseCompletionRequest_PenaltiesOmitted` — a body without them produces neither, so absent stays absent.

Confirmed these are real regression tests. Against unpatched `parseCompletionRequest`:

```
--- FAIL: TestParseCompletionRequest_Penalties (0.00s)
    Error: map[attribute.Key]attribute.Value{} does not contain "gen_ai.request.frequency_penalty"
```

With the change, all three modules pass:

```
ok  go.opentelemetry.io/otelc/instrumentation/github.com/openai/openai-go      7.111s
ok  go.opentelemetry.io/otelc/instrumentation/github.com/openai/openai-go/v2   6.387s
ok  go.opentelemetry.io/otelc/instrumentation/github.com/openai/openai-go/v3   6.950s
```

`make` is not available on my machine (Windows), so I ran `go test ./...` per module and verified every changed file is `gofmt` clean rather than running `make format` / `make test`. Worth a second pair of eyes on the lint job.
