### PR TITLE
docs: list aws-sdk-go-v2, linodego, and logging instrumentations in Supported Libraries

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -129,6 +129,9 @@ The following libraries are automatically instrumented:
 | `github.com/openai/openai-go` (v1/v2/v3) | GenAI spans |
 | `github.com/anthropics/anthropic-sdk-go` | GenAI spans |
 | `github.com/segmentio/kafka-go` | Kafka messaging spans |
+| `github.com/aws/aws-sdk-go-v2` | AWS SDK client spans |
+| `github.com/linode/linodego/v2` | HTTP client spans and metrics |
+| `log`, `log/slog`, `github.com/sirupsen/logrus` | Trace/span ID log correlation |
 
 ## Learn More
 


### PR DESCRIPTION
The **Supported Libraries** table in `docs/getting-started.md` was missing several instrumentations that already ship under `instrumentation/`:

- `github.com/aws/aws-sdk-go-v2` — hooks `config.LoadDefaultConfig` to append the `otelaws` middlewares
- `github.com/linode/linodego/v2` — HTTP client spans plus the `linodego.client.operation.duration` histogram
- `log`, `log/slog`, `github.com/sirupsen/logrus` — attach `trace_id`/`span_id` to log records

Docs only, 3 added table rows.