### PR TITLE
fix(tool/internal/instrument): main does not compile, undefined: idx in collectArguments

### DIFF
--- a/tool/internal/instrument/apply_func.go
+++ b/tool/internal/instrument/apply_func.go
@@ -123,8 +123,7 @@ func collectArguments(funcDecl *dst.FuncDecl, hash string) []string {
 				// so it falls into this branch, but "_" cannot have its
 				// address taken during trampoline generation the way a named
 				// receiver can. Assign it a generated name instead.
-				receiver = fmt.Sprintf("%s%d", ignoredParam, idx)
-				idx++
+				receiver = next(ignoredParam)
 				recv.Names[0].Name = receiver
 			}
 			args = append(args, receiver)

--- a/tool/internal/instrument/apply_func_test.go
+++ b/tool/internal/instrument/apply_func_test.go
@@ -104,7 +104,7 @@ func TestCollectArguments(t *testing.T) {
 		{
 			name:     "underscore receiver",
 			src:      "package main\ntype T struct{}\nfunc (_ T) F() {}",
-			expected: []string{"_ignoredParam0"},
+			expected: []string{syntheticParam(0)},
 		},
 		{
 			name:     "named receiver with params",


### PR DESCRIPTION
## `main` is currently broken

`go build ./tool/...` fails on `main` as of `b3602ec`:

```
tool/internal/instrument/apply_func.go:126:50: undefined: idx
tool/internal/instrument/apply_func.go:127:5: undefined: idx
```

This takes down `make build`, so every PR that reaches the build step fails with something unrelated to its own diff. I hit it as `Overhead Threshold Check` failing at the `Build otelc` step on an unrelated PR of mine:

```
Building instrumentation tool...
# go.opentelemetry.io/otelc/tool/internal/instrument
tool/internal/instrument/apply_func.go:126:50: undefined: idx
/bin/bash: line 5: ./otelc: No such file or directory
make: *** [Makefile:142: build] Error 127
```

Bisected: `1bec7dc` builds, `2d6daf5` does not.

## How it happened

Two PRs landed the same day and collided without either one's CI seeing the other:

- **#799** (`450a2b6`) added the blank-receiver branch to `collectArguments`, naming the synthetic receiver with the package's `idx` counter.
- **#1035** (`2d6daf5`) replaced that counter with `syntheticNamer` / `next()`, converting every call site that existed *on its base* — which did not yet include the branch #799 had just added.

Both were green on their own base. Neither branch was rebased on the other, so the missed call site only exists once both are merged. Nothing is wrong with either PR in isolation.

This is the failure mode @dobbydobap described in #973 — a green check from a stale base is indistinguishable from a green check from current `main` in the PR list. Worth noting as a live example, since the discussion there was about whether to require branches to be up to date before merging.

## Fix

Point the blank-receiver branch at `next(ignoredParam)`, matching the three sibling branches in the same function. That also gives the blank receiver the hash-qualified name #1035 introduced, which is exactly the collision-avoidance that PR was about — so this is the naming #1035 would have applied had the branch been visible to it.

The `"underscore receiver"` case in `TestCollectArguments` still asserted the pre-#1035 literal `"_ignoredParam0"`. It now uses the `syntheticParam(0)` helper the neighbouring `"unnamed receiver"` case already uses. That assertion is the reason the fix is not purely a one-line change: the test encoded the old naming scheme too.

## Verification

- `go build ./...` — clean
- `go test ./tool/...` — all 13 packages pass, including `tool/internal/instrument`

Given this blocks builds on `main`, it may be worth merging ahead of the queue.
