### PR TITLE
fix(tool): use collision-safe names for blank receivers

### DIFF
--- a/tool/internal/instrument/apply_func.go
+++ b/tool/internal/instrument/apply_func.go
@@ -123,8 +123,7 @@ func collectArguments(funcDecl *dst.FuncDecl, hash string) []string {
 				// so it falls into this branch, but "_" cannot have its
 				// address taken during trampoline generation the way a named
 				// receiver can. Assign it a generated name instead.
-				receiver = fmt.Sprintf("%s%d", ignoredParam, idx)
-				idx++
+				receiver = next(ignoredParam)
 				recv.Names[0].Name = receiver
 			}
 			args = append(args, receiver)

--- a/tool/internal/instrument/apply_func_test.go
+++ b/tool/internal/instrument/apply_func_test.go
@@ -104,7 +104,12 @@ func TestCollectArguments(t *testing.T) {
 		{
 			name:     "underscore receiver",
 			src:      "package main\ntype T struct{}\nfunc (_ T) F() {}",
-			expected: []string{"_ignoredParam0"},
+			expected: []string{syntheticParam(0)},
+		},
+		{
+			name:     "underscore receiver with legacy synthetic-looking param name",
+			src:      "package main\ntype T struct{}\nfunc (_ T) F(_ignoredParam0 int) {}",
+			expected: []string{syntheticParam(0), "_ignoredParam0"},
 		},
 		{
 			name:     "named receiver with params",
@@ -199,6 +204,10 @@ func TestCollectNamesNoCollision(t *testing.T) {
 		{
 			name: "blank receiver and blank named return",
 			src:  "package main\ntype T struct{}\nfunc (_ T) M() (_ error) { return nil }",
+		},
+		{
+			name: "blank receiver and legacy synthetic-looking param name",
+			src:  "package main\ntype T struct{}\nfunc (_ T) M(_ignoredParam0 int) {}",
 		},
 		{
 			name: "unnamed param and unnamed return (control)",


### PR DESCRIPTION
## Description

Use `syntheticNamer` when remapping blank method receivers.

PR #1035 migrated generated parameter and return names to collision-safe, rule-identity-based names, but the blank-receiver branch retained the old counter-based implementation. Because the local counter was removed in the same migration, current `main` also fails to compile with `undefined: idx`.

This change routes blank receivers through the existing `next(ignoredParam)` generator.

## Motivation

Blank receivers should follow the same naming path as unnamed receivers and blank parameters. This prevents collisions with existing signature identifiers and restores compilation on current `main`.

Fixes #1054