### PR TITLE
fix(tool): allow profile paths sharing build temp prefix

### DIFF
--- a/tool/cmd/otelc/profiling.go
+++ b/tool/cmd/otelc/profiling.go
@@ -46,7 +46,11 @@ func initProfiling(ctx context.Context, cmd *cli.Command) (context.Context, erro
 
 	// Guard against placing profiles inside .otelc-build/ which Cleanup removes.
 	buildTemp := util.GetBuildTempDir()
-	if strings.HasPrefix(profilePath, buildTemp) {
+	rel, err := filepath.Rel(buildTemp, profilePath)
+	if err != nil {
+		return ctx, ex.Wrapf(err, "resolve profile path relative to build temp directory")
+	}
+	if rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
 		return ctx, ex.Newf(
 			"profile-path %q must not be inside the build temp directory %q",
 			profilePath, buildTemp,

--- a/tool/cmd/otelc/profiling.go
+++ b/tool/cmd/otelc/profiling.go
@@ -46,11 +46,7 @@ func initProfiling(ctx context.Context, cmd *cli.Command) (context.Context, erro
 
 	// Guard against placing profiles inside .otelc-build/ which Cleanup removes.
 	buildTemp := util.GetBuildTempDir()
-	rel, err := filepath.Rel(buildTemp, profilePath)
-	if err != nil {
-		return ctx, ex.Wrapf(err, "resolve profile path relative to build temp directory")
-	}
-	if rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
+	if pathWithin(buildTemp, profilePath) {
 		return ctx, ex.Newf(
 			"profile-path %q must not be inside the build temp directory %q",
 			profilePath, buildTemp,
@@ -84,6 +80,11 @@ func initProfiling(ctx context.Context, cmd *cli.Command) (context.Context, erro
 	logger.InfoContext(ctx, "profiling started", "path", profilePath, "profiles", joined)
 
 	return ctx, nil
+}
+
+func pathWithin(parent, path string) bool {
+	rel, err := filepath.Rel(parent, path)
+	return err == nil && (rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))))
 }
 
 // stopProfiling stops the active profiling session. When --profile-summary is set,

--- a/tool/cmd/otelc/profiling_test.go
+++ b/tool/cmd/otelc/profiling_test.go
@@ -105,6 +105,26 @@ func TestInitProfiling(t *testing.T) {
 	})
 }
 
+func TestPathWithin(t *testing.T) {
+	parent := filepath.Join("root", ".otelc-build")
+	tests := map[string]struct {
+		path string
+		want bool
+	}{
+		"same directory": {path: parent, want: true},
+		"descendant":     {path: filepath.Join(parent, "profiles"), want: true},
+		"parent":         {path: filepath.Dir(parent), want: false},
+		"sibling":        {path: filepath.Join("root", "profiles"), want: false},
+		"prefix sibling": {path: parent + "-profiles", want: false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, pathWithin(parent, tt.path))
+		})
+	}
+}
+
 func TestStopProfiling(t *testing.T) {
 	t.Run("no active session is a no-op", func(t *testing.T) {
 		activeSession = nil

--- a/tool/cmd/otelc/profiling_test.go
+++ b/tool/cmd/otelc/profiling_test.go
@@ -68,6 +68,27 @@ func TestInitProfiling(t *testing.T) {
 		assert.Contains(t, err.Error(), "build temp")
 	})
 
+	t.Run("profile-path matching build temp errors", func(t *testing.T) {
+		activeSession = nil
+		workDir := t.TempDir()
+		t.Setenv(util.EnvOtelcWorkDir, workDir)
+		err := runInitProfiling(t, "--profile", "cpu", "--profile-path", util.GetBuildTempDir())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "build temp")
+	})
+
+	t.Run("profile-path sharing build temp prefix starts a session", func(t *testing.T) {
+		activeSession = nil
+		workDir := t.TempDir()
+		t.Setenv(util.EnvOtelcWorkDir, workDir)
+		profDir := util.GetBuildTempDir() + "-profiles"
+
+		require.NoError(t, runInitProfiling(t, "--profile", "cpu", "--profile-path", profDir))
+		require.NotNil(t, activeSession)
+		require.NoError(t, activeSession.Stop())
+		activeSession = nil
+	})
+
 	t.Run("valid profile starts a session and sets env", func(t *testing.T) {
 		activeSession = nil
 		t.Setenv(util.EnvOtelcWorkDir, t.TempDir())


### PR DESCRIPTION
## Description

Replace the textual prefix check for `--profile-path` with path-aware directory containment using `filepath.Rel`.

The `.otelc-build` directory itself and its descendants remain rejected, while sibling directories sharing the same prefix, such as `.otelc-build-profiles`, are now accepted.

Regression tests cover both the exact build directory and a prefix-sharing sibling.

## Motivation

The previous `strings.HasPrefix` check treated sibling paths beginning with `.otelc-build` as though they were inside the build temporary directory.

Fixes #1042