### PR TITLE
docs(docs): correct configuration file naming to otelc.yml

### DIFF
--- a/docs/ux-design.md
+++ b/docs/ux-design.md
@@ -113,7 +113,7 @@ $ go run go.opentelemetry.io/otelc/tool/cmd/otelc@latest setup
 ℹ️ Using go tool dependencies or a `otel.instrumentation.go` file to configure
    integrations is recommended as it ensures the instrumentation packages are
    represented in your `go.mod` file, making builds reproducible.
-   Using a `.otel.yml` file is useful when instrumenting applications without
+   Using an `otelc.yml` file is useful when instrumenting applications without
    modifying their codebase at all; which may be preferable when building
    third-party applications or integrating in the CI/CD pipeline. The
    reproductibility of builds is no longer guaranteed by the go toolchain, and
@@ -122,7 +122,7 @@ $ go run go.opentelemetry.io/otelc/tool/cmd/otelc@latest setup
 🤖 How do you want to configure instrumentation for this project?
    (*) Using go tool dependencies (Recommended)
    ( ) Using the `otel.instrumentation.go` file
-   ( ) Using a `.otel.yml` file
+   ( ) Using an `otelc.yml` file
 🆗 I will use go tool dependencies to enable integration packages.
 
 🤖 We're all set! Based on your answers, I will execute the following commands:
@@ -169,7 +169,7 @@ ways:
    alias `otelc.tool.go`) allows instrumentation packages to be declared
    explicitly in source control and managed as normal Go module dependencies.
 
-2. The `.otel.yml` file allows injecting configuration directly within the
+2. The `otelc.yml` file allows injecting configuration directly within the
    CI/CD pipeline without persisting any change to the project's source code
    &ndash; but has the disadvantage of making hermetic or reproducible builds
    more difficult (the `go.mod` and `go.sum` files ought to be considered as
@@ -264,7 +264,7 @@ configuration:
 
 - `otel.instrumentation.go` (or the compatibility alias `otelc.tool.go`),
   which declares instrumentation packages through Go imports;
-- `.otel.yml`, which provides module-local instrumentation configuration;
+- `otelc.yml`, which provides module-local instrumentation configuration;
 - `--rules`, which allows an explicit rule set to be supplied at build time.
 
 All rule files use the same schema described in the


### PR DESCRIPTION
## Description
This PR updates docs/ux design.md to replace all references of .otel.yml with otelc.yml. 

## Motivation
There was a discrepancy between the early UX design document and the actual implementation of the configuration resolver. docs/ux design.md previously instructed users to utilize a .otel.yml file for module local instrumentation configuration (for example in CI/CD environments). 
However, the file discovery implementation (isRuleFile in tool/internal/setup/match.go) strictly filters for otelc.yml, otelc.yaml, *.otelc.yml, and *.otelc.yaml. It completely ignores .otel.yml. 
If a user had followed the outdated UX documentation, their configuration would have been silently ignored by the otelc tool during builds. This aligns the UX design document with the working implementation and the broader documentation ecosystem (e.g., external-configuration.md).

Fixes # N/A (Documentation correction)
---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [x] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
