### PR TITLE
fix(tool): implement isSetup logic to correctly track setup completion

### DIFF
--- a/tool/internal/setup/pin_helpers_test.go
+++ b/tool/internal/setup/pin_helpers_test.go
@@ -16,8 +16,20 @@ import (
 )
 
 func TestIsSetup(t *testing.T) {
-	// isSetup is currently a stub that always reports false.
+	// By default, no setup file exists.
 	assert.False(t, isSetup())
+
+	// Set up a mock environment
+	dir := newModuleDir(t)
+	t.Setenv(util.EnvOtelcWorkDir, dir)
+	
+	// Create the build temp dir and the matched file
+	matchedFile := util.GetMatchedRuleFile()
+	require.NoError(t, os.MkdirAll(filepath.Dir(matchedFile), 0o755))
+	require.NoError(t, os.WriteFile(matchedFile, []byte("{}"), 0o644))
+
+	// isSetup should now report true
+	assert.True(t, isSetup())
 }
 
 // newModuleDir creates a minimal Go module in a fresh temp directory and

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -62,8 +62,7 @@ func keepForDebug(ctx context.Context, srcPath string) {
 
 // This function can be used to check if the setup has been completed.
 func isSetup() bool {
-	// TODO: Implement Task
-	return false
+	return util.PathExists(util.GetMatchedRuleFile())
 }
 
 // flagsWithPathValues contains flags that accept a value from "go build" command.


### PR DESCRIPTION
## Description

This PR implements the missing logic for the `isSetup()` function in `tool/internal/setup/setup.go`. 

Previously, this function always returned `false` with a `// TODO: Implement Task` stub. The stub has been removed, and `isSetup()` now correctly determines setup completion by checking for the existence of `matched.json` via `util.PathExists(util.GetMatchedRuleFile())`. 

Additionally, `TestIsSetup` has been updated in `pin_helpers_test.go` to mock the environment and properly assert the `true` and `false` states of this function.

## Motivation

The `isSetup()` function is intended to prevent redundant executions of the setup phase by checking if `otelc setup` has already finished successfully. Without this logic, the tool lacked an accurate mechanism to short-circuit the setup routines, relying entirely on downstream processes. Implementing this speeds up repeated executions and properly completes the intended setup architecture.

Fixes # (insert issue number if applicable, or leave blank)

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
