### PR TITLE
fix(tool/cmd/otelc): allow profile-path sibling directories sharing build-temp prefix

### DIFF
--- a/tool/cmd/otelc/profiling.go
+++ b/tool/cmd/otelc/profiling.go
@@ -46,7 +46,7 @@ func initProfiling(ctx context.Context, cmd *cli.Command) (context.Context, erro
 
 	// Guard against placing profiles inside .otelc-build/ which Cleanup removes.
 	buildTemp := util.GetBuildTempDir()
-	if strings.HasPrefix(profilePath, buildTemp) {
+	if isSubPath(profilePath, buildTemp) {
 		return ctx, ex.Newf(
 			"profile-path %q must not be inside the build temp directory %q",
 			profilePath, buildTemp,
@@ -116,4 +116,13 @@ func stopProfiling(ctx context.Context, cmd *cli.Command) error {
 	logger.InfoContext(ctx, "merging profile files", "dir", profileDir)
 	mergeErr := profile.Merge(ctx, profileDir, types)
 	return ex.Join(stopErr, mergeErr)
+}
+
+// isSubPath reports whether target is equal to base or located inside base.
+func isSubPath(target, base string) bool {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || !strings.HasPrefix(rel, "..")
 }

--- a/tool/cmd/otelc/profiling_test.go
+++ b/tool/cmd/otelc/profiling_test.go
@@ -68,6 +68,31 @@ func TestInitProfiling(t *testing.T) {
 		assert.Contains(t, err.Error(), "build temp")
 	})
 
+	t.Run("profile-path equal to build temp errors", func(t *testing.T) {
+		activeSession = nil
+		workDir := t.TempDir()
+		t.Setenv(util.EnvOtelcWorkDir, workDir)
+		buildTemp := util.GetBuildTempDir()
+		err := runInitProfiling(t, "--profile", "cpu", "--profile-path", buildTemp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "build temp")
+	})
+
+	t.Run("profile-path sharing prefix with build temp is allowed", func(t *testing.T) {
+		activeSession = nil
+		workDir := t.TempDir()
+		t.Setenv(util.EnvOtelcWorkDir, workDir)
+		t.Setenv(profile.EnvProfilePath, "")
+		t.Setenv(profile.EnvEnabledProfiles, "")
+		sibling := util.GetBuildTempDir() + "-profiles"
+
+		require.NoError(t, runInitProfiling(t, "--profile", "cpu", "--profile-path", sibling))
+		require.NotNil(t, activeSession)
+
+		require.NoError(t, activeSession.Stop())
+		activeSession = nil
+	})
+
 	t.Run("valid profile starts a session and sets env", func(t *testing.T) {
 		activeSession = nil
 		t.Setenv(util.EnvOtelcWorkDir, t.TempDir())
@@ -123,4 +148,70 @@ func TestStopProfiling(t *testing.T) {
 		require.NoError(t, app.Run(context.Background(), []string{"otelc", "--profile-summary"}))
 		assert.Nil(t, activeSession)
 	})
+}
+
+func TestIsSubPath(t *testing.T) {
+	base := filepath.Join(string(filepath.Separator), "path", "to", ".otelc-build")
+
+	tests := []struct {
+		name     string
+		target   string
+		base     string
+		expected bool
+	}{
+		{
+			name:     "exact base path",
+			target:   base,
+			base:     base,
+			expected: true,
+		},
+		{
+			name:     "child path inside base",
+			target:   filepath.Join(base, "sub", "dir"),
+			base:     base,
+			expected: true,
+		},
+		{
+			name:     "sibling path with shared prefix",
+			target:   base + "-profiles",
+			base:     base,
+			expected: false,
+		},
+		{
+			name:     "nested path under sibling with shared prefix",
+			target:   filepath.Join(base+"-profiles", "sub", "dir"),
+			base:     base,
+			expected: false,
+		},
+		{
+			name:     "target with trailing separator equal to base",
+			target:   base + string(filepath.Separator),
+			base:     base,
+			expected: true,
+		},
+		{
+			name:     "parent directory",
+			target:   filepath.Dir(base),
+			base:     base,
+			expected: false,
+		},
+		{
+			name:     "completely different path",
+			target:   filepath.Join(string(filepath.Separator), "other", "dir"),
+			base:     base,
+			expected: false,
+		},
+		{
+			name:     "incompatible relative path error path",
+			target:   "relative/path",
+			base:     base,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isSubPath(tt.target, tt.base))
+		})
+	}
 }


### PR DESCRIPTION
Fixes #1042

### Description
In `tool/cmd/otelc/profiling.go`, `initProfiling` previously checked if `--profile-path` was inside the build temp directory (`.otelc-build`) using `strings.HasPrefix(profilePath, buildTemp)`.

Because string prefix matching is path-boundary unaware, sibling directories sharing the prefix (e.g. `.otelc-build-profiles` or `.otelc-build-123`) were incorrectly matched and rejected as being inside `.otelc-build`.

This PR replaces `strings.HasPrefix` with a path-boundary aware `isSubPath(target, base)` helper leveraging `filepath.Rel`. It also adds unit tests covering sibling directory paths and exact build temp directory paths.

### Checklist
- [x] PR title follows conventional commits format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow testing guidelines
- [x] Documentation updated (if applicable)
