### PR TITLE
refactor(test): replace log.Fatal with graceful shutdown in example apps

### DIFF
--- a/test/apps/anthropicclient/main.go
+++ b/test/apps/anthropicclient/main.go
@@ -8,8 +8,10 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
+	"os"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -21,7 +23,7 @@ var (
 	model  = flag.String("model", "claude-sonnet-4-5", "The model to use")
 )
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	client := anthropic.NewClient(
@@ -37,12 +39,20 @@ func main() {
 		},
 	})
 	if err != nil {
-		log.Fatalf("failed to create message: %v", err)
+		return fmt.Errorf("failed to create message: %w", err)
 	}
 
 	for _, block := range message.Content {
 		if text, ok := block.AsAny().(anthropic.TextBlock); ok {
 			slog.Info("response", "content", text.Text)
 		}
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/test/apps/awsclient/main.go
+++ b/test/apps/awsclient/main.go
@@ -8,8 +8,10 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -21,7 +23,7 @@ var (
 	endpoint = flag.String("endpoint", "http://localhost:8080", "DynamoDB endpoint URL")
 )
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	ctx := context.Background()
@@ -31,7 +33,7 @@ func main() {
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
 	)
 	if err != nil {
-		log.Fatalf("failed to load AWS config: %v", err)
+		return fmt.Errorf("failed to load AWS config: %w", err)
 	}
 
 	client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
@@ -41,8 +43,16 @@ func main() {
 	slog.Info("Listing DynamoDB tables", "endpoint", *endpoint)
 	out, err := client.ListTables(ctx, &dynamodb.ListTablesInput{})
 	if err != nil {
-		log.Fatalf("failed to list tables: %v", err)
+		return fmt.Errorf("failed to list tables: %w", err)
 	}
 
 	slog.Info("DynamoDB operations completed successfully", "tables", len(out.TableNames))
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/dbclient/main.go
+++ b/test/apps/dbclient/main.go
@@ -10,8 +10,10 @@ import (
 	"context"
 	"database/sql"
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
+	"os"
 
 	_ "go.opentelemetry.io/otelc/test/shared/testdb"
 )
@@ -22,12 +24,12 @@ var (
 	op         = flag.String("op", "all", "The operation to perform: ping, exec, query, tx, prepare, all")
 )
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	db, err := sql.Open(*driverName, *dsn)
 	if err != nil {
-		log.Fatalf("failed to open database: %v", err)
+		return fmt.Errorf("failed to open database: %w", err)
 	}
 	defer db.Close()
 
@@ -51,10 +53,18 @@ func main() {
 		doPrepare(ctx, db)
 		doTx(ctx, db)
 	default:
-		log.Fatalf("unknown operation: %s", *op)
+		return fmt.Errorf("unknown operation: %s", *op)
 	}
 
 	slog.Info("database operations completed successfully")
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func doPing(ctx context.Context, db *sql.DB) {

--- a/test/apps/gincustom/main.go
+++ b/test/apps/gincustom/main.go
@@ -8,13 +8,14 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/gin-gonic/gin"
 )
 
 var port = flag.String("port", "8080", "port to listen on")
 
-func main() {
+func run() error {
 	flag.Parse()
 	gin.SetMode(gin.ReleaseMode)
 
@@ -27,6 +28,14 @@ func main() {
 
 	addr := fmt.Sprintf(":%s", *port)
 	if err := r.Run(addr); err != nil {
-		log.Fatalf("server error: %v", err)
+		return fmt.Errorf("server error: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/test/apps/ginserver/main.go
+++ b/test/apps/ginserver/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -16,7 +17,7 @@ import (
 
 var port = flag.String("port", "8080", "port to listen on")
 
-func main() {
+func run() error {
 	flag.Parse()
 	gin.SetMode(gin.ReleaseMode)
 
@@ -43,6 +44,14 @@ func main() {
 
 	addr := fmt.Sprintf(":%s", *port)
 	if err := r.Run(addr); err != nil {
-		log.Fatalf("server error: %v", err)
+		return fmt.Errorf("server error: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/test/apps/ginserverhttpclient/main.go
+++ b/test/apps/ginserverhttpclient/main.go
@@ -27,7 +27,7 @@ func backendHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "backend says hello")
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 	gin.SetMode(gin.ReleaseMode)
 
@@ -40,7 +40,7 @@ func main() {
 	}
 	go func() {
 		if err := backendServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("backend error: %v", err)
+			return fmt.Errorf("backend error: %w", err)
 		}
 	}()
 
@@ -73,7 +73,7 @@ func main() {
 
 	go func() {
 		if err := frontendServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("frontend error: %v", err)
+			return fmt.Errorf("frontend error: %w", err)
 		}
 	}()
 
@@ -84,4 +84,12 @@ func main() {
 
 	backendServer.Shutdown(context.Background())
 	frontendServer.Shutdown(context.Background())
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/grpcclient/main.go
+++ b/test/apps/grpcclient/main.go
@@ -8,9 +8,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"log/slog"
+	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -26,12 +28,12 @@ var (
 	count  = flag.Int("count", 1, "Number of requests to make (for streaming)")
 )
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		log.Fatalf("failed to connect: %v", err)
+		return fmt.Errorf("failed to connect: %w", err)
 	}
 	defer conn.Close()
 
@@ -49,7 +51,7 @@ func main() {
 func doUnary(ctx context.Context, client pb.GreeterClient) {
 	resp, err := client.SayHello(ctx, &pb.HelloRequest{Name: *name})
 	if err != nil {
-		log.Fatalf("failed to call SayHello: %v", err)
+		return fmt.Errorf("failed to call SayHello: %w", err)
 	}
 	slog.Info("greeting", "message", resp.GetMessage())
 }
@@ -57,17 +59,17 @@ func doUnary(ctx context.Context, client pb.GreeterClient) {
 func doStreaming(ctx context.Context, client pb.GreeterClient) {
 	stream, err := client.SayHelloStream(ctx)
 	if err != nil {
-		log.Fatalf("failed to call SayHelloStream: %v", err)
+		return fmt.Errorf("failed to call SayHelloStream: %w", err)
 	}
 
 	// Send requests
 	for i := 0; i < *count; i++ {
 		if err := stream.Send(&pb.HelloRequest{Name: *name}); err != nil {
-			log.Fatalf("failed to send: %v", err)
+			return fmt.Errorf("failed to send: %w", err)
 		}
 	}
 	if err := stream.CloseSend(); err != nil {
-		log.Fatalf("failed to close send: %v", err)
+		return fmt.Errorf("failed to close send: %w", err)
 	}
 
 	// Receive responses
@@ -77,8 +79,16 @@ func doStreaming(ctx context.Context, client pb.GreeterClient) {
 			break
 		}
 		if err != nil {
-			log.Fatalf("failed to receive: %v", err)
+			return fmt.Errorf("failed to receive: %w", err)
 		}
 		slog.Info("stream response", "message", resp.GetMessage())
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/test/apps/grpcserver/main.go
+++ b/test/apps/grpcserver/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"log/slog"
 	"net"
+	"os"
 
 	"go.opentelemetry.io/otelc/test/shared/grpcpb/pb"
 	"google.golang.org/grpc"
@@ -45,13 +46,13 @@ func (s *server) SayHelloStream(stream pb.Greeter_SayHelloStreamServer) error {
 	}
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	addr := fmt.Sprintf(":%d", *port)
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		return fmt.Errorf("failed to listen: %w", err)
 	}
 	defer lis.Close()
 
@@ -60,6 +61,14 @@ func main() {
 
 	slog.Info("server started", "address", lis.Addr())
 	if err := s.Serve(lis); err != nil {
-		log.Fatalf("failed to serve: %v", err)
+		return fmt.Errorf("failed to serve: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/test/apps/grpcserverdbclient/main.go
+++ b/test/apps/grpcserverdbclient/main.go
@@ -38,25 +38,25 @@ func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloRe
 	return &pb.HelloReply{Message: "frontend querying database"}, nil
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	db, err := sql.Open("testdb", "user:pass@tcp(127.0.0.1:3306)/testdb?charset=utf8")
 	if err != nil {
-		log.Fatalf("failed to open database: %v", err)
+		return fmt.Errorf("failed to open database: %w", err)
 	}
 	defer db.Close()
 
 	lis, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", *frontPort))
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		return fmt.Errorf("failed to listen: %w", err)
 	}
 	grpcServer := grpc.NewServer()
 	pb.RegisterGreeterServer(grpcServer, &server{db: db})
 
 	go func() {
 		if err := grpcServer.Serve(lis); err != nil {
-			log.Fatalf("frontend server failed: %v", err)
+			return fmt.Errorf("frontend server failed: %w", err)
 		}
 	}()
 
@@ -66,4 +66,12 @@ func main() {
 	<-ctx.Done()
 
 	grpcServer.GracefulStop()
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/grpcservergrpcclient/main.go
+++ b/test/apps/grpcservergrpcclient/main.go
@@ -45,27 +45,27 @@ func (s *frontendServer) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb
 	return &pb.HelloReply{Message: "frontend calling backend, response: " + resp.GetMessage()}, nil
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	// Start backend
 	backLis, err := net.Listen("tcp", fmt.Sprintf(":%d", *backPort))
 	if err != nil {
-		log.Fatalf("failed to listen on backPort: %v", err)
+		return fmt.Errorf("failed to listen on backPort: %w", err)
 	}
 	backGrpcServer := grpc.NewServer()
 	pb.RegisterGreeterServer(backGrpcServer, &backendServer{})
 
 	go func() {
 		if err := backGrpcServer.Serve(backLis); err != nil {
-			log.Fatalf("backend server failed: %v", err)
+			return fmt.Errorf("backend server failed: %w", err)
 		}
 	}()
 
 	// Connect to backend
 	conn, err := grpc.NewClient(fmt.Sprintf("127.0.0.1:%d", *backPort), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		log.Fatalf("failed to connect to backend: %v", err)
+		return fmt.Errorf("failed to connect to backend: %w", err)
 	}
 	defer conn.Close()
 	client := pb.NewGreeterClient(conn)
@@ -73,14 +73,14 @@ func main() {
 	// Start frontend
 	frontLis, err := net.Listen("tcp", fmt.Sprintf(":%d", *frontPort))
 	if err != nil {
-		log.Fatalf("failed to listen on frontPort: %v", err)
+		return fmt.Errorf("failed to listen on frontPort: %w", err)
 	}
 	frontGrpcServer := grpc.NewServer()
 	pb.RegisterGreeterServer(frontGrpcServer, &frontendServer{backendClient: client})
 
 	go func() {
 		if err := frontGrpcServer.Serve(frontLis); err != nil {
-			log.Fatalf("frontend server failed: %v", err)
+			return fmt.Errorf("frontend server failed: %w", err)
 		}
 	}()
 
@@ -91,4 +91,12 @@ func main() {
 
 	backGrpcServer.GracefulStop()
 	frontGrpcServer.GracefulStop()
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/grpcserverkafkaclient/main.go
+++ b/test/apps/grpcserverkafkaclient/main.go
@@ -72,19 +72,19 @@ func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloRe
 	return &pb.HelloReply{Message: "frontend produced message to kafka"}, nil
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *frontPort))
 	if err != nil {
-		log.Fatalf("failed to listen on frontPort: %v", err)
+		return fmt.Errorf("failed to listen on frontPort: %w", err)
 	}
 	grpcServer := grpc.NewServer()
 	pb.RegisterGreeterServer(grpcServer, &server{})
 
 	go func() {
 		if err := grpcServer.Serve(lis); err != nil {
-			log.Fatalf("frontend server failed: %v", err)
+			return fmt.Errorf("frontend server failed: %w", err)
 		}
 	}()
 
@@ -94,4 +94,12 @@ func main() {
 	<-ctx.Done()
 
 	grpcServer.GracefulStop()
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/httpclient/main.go
+++ b/test/apps/httpclient/main.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
+	"os"
 )
 
 var (
@@ -19,20 +20,28 @@ var (
 	name = flag.String("name", "world", "The name to greet")
 )
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	url := fmt.Sprintf("%s/hello?name=%s", *addr, *name)
 	resp, err := http.Get(url)
 	if err != nil {
-		log.Fatalf("failed to make request: %v", err)
+		return fmt.Errorf("failed to make request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("failed to read response: %v", err)
+		return fmt.Errorf("failed to read response: %w", err)
 	}
 
 	slog.Info("response", "body", string(body))
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/httpserver/main.go
+++ b/test/apps/httpserver/main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 )
 
 var port = flag.String("port", "8080", "The server port")
@@ -22,12 +23,20 @@ func greetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	addr := fmt.Sprintf(":%s", *port)
 	http.HandleFunc("/hello", greetHandler)
 	if err := http.ListenAndServe(addr, nil); err != nil {
-		log.Fatalf("failed to serve: %v", err)
+		return fmt.Errorf("failed to serve: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/test/apps/httpserverdbclient/main.go
+++ b/test/apps/httpserverdbclient/main.go
@@ -21,12 +21,12 @@ import (
 
 var frontPort = flag.Int("front-port", 8080, "port for HTTP frontend")
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	db, err := sql.Open("testdb", "user:pass@tcp(127.0.0.1:3306)/testdb?charset=utf8")
 	if err != nil {
-		log.Fatalf("failed to open database: %v", err)
+		return fmt.Errorf("failed to open database: %w", err)
 	}
 	defer db.Close()
 
@@ -50,7 +50,7 @@ func main() {
 
 	go func() {
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("frontend server failed: %v", err)
+			return fmt.Errorf("frontend server failed: %w", err)
 		}
 	}()
 
@@ -62,6 +62,14 @@ func main() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := server.Shutdown(shutdownCtx); err != nil {
-		log.Fatalf("server shutdown failed: %v", err)
+		return fmt.Errorf("server shutdown failed: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/test/apps/httpserverkafkaclient/main.go
+++ b/test/apps/httpserverkafkaclient/main.go
@@ -41,7 +41,7 @@ func ensureTopic(ctx context.Context, topic string) {
 	})
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	topic := "test-topic-http"
@@ -80,7 +80,7 @@ func main() {
 
 	go func() {
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("frontend server failed: %v", err)
+			return fmt.Errorf("frontend server failed: %w", err)
 		}
 	}()
 
@@ -92,6 +92,14 @@ func main() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := server.Shutdown(shutdownCtx); err != nil {
-		log.Fatalf("server shutdown failed: %v", err)
+		return fmt.Errorf("server shutdown failed: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/test/apps/k8sclient/main.go
+++ b/test/apps/k8sclient/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -20,20 +21,20 @@ import (
 
 const eventTimeout = 10 * time.Second
 
-func main() {
+func run() error {
 	kubeConfigYaml := os.Getenv("KUBECONFIG_YAML")
 	if kubeConfigYaml == "" {
-		log.Fatal("KUBECONFIG_YAML environment variable is not set")
+		return fmt.Errorf("KUBECONFIG_YAML environment variable is not set")
 	}
 
 	config, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeConfigYaml))
 	if err != nil {
-		log.Fatalf("Failed to build kubeconfig: %v", err)
+		return fmt.Errorf("Failed to build kubeconfig: %w", err)
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Fatalf("Failed to create Kubernetes client: %v", err)
+		return fmt.Errorf("Failed to create Kubernetes client: %w", err)
 	}
 
 	stopCh := make(chan struct{})
@@ -120,13 +121,13 @@ func main() {
 	// create a pod
 	_, err = clientset.CoreV1().Pods(corev1.NamespaceDefault).Create(ctx, &pod, metav1.CreateOptions{})
 	if err != nil {
-		log.Fatalf("Failed to create pod: %v", err)
+		return fmt.Errorf("Failed to create pod: %w", err)
 	}
 
 	select {
 	case <-addedCh:
 	case <-time.After(eventTimeout):
-		log.Fatalf("Timed out waiting for pod creation event")
+		return fmt.Errorf("Timed out waiting for pod creation event")
 	}
 
 	// update the pod
@@ -141,7 +142,7 @@ func main() {
 		return err
 	})
 	if err != nil {
-		log.Fatalf("Failed to update pod: %v", err)
+		return fmt.Errorf("Failed to update pod: %w", err)
 	}
 
 	select {
@@ -155,7 +156,7 @@ func main() {
 		GracePeriodSeconds: new(int64),
 	})
 	if err != nil {
-		log.Fatalf("Failed to delete pod: %v", err)
+		return fmt.Errorf("Failed to delete pod: %w", err)
 	}
 
 	select {
@@ -166,4 +167,12 @@ func main() {
 
 	close(stopCh)
 	factory.Shutdown()
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/kafkaconsumer/main.go
+++ b/test/apps/kafkaconsumer/main.go
@@ -8,6 +8,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
@@ -29,7 +30,7 @@ func brokers() []string {
 	return []string{"localhost:9092"}
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -54,7 +55,7 @@ func main() {
 
 	msg, err := r.ReadMessage(ctx)
 	if err != nil {
-		log.Fatalf("failed to read message: %v", err)
+		return fmt.Errorf("failed to read message: %w", err)
 	}
 	slog.Info("consumed message", "topic", *topic, "key", string(msg.Key), "offset", msg.Offset)
 }
@@ -90,6 +91,14 @@ func writeMessage(ctx context.Context, key, value string) {
 	defer w.Close()
 
 	if err := w.WriteMessages(ctx, kafka.Message{Key: []byte(key), Value: []byte(value)}); err != nil {
-		log.Fatalf("failed to write messages: %v", err)
+		return fmt.Errorf("failed to write messages: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/test/apps/kafkaproducer/main.go
+++ b/test/apps/kafkaproducer/main.go
@@ -8,6 +8,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
@@ -26,7 +27,7 @@ func brokers() []string {
 	return []string{"localhost:9092"}
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -67,6 +68,14 @@ func writeMessage(ctx context.Context, key, value string) {
 	defer w.Close()
 
 	if err := w.WriteMessages(ctx, kafka.Message{Key: []byte(key), Value: []byte(value)}); err != nil {
-		log.Fatalf("failed to write messages: %v", err)
+		return fmt.Errorf("failed to write messages: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/test/apps/linodegoclient/main.go
+++ b/test/apps/linodegoclient/main.go
@@ -28,12 +28,12 @@ var (
 	id   = flag.Int("id", 123, "Resource ID used by get operations")
 )
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	client, err := linodego.NewClient(http.DefaultClient)
 	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
+		return fmt.Errorf("failed to create client: %w", err)
 	}
 	client.SetToken("test-token")
 	// Avoid response cache so each ListRegions call hits the wire in tests.
@@ -41,7 +41,7 @@ func main() {
 
 	apiRoot := *addr + "/v4"
 	if _, err := client.UseURL(apiRoot); err != nil {
-		log.Fatalf("failed to set API URL %q: %v", apiRoot, err)
+		return fmt.Errorf("failed to set API URL %q: %w", apiRoot, err)
 	}
 
 	ctx := context.Background()
@@ -52,7 +52,7 @@ func main() {
 	case "smoke":
 		runSmoke(ctx, client, *id)
 	default:
-		log.Fatalf("unknown mode %q (want smoke|not_found)", *mode)
+		return fmt.Errorf("unknown mode %q (want smoke|not_found)", *mode)
 	}
 }
 
@@ -118,10 +118,18 @@ func runNotFound(ctx context.Context, client linodego.Client, resourceID int) {
 		slog.Info("get_instance_error", "id", resourceID, "error", err.Error())
 		return
 	}
-	log.Fatalf("expected GetInstance(%d) to fail", resourceID)
+	return fmt.Errorf("expected GetInstance(%d) to fail", resourceID)
 }
 
 func fail(op string, err error) {
 	fmt.Fprintf(os.Stderr, "%s error: %v\n", op, err)
-	log.Fatalf("%s failed: %v", op, err)
+	return fmt.Errorf("%s failed: %w", op, err)
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/logslog/main.go
+++ b/test/apps/logslog/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
@@ -14,10 +15,10 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-func main() {
+func run() error {
 	exporter, err := stdouttrace.New(stdouttrace.WithWriter(os.Stdout))
 	if err != nil {
-		log.Fatalf("failed to create exporter: %v", err)
+		return fmt.Errorf("failed to create exporter: %w", err)
 	}
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exporter)),
@@ -40,4 +41,12 @@ func main() {
 	log.Print("standard log message 3")
 
 	span.End()
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/logslogrus/main.go
+++ b/test/apps/logslogrus/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 
@@ -14,10 +15,10 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-func main() {
+func run() error {
 	exporter, err := stdouttrace.New(stdouttrace.WithWriter(os.Stdout))
 	if err != nil {
-		log.Fatalf("failed to create exporter: %v", err)
+		return fmt.Errorf("failed to create exporter: %w", err)
 	}
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exporter)),
@@ -42,4 +43,12 @@ func main() {
 	logger.WithContext(ctx).Info("logrus info message with context")
 
 	span.End()
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/mongoclient/main.go
+++ b/test/apps/mongoclient/main.go
@@ -8,8 +8,10 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
+	"os"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -24,7 +26,7 @@ var (
 	uri     = flag.String("uri", "mongodb://localhost:27017", "MongoDB connection URI")
 )
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	ctx := context.Background()
@@ -37,7 +39,7 @@ func main() {
 	case "2":
 		v2(ctx)
 	default:
-		log.Fatalf("invalid version: %v", *version)
+		return fmt.Errorf("invalid version: %v", *version)
 	}
 
 	slog.Info("MongoDB operations completed successfully")
@@ -46,11 +48,11 @@ func main() {
 func v1(ctx context.Context) {
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(*uri))
 	if err != nil {
-		log.Fatalf("failed to connect to MongoDB: %v", err)
+		return fmt.Errorf("failed to connect to MongoDB: %w", err)
 	}
 	defer func() {
 		if err := client.Disconnect(ctx); err != nil {
-			log.Fatalf("failed to disconnect from MongoDB: %v", err)
+			return fmt.Errorf("failed to disconnect from MongoDB: %w", err)
 		}
 	}()
 
@@ -62,18 +64,18 @@ func v1(ctx context.Context) {
 		{Key: "status", Value: "active"},
 	})
 	if err != nil {
-		log.Fatalf("failed to insert document: %v", err)
+		return fmt.Errorf("failed to insert document: %w", err)
 	}
 }
 
 func v2(ctx context.Context) {
 	client, err := mongov2.Connect(optionsv2.Client().ApplyURI(*uri))
 	if err != nil {
-		log.Fatalf("failed to connect to MongoDB: %v", err)
+		return fmt.Errorf("failed to connect to MongoDB: %w", err)
 	}
 	defer func() {
 		if err := client.Disconnect(ctx); err != nil {
-			log.Fatalf("failed to disconnect from MongoDB: %v", err)
+			return fmt.Errorf("failed to disconnect from MongoDB: %w", err)
 		}
 	}()
 
@@ -85,6 +87,14 @@ func v2(ctx context.Context) {
 		{Key: "status", Value: "active"},
 	})
 	if err != nil {
-		log.Fatalf("failed to insert document: %v", err)
+		return fmt.Errorf("failed to insert document: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/test/apps/openaiclient/main.go
+++ b/test/apps/openaiclient/main.go
@@ -8,8 +8,10 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
+	"os"
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -21,7 +23,7 @@ var (
 	model  = flag.String("model", "gpt-4", "The model to use")
 )
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	client := openai.NewClient(
@@ -36,8 +38,16 @@ func main() {
 		Model: openai.ChatModel(*model),
 	})
 	if err != nil {
-		log.Fatalf("failed to create chat completion: %v", err)
+		return fmt.Errorf("failed to create chat completion: %w", err)
 	}
 
 	slog.Info("response", "content", completion.Choices[0].Message.Content)
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/otelsdk/main.go
+++ b/test/apps/otelsdk/main.go
@@ -199,7 +199,7 @@ func requestedPaths() []string {
 	return []string{"otel", "worker", "compact"}
 }
 
-func main() {
+func run() error {
 	flag.Parse()
 	addr := fmt.Sprintf(":%s", *port)
 
@@ -222,22 +222,30 @@ func main() {
 
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		return fmt.Errorf("failed to listen: %w", err)
 	}
 	go func() {
 		if err := http.Serve(ln, nil); err != nil {
-			log.Fatalf("failed to serve: %v", err)
+			return fmt.Errorf("failed to serve: %w", err)
 		}
 	}()
 
 	for _, path := range requestedPaths() {
 		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%s/%s", *port, path))
 		if err != nil {
-			log.Fatalf("request to %s failed: %v", path, err)
+			return fmt.Errorf("request to %s failed: %w", path, err)
 		}
 		resp.Body.Close()
 	}
 
 	// Give time for span export
 	time.Sleep(1 * time.Second)
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/test/apps/redisclient/main.go
+++ b/test/apps/redisclient/main.go
@@ -8,15 +8,17 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
+	"os"
 
 	"github.com/redis/go-redis/v9"
 )
 
 var addr = flag.String("addr", "localhost:6379", "The Redis server address")
 
-func main() {
+func run() error {
 	flag.Parse()
 
 	ctx := context.Background()
@@ -29,21 +31,29 @@ func main() {
 	// SET command
 	err := rdb.Set(ctx, "testkey", "testvalue", 0).Err()
 	if err != nil {
-		log.Fatalf("failed to set key: %v", err)
+		return fmt.Errorf("failed to set key: %w", err)
 	}
 	slog.Info("SET", "key", "testkey", "value", "testvalue")
 
 	// GET command
 	val, err := rdb.Get(ctx, "testkey").Result()
 	if err != nil {
-		log.Fatalf("failed to get key: %v", err)
+		return fmt.Errorf("failed to get key: %w", err)
 	}
 	slog.Info("GET", "key", "testkey", "value", val)
 
 	// DEL command
 	err = rdb.Del(ctx, "testkey").Err()
 	if err != nil {
-		log.Fatalf("failed to del key: %v", err)
+		return fmt.Errorf("failed to del key: %w", err)
 	}
 	slog.Info("DEL", "key", "testkey")
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
## Description

This PR refactors all `main.go` files inside the `test/apps/` directory to replace calls to `log.Fatal` and `log.Fatalf` with a graceful shutdown pattern. 

Specifically, the core application logic has been moved from `main()` to a `run() error` function. The new `main()` wrapper executes `run()`, logs any returned errors using `log.Printf`, and subsequently exits with `os.Exit(1)`.

## Motivation

Sample apps and tests previously used `log.Fatal` or `log.Fatalf` to exit upon error. `log.Fatal` immediately calls `os.Exit(1)`, which prevents any deferred functions (such as `defer provider.Shutdown()`) from running. 

This meant that traces generated just prior to an error might not be properly flushed to the backend before process termination. This refactor ensures all `defer` statements are respected while preserving the non-zero exit code behavior on failure.

Fixes # (insert issue number if applicable, or leave blank)

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
