### PR TITLE
refactor(tool): unify import path alias deduction

### DIFF
--- a/tool/internal/ast/shared.go
+++ b/tool/internal/ast/shared.go
@@ -346,13 +346,13 @@ func AddStructField(st *dst.StructType, name, t string) {
 // full interface-satisfaction checking.
 //
 // Qualified type names are resolved against imports, which maps the local
-// identifier used at a use site to its real import path (see importAliasMap).
+// identifier used at a use site to its real import path (see ImportAliasMap).
 // Matching is therefore relative to the enclosing file's import declarations.
 func funcDeclMatchesFilters(funcDecl *dst.FuncDecl, r *rule.InstFuncRule, root *dst.File) (bool, error) {
 	if r.Signature == nil && r.SignatureContains == nil && r.Result == "" && r.LastResult == "" && r.Param == "" {
 		return true, nil
 	}
-	imports := importAliasMap(root)
+	imports := ImportAliasMap(root)
 	ft := funcDecl.Type
 
 	if r.Signature != nil {

--- a/tool/internal/ast/typename.go
+++ b/tool/internal/ast/typename.go
@@ -4,6 +4,7 @@
 package ast
 
 import (
+	"go/token"
 	"regexp"
 	"strconv"
 	"strings"
@@ -64,7 +65,7 @@ func (t parsedTypeName) matches(node dst.Expr, imports map[string]string) bool {
 		// tests with no backing *dst.File): compare against importPath's last
 		// segment. Note this cannot rescue a miskeyed map — a tail match here
 		// would imply ident.Name is a key, so the lookup above would have hit.
-		return importPathTail(t.importPath) == ident.Name && t.name == n.Sel.Name
+		return DefaultImportAlias(t.importPath) == ident.Name && t.name == n.Sel.Name
 
 	case *dst.StarExpr:
 		inner := parsedTypeName{importPath: t.importPath, name: t.name}
@@ -108,7 +109,7 @@ func fieldListContainsType(fields *dst.FieldList, typeStr string, imports map[st
 	return false, nil
 }
 
-// importAliasMap builds a map from the local identifier used to reference an
+// ImportAliasMap builds a map from the local identifier used to reference an
 // imported package within file (its explicit alias, or its default package
 // name when unaliased) to that package's real import path. It correctly disambiguates:
 //   - aliased imports (e.g. `import althttp "net/http"`)
@@ -119,15 +120,32 @@ func fieldListContainsType(fields *dst.FieldList, typeStr string, imports map[st
 // it: that resolves unaliased imports with pkgload.ResolvePackageName (a
 // go/packages load that ex.Fatalf's on failure), which is too costly and too fatal
 // for the setup/match path, where this runs for every compiled package in the build.
-// The cost is that the default name here is a syntactic guess; see importPathTail.
+// The cost is that the default name here is a syntactic guess; see DefaultImportAlias.
 //
 // Returns nil when file is nil.
-func importAliasMap(file *dst.File) map[string]string {
+func ImportAliasMap(file *dst.File) map[string]string {
 	if file == nil {
 		return nil
 	}
-	aliases := make(map[string]string, len(file.Imports))
-	for _, imp := range file.Imports {
+	var specs []*dst.ImportSpec
+	if len(file.Imports) > 0 {
+		specs = file.Imports
+	} else {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*dst.GenDecl)
+			if !ok || genDecl.Tok != token.IMPORT {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				if importSpec, isImport := spec.(*dst.ImportSpec); isImport {
+					specs = append(specs, importSpec)
+				}
+			}
+		}
+	}
+
+	aliases := make(map[string]string, len(specs))
+	for _, imp := range specs {
 		if imp.Path == nil {
 			continue
 		}
@@ -135,13 +153,13 @@ func importAliasMap(file *dst.File) map[string]string {
 		if err != nil {
 			continue
 		}
-		alias := importPathTail(path)
+		alias := DefaultImportAlias(path)
 		if imp.Name != nil {
 			alias = imp.Name.Name
 		}
 		// Blank and dot imports don't introduce a qualified identifier that a
 		// type reference could use, so they can't participate in matching.
-		if alias == "_" || alias == "." {
+		if alias == "" || alias == "_" || alias == "." {
 			continue
 		}
 		aliases[alias] = path
@@ -149,15 +167,20 @@ func importAliasMap(file *dst.File) map[string]string {
 	return aliases
 }
 
-// importPathTail returns the local identifier conventionally used to reference
-// an import path: its last segment, ignoring a Go module major-version suffix
-// ("/v2".."/vN", or gopkg.in's ".vN"), which is part of the module path but not
-// of the package name, e.g. "net/http" -> "http", "github.com/x/jwt/v5" -> "jwt".
+// DefaultImportAlias (also aliased as ImportPathTail) returns the local identifier
+// conventionally used to reference an import path: its last segment, ignoring a
+// Go module major-version suffix ("/v2".."/vN", or gopkg.in's ".vN"), which is
+// part of the module path but not of the package name, e.g. "net/http" -> "http",
+// "github.com/x/jwt/v5" -> "jwt", "gopkg.in/yaml.v3" -> "yaml".
 //
 // This is a convention, not a guarantee: a package may declare a name unrelated
 // to its path (e.g. "github.com/redis/go-redis/v9" declares "redis"). Such
 // packages are matched only when the importing file aliases them explicitly.
-func importPathTail(path string) string {
+func DefaultImportAlias(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" || path == "." || path == "/" {
+		return ""
+	}
 	if i := strings.LastIndexByte(path, '/'); i >= 0 && isMajorVersion(path[i+1:]) {
 		path = path[:i]
 	}
@@ -168,7 +191,16 @@ func importPathTail(path string) string {
 	if i := strings.LastIndexByte(path, '.'); i >= 0 && isMajorVersion(path[i+1:]) {
 		path = path[:i]
 	}
+	if path == "." || path == "/" {
+		return ""
+	}
 	return path
+}
+
+// ImportPathTail returns the local identifier conventionally used to reference an import path.
+// It is an alias for DefaultImportAlias.
+func ImportPathTail(path string) string {
+	return DefaultImportAlias(path)
 }
 
 // isMajorVersion reports whether s is a module major-version element ("v2", "v11").

--- a/tool/internal/ast/typename.go
+++ b/tool/internal/ast/typename.go
@@ -197,12 +197,6 @@ func DefaultImportAlias(path string) string {
 	return path
 }
 
-// ImportPathTail returns the local identifier conventionally used to reference an import path.
-// It is an alias for DefaultImportAlias.
-func ImportPathTail(path string) string {
-	return DefaultImportAlias(path)
-}
-
 // isMajorVersion reports whether s is a module major-version element ("v2", "v11").
 func isMajorVersion(s string) bool {
 	if len(s) < 2 || s[0] != 'v' {

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -260,7 +260,7 @@ func TestTypeNameMatches_ImportAliasResolution(t *testing.T) {
 
 func TestImportAliasMap(t *testing.T) {
 	t.Run("nil file returns nil", func(t *testing.T) {
-		assert.Nil(t, importAliasMap(nil))
+		assert.Nil(t, ImportAliasMap(nil))
 	})
 
 	t.Run("resolves default and aliased imports, skips blank and dot imports", func(t *testing.T) {
@@ -278,7 +278,7 @@ func f(r *http.Request, r2 *althttp.Request) {}
 `)
 		require.NoError(t, err)
 
-		imports := importAliasMap(file)
+		imports := ImportAliasMap(file)
 		assert.Len(t, imports, 2)
 		assert.Equal(t, "net/http", imports["http"])
 		assert.Equal(t, "net/http", imports["althttp"])
@@ -299,7 +299,7 @@ func f(t *jwt.Token, n *yaml.Node) {}
 `)
 		require.NoError(t, err)
 
-		imports := importAliasMap(file)
+		imports := ImportAliasMap(file)
 		assert.Equal(t, "github.com/golang-jwt/jwt/v5", imports["jwt"])
 		assert.Equal(t, "gopkg.in/yaml.v3", imports["yaml"])
 	})
@@ -317,7 +317,7 @@ func f(x *foo.T, y *bar.T) {}
 `)
 		require.NoError(t, err)
 
-		imports := importAliasMap(file)
+		imports := ImportAliasMap(file)
 		assert.Len(t, imports, 2)
 		assert.Equal(t, "github.com/a/foo/v2", imports["foo"])
 		assert.Equal(t, "github.com/b/bar/v2", imports["bar"])
@@ -334,7 +334,7 @@ func f(c *redis.Client) {}
 `)
 		require.NoError(t, err)
 
-		imports := importAliasMap(file)
+		imports := ImportAliasMap(file)
 		assert.NotContains(t, imports, "redis")
 		assert.Equal(t, "github.com/redis/go-redis/v9", imports["go-redis"])
 	})
@@ -351,7 +351,7 @@ func f(c *vault.Client) {}
 `)
 		require.NoError(t, err)
 
-		imports := importAliasMap(file)
+		imports := ImportAliasMap(file)
 		assert.Equal(t, "github.com/hashicorp/vault", imports["vault"])
 	})
 
@@ -361,7 +361,7 @@ func f(c *vault.Client) {}
 			{Path: &dst.BasicLit{Value: `"net/http"`}},
 		}}
 
-		imports := importAliasMap(file)
+		imports := ImportAliasMap(file)
 		assert.Len(t, imports, 1)
 		assert.Equal(t, "net/http", imports["http"])
 	})
@@ -372,10 +372,41 @@ func f(c *vault.Client) {}
 			{Path: &dst.BasicLit{Value: `"net/http"`}},
 		}}
 
-		imports := importAliasMap(file)
+		imports := ImportAliasMap(file)
 		assert.Len(t, imports, 1)
 		assert.Equal(t, "net/http", imports["http"])
 	})
+}
+
+func TestDefaultImportAlias(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "net/http", want: "http"},
+		{input: "fmt", want: "fmt"},
+		{input: "github.com/golang-jwt/jwt/v5", want: "jwt"},
+		{input: "github.com/example/pkg/v2", want: "pkg"},
+		{input: "gopkg.in/yaml.v3", want: "yaml"},
+		{input: "gopkg.in/go-playground/validator.v9", want: "validator"},
+		{input: "github.com/hashicorp/vault", want: "vault"},
+		{input: "github.com/redis/go-redis/v9", want: "go-redis"},
+		{input: "example.com/foo/v10", want: "foo"},
+		{input: "yaml.v2", want: "yaml"},
+		{input: "v2", want: "v2"},
+		{input: "", want: ""},
+		{input: ".", want: ""},
+		{input: "/", want: ""},
+		{input: "   ", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := DefaultImportAlias(tt.input)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, ImportPathTail(tt.input))
+		})
+	}
 }
 
 func mustContains(t *testing.T, fields *dst.FieldList, typeStr string) bool {

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -404,6 +404,30 @@ func f(c *vault.Client) {}
 		assert.Equal(t, "net/http", imports["http"])
 		assert.Equal(t, "net/http", imports["althttp"])
 	})
+
+	t.Run("Imports takes precedence when both Imports and Decls contain specs", func(t *testing.T) {
+		file := &dst.File{
+			Imports: []*dst.ImportSpec{
+				{Path: &dst.BasicLit{Value: `"net/http"`}},
+			},
+			Decls: []dst.Decl{
+				&dst.GenDecl{
+					Tok: token.IMPORT,
+					Specs: []dst.Spec{
+						&dst.ImportSpec{
+							Name: &dst.Ident{Name: "ignored"},
+							Path: &dst.BasicLit{Value: `"other/pkg"`},
+						},
+					},
+				},
+			},
+		}
+
+		imports := ImportAliasMap(file)
+		assert.Len(t, imports, 1)
+		assert.Equal(t, "net/http", imports["http"])
+		assert.NotContains(t, imports, "ignored")
+	})
 }
 
 func TestDefaultImportAlias(t *testing.T) {
@@ -434,7 +458,6 @@ func TestDefaultImportAlias(t *testing.T) {
 		t.Run(tt.input, func(t *testing.T) {
 			got := DefaultImportAlias(tt.input)
 			assert.Equal(t, tt.want, got)
-			assert.Equal(t, tt.want, ImportPathTail(tt.input))
 		})
 	}
 }

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -4,6 +4,7 @@
 package ast
 
 import (
+	"go/token"
 	"testing"
 
 	"github.com/dave/dst"
@@ -376,6 +377,33 @@ func f(c *vault.Client) {}
 		assert.Len(t, imports, 1)
 		assert.Equal(t, "net/http", imports["http"])
 	})
+
+	t.Run("resolves imports from Decls when Imports slice is empty", func(t *testing.T) {
+		file := &dst.File{
+			Decls: []dst.Decl{
+				&dst.GenDecl{
+					Tok: token.IMPORT,
+					Specs: []dst.Spec{
+						&dst.ImportSpec{
+							Path: &dst.BasicLit{Value: `"net/http"`},
+						},
+						&dst.ImportSpec{
+							Name: &dst.Ident{Name: "althttp"},
+							Path: &dst.BasicLit{Value: `"net/http"`},
+						},
+					},
+				},
+				&dst.GenDecl{
+					Tok: token.VAR,
+				},
+			},
+		}
+
+		imports := ImportAliasMap(file)
+		assert.Len(t, imports, 2)
+		assert.Equal(t, "net/http", imports["http"])
+		assert.Equal(t, "net/http", imports["althttp"])
+	})
 }
 
 func TestDefaultImportAlias(t *testing.T) {
@@ -394,6 +422,8 @@ func TestDefaultImportAlias(t *testing.T) {
 		{input: "example.com/foo/v10", want: "foo"},
 		{input: "yaml.v2", want: "yaml"},
 		{input: "v2", want: "v2"},
+		{input: "./v2", want: ""},
+		{input: "/v2", want: ""},
 		{input: "", want: ""},
 		{input: ".", want: ""},
 		{input: "/", want: ""},

--- a/tool/internal/instrument/apply_call.go
+++ b/tool/internal/instrument/apply_call.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dave/dst/dstutil"
 
 	"go.opentelemetry.io/otelc/tool/ex"
+	"go.opentelemetry.io/otelc/tool/internal/ast"
 	"go.opentelemetry.io/otelc/tool/internal/rule"
 	"go.opentelemetry.io/otelc/tool/util"
 )

--- a/tool/internal/instrument/apply_call.go
+++ b/tool/internal/instrument/apply_call.go
@@ -17,7 +17,7 @@ import (
 // applyCallRule transforms function calls at call sites by wrapping them with
 // instrumentation code according to the provided replacement template.
 func (ip *InstrumentPhase) applyCallRule(ctx context.Context, r *rule.InstCallRule, root *dst.File) error {
-	importAliases := collectImportAliases(root)
+	importAliases := ast.ImportAliasMap(root)
 
 	appendModified := ip.applyCallAppendArgs(r, root, importAliases)
 

--- a/tool/internal/instrument/apply_call_helpers.go
+++ b/tool/internal/instrument/apply_call_helpers.go
@@ -6,7 +6,6 @@ package instrument
 import (
 	"github.com/dave/dst"
 
-	"go.opentelemetry.io/otelc/tool/internal/ast"
 	"go.opentelemetry.io/otelc/tool/internal/rule"
 )
 

--- a/tool/internal/instrument/apply_call_helpers.go
+++ b/tool/internal/instrument/apply_call_helpers.go
@@ -54,7 +54,3 @@ func matchesCallRule(call *dst.CallExpr, r *rule.InstCallRule, importAliases map
 	resolvedPath, ok := importAliases[ident.Name]
 	return ok && resolvedPath == importPath
 }
-
-func collectImportAliases(file *dst.File) map[string]string {
-	return ast.ImportAliasMap(file)
-}

--- a/tool/internal/instrument/apply_call_helpers.go
+++ b/tool/internal/instrument/apply_call_helpers.go
@@ -4,12 +4,9 @@
 package instrument
 
 import (
-	"go/token"
-	"path"
-	"strings"
-
 	"github.com/dave/dst"
 
+	"go.opentelemetry.io/otelc/tool/internal/ast"
 	"go.opentelemetry.io/otelc/tool/internal/rule"
 )
 
@@ -59,80 +56,5 @@ func matchesCallRule(call *dst.CallExpr, r *rule.InstCallRule, importAliases map
 }
 
 func collectImportAliases(file *dst.File) map[string]string {
-	aliases := make(map[string]string)
-	for _, decl := range file.Decls {
-		genDecl, ok := decl.(*dst.GenDecl)
-		if !ok || genDecl.Tok != token.IMPORT {
-			continue
-		}
-		for _, spec := range genDecl.Specs {
-			importSpec, isImport := spec.(*dst.ImportSpec)
-			if !isImport || importSpec.Path == nil {
-				continue
-			}
-			importPath := strings.Trim(importSpec.Path.Value, `"`)
-			var alias string
-			if importSpec.Name != nil {
-				alias = importSpec.Name.Name
-			} else {
-				alias = defaultImportAlias(importPath)
-			}
-			if alias == "" || alias == "_" || alias == "." {
-				continue
-			}
-			aliases[alias] = importPath
-		}
-	}
-	return aliases
-}
-
-// defaultImportAlias infers the package alias from an import path, replicating
-// Go's default alias rules (last path element, versioned-path stripping, gopkg.in
-// conventions). This is a best-effort reimplementation — edge cases like package
-// names containing hyphens, _test packages, or build-tag-conditional imports may
-// behave differently from the Go compiler's own resolution.
-func defaultImportAlias(importPath string) string {
-	base := path.Base(importPath)
-	if base == "." || base == "/" {
-		return ""
-	}
-	if strings.HasPrefix(importPath, "gopkg.in/") {
-		if trimmed := trimGopkgInVersion(base); trimmed != "" {
-			return trimmed
-		}
-	}
-	if isVersionSuffix(base) {
-		parent := path.Base(path.Dir(importPath))
-		if parent != "." && parent != "/" {
-			return parent
-		}
-	}
-	return base
-}
-
-func trimGopkgInVersion(base string) string {
-	idx := strings.LastIndex(base, ".v")
-	if idx <= 0 {
-		return ""
-	}
-	if !isDigits(base[idx+2:]) {
-		return ""
-	}
-	return base[:idx]
-}
-
-func isVersionSuffix(base string) bool {
-	if len(base) < 2 || base[0] != 'v' {
-		return false
-	}
-	return isDigits(base[1:])
-}
-
-func isDigits(s string) bool {
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return s != ""
+	return ast.ImportAliasMap(file)
 }

--- a/tool/internal/instrument/apply_call_test.go
+++ b/tool/internal/instrument/apply_call_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/otelc/tool/internal/ast"
 	"go.opentelemetry.io/otelc/tool/internal/rule"
 )
 
@@ -221,7 +222,7 @@ func TestMatchesCallRule_ImportAliasFromVersionSuffix(t *testing.T) {
 		},
 	}
 
-	importAliases := collectImportAliases(file)
+	importAliases := ast.ImportAliasMap(file)
 	matches := matchesCallRule(call, r, importAliases)
 
 	assert.True(t, matches)
@@ -440,7 +441,7 @@ func TestMatchesCallRule_ImportAliasFromGopkgIn(t *testing.T) {
 		},
 	}
 
-	importAliases := collectImportAliases(file)
+	importAliases := ast.ImportAliasMap(file)
 	matches := matchesCallRule(call, r, importAliases)
 
 	assert.True(t, matches)
@@ -488,7 +489,7 @@ func TestApplyCallAppendArgs_NoMatchReturnsFalse(t *testing.T) {
 	}
 
 	ip := newTestPhase()
-	importAliases := collectImportAliases(file)
+	importAliases := ast.ImportAliasMap(file)
 	result := ip.applyCallAppendArgs(r, file, importAliases)
 
 	assert.False(t, result, "applyCallAppendArgs must return false when no calls match")


### PR DESCRIPTION
## Description

Unifies import path alias deduction across AST inspection and rewriting tools by using `ast.ImportAliasMap` directly and removing duplicate helper routines (`collectImportAliases`). Also adds comprehensive test coverage for AST and utility helper functions.

Closes #1041

## Type of Change

- [x] Refactoring / Code cleanup
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist

- [x] Follows the conventional commit format for PR title (`refactor(tool): ...`)
- [x] Tests added / updated and passing
- [x] Code adheres to the repository's coding style
