### PR TITLE
fix(tool/internal/instrument): resolve file rule path directly to prevent filename suffix collision

### DIFF
--- a/tool/internal/instrument/apply_file.go
+++ b/tool/internal/instrument/apply_file.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"go.opentelemetry.io/otelc/tool/ex"
@@ -23,21 +22,10 @@ func stripBuildIgnoreTag(content string) string {
 
 // applyFileRule introduces the new file to the target package at compile time.
 func (ip *InstrumentPhase) applyFileRule(ctx context.Context, rule *rule.InstFileRule, pkgName string) error {
-	// List all files in the rule module path
-	files, err := util.ListFiles(rule.ResolvedPath)
-	if err != nil {
-		return ex.Wrapf(err, "listing files for rule %s in dir %s (import path %s)",
-			rule.Name, rule.ResolvedPath, rule.Path)
+	file := filepath.Join(rule.ResolvedPath, rule.File)
+	if !util.PathExists(file) {
+		return ex.Newf("file %s not found in %s", rule.File, rule.ResolvedPath)
 	}
-
-	// Find the new file we want to introduce
-	index := slices.IndexFunc(files, func(file string) bool {
-		return strings.HasSuffix(file, rule.File)
-	})
-	if index == -1 {
-		return ex.Newf("file %s not found", rule.File)
-	}
-	file := files[index]
 
 	// Parse the new file into AST nodes and modify it as needed.
 	// Keep processing in-memory to avoid mutating shared temp rule files.

--- a/tool/internal/instrument/apply_file_test.go
+++ b/tool/internal/instrument/apply_file_test.go
@@ -4,9 +4,16 @@
 package instrument
 
 import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otelc/tool/internal/rule"
 )
 
 func TestStripBuildIgnoreTag(t *testing.T) {
@@ -66,4 +73,138 @@ func main() {}
 			assert.Equal(t, tt.expected, stripBuildIgnoreTag(tt.input))
 		})
 	}
+}
+
+func TestApplyFileRule_Success(t *testing.T) {
+	srcDir := t.TempDir()
+	workDir := t.TempDir()
+
+	content := `//go:build ignore
+
+package sourcepkg
+
+func Helper() string {
+	return "ok"
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "helper.go"), []byte(content), 0o644))
+
+	ip := &InstrumentPhase{
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workDir: workDir,
+	}
+
+	fileRule := &rule.InstFileRule{
+		File:         "helper.go",
+		Path:         "example.com/mypkg",
+		ResolvedPath: srcDir,
+	}
+	fileRule.Name = "test_file_rule"
+
+	err := ip.applyFileRule(t.Context(), fileRule, "targetpkg")
+	require.NoError(t, err)
+
+	outPath := filepath.Join(workDir, "otelc.helper.go")
+	require.FileExists(t, outPath)
+
+	outData, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(outData), "package targetpkg")
+	assert.Contains(t, string(outData), "func Helper()")
+	assert.NotContains(t, string(outData), "//go:build ignore")
+	assert.Contains(t, ip.compileArgs, outPath)
+}
+
+func TestApplyFileRule_NoCollisionWithSuffix(t *testing.T) {
+	srcDir := t.TempDir()
+	workDir := t.TempDir()
+
+	customContent := `package sourcepkg
+func CustomHelper() {}
+`
+	origContent := `package sourcepkg
+func OrigHelper() {}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "custom_helper.go"), []byte(customContent), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "helper.go"), []byte(origContent), 0o644))
+
+	ip := &InstrumentPhase{
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workDir: workDir,
+	}
+
+	fileRule := &rule.InstFileRule{
+		File:         "helper.go",
+		Path:         "example.com/mypkg",
+		ResolvedPath: srcDir,
+	}
+	fileRule.Name = "test_file_rule"
+
+	err := ip.applyFileRule(t.Context(), fileRule, "targetpkg")
+	require.NoError(t, err)
+
+	outPath := filepath.Join(workDir, "otelc.helper.go")
+	require.FileExists(t, outPath)
+
+	outData, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(outData), "OrigHelper")
+	assert.NotContains(t, string(outData), "CustomHelper")
+}
+
+func TestApplyFileRule_FileNotFound(t *testing.T) {
+	srcDir := t.TempDir()
+	workDir := t.TempDir()
+
+	ip := &InstrumentPhase{
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workDir: workDir,
+	}
+
+	fileRule := &rule.InstFileRule{
+		File:         "nonexistent.go",
+		Path:         "example.com/mypkg",
+		ResolvedPath: srcDir,
+	}
+	fileRule.Name = "test_missing_file_rule"
+
+	err := ip.applyFileRule(t.Context(), fileRule, "targetpkg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file nonexistent.go not found in")
+}
+
+func TestApplyFileRule_SubdirectoryFile(t *testing.T) {
+	srcDir := t.TempDir()
+	workDir := t.TempDir()
+
+	subDir := filepath.Join(srcDir, "sub")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+
+	content := `package sourcepkg
+func SubHelper() {}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "helper.go"), []byte(content), 0o644))
+
+	ip := &InstrumentPhase{
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workDir: workDir,
+	}
+
+	fileRule := &rule.InstFileRule{
+		File:         "sub/helper.go",
+		Path:         "example.com/mypkg",
+		ResolvedPath: srcDir,
+	}
+	fileRule.Name = "test_sub_file_rule"
+
+	err := ip.applyFileRule(t.Context(), fileRule, "targetpkg")
+	require.NoError(t, err)
+
+	outPath := filepath.Join(workDir, "otelc.helper.go")
+	require.FileExists(t, outPath)
+
+	outData, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(outData), "package targetpkg")
+	assert.Contains(t, string(outData), "func SubHelper()")
 }


### PR DESCRIPTION
## Description

This PR updates `applyFileRule` in `tool/internal/instrument/apply_file.go` to directly resolve the target file via `filepath.Join(rule.ResolvedPath, rule.File)` and verify its existence with `util.PathExists(file)`, instead of listing all directory files with `util.ListFiles` and matching with `strings.HasSuffix`.

Unit tests have been added to `tool/internal/instrument/apply_file_test.go` covering:
- Successful file rule application and package renaming.
- Verifying that files sharing common suffixes (e.g. `custom_helper.go` vs `helper.go`) do not cause accidental collisions.
- Clear error handling for missing files.
- Subdirectory relative path support.

## Motivation

Previously, `applyFileRule` scanned all files in `rule.ResolvedPath` with `util.ListFiles` and found the target file using `strings.HasSuffix(file, rule.File)`. Because `strings.HasSuffix` does not respect path segment boundaries, any file sharing a suffix (e.g., `my_hook.go` when `hook.go` is specified) could be chosen if enumerated first during directory traversal. Directly constructing and validating `filepath.Join(rule.ResolvedPath, rule.File)` eliminates false suffix collisions and avoids unnecessary directory walks.

Fixes #1039

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable)
