### PR TITLE
refactor(tool/internal/setup): use embedded manifest in pin instead of extracting tarball

### DIFF
--- a/tool/internal/setup/pin.go
+++ b/tool/internal/setup/pin.go
@@ -166,8 +166,6 @@ func generateOtelInstrumentationGo(imports map[string]bool, opts PinOptions) *ds
 	}
 }
 
-
-
 func ensureOtelcRequireVersion(f *modfile.File, version string) (bool, error) {
 	if !semver.IsValid(version) || version == "v0.0.0" || module.IsPseudoVersion(version) {
 		return false, nil

--- a/tool/internal/setup/pin.go
+++ b/tool/internal/setup/pin.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
-	"io/fs"
 	"log/slog"
 	"maps"
 	"os"
@@ -22,10 +21,10 @@ import (
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
-	"gopkg.in/yaml.v3"
 
 	"go.opentelemetry.io/otelc/tool/ex"
 	"go.opentelemetry.io/otelc/tool/internal/ast"
+	"go.opentelemetry.io/otelc/tool/internal/manifest"
 	"go.opentelemetry.io/otelc/tool/internal/pkgload"
 	"go.opentelemetry.io/otelc/tool/internal/rule"
 	"go.opentelemetry.io/otelc/tool/util"
@@ -167,76 +166,7 @@ func generateOtelInstrumentationGo(imports map[string]bool, opts PinOptions) *ds
 	}
 }
 
-type yamlRule struct {
-	Target       string `yaml:"target"`
-	VersionRange string `yaml:"version"`
-}
 
-func loadModuleRules(moduleDir, module string, loaded map[string][]yamlRule) error {
-	return filepath.WalkDir(moduleDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if d.IsDir() {
-			// Skip any submodules
-			if path != moduleDir && util.PathExists(filepath.Join(path, "go.mod")) {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		if !isRuleFile(d.Name()) {
-			return nil
-		}
-
-		data, readErr := os.ReadFile(path) //nolint:gosec // walking embedded rules from extractOtelcBundle
-		if readErr != nil {
-			return ex.Wrapf(readErr, "reading rule file %s", path)
-		}
-
-		var rules map[string]yamlRule
-		if unmarshalErr := yaml.Unmarshal(data, &rules); unmarshalErr != nil {
-			return ex.Wrapf(unmarshalErr, "parsing rule file %s", path)
-		}
-
-		for _, r := range rules {
-			if r.Target != "" {
-				loaded[module] = append(loaded[module], r)
-			}
-		}
-
-		return nil
-	})
-}
-
-func loadMinimalRules(rulesRoot string) (map[string][]yamlRule, error) {
-	loaded := make(map[string][]yamlRule)
-
-	err := filepath.WalkDir(rulesRoot, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		// rulesRoot is instrumentation/
-		// We want to load rules for submodules within instrumentation/
-		// Look for go.mod nested within instrumentation/
-		if d.IsDir() || d.Name() != "go.mod" || filepath.Dir(path) == rulesRoot {
-			return nil
-		}
-
-		modFile, err := parseGoMod(path)
-		if err != nil {
-			return ex.Wrapf(err, "loading %s", path)
-		}
-
-		return loadModuleRules(filepath.Dir(path), modFile.Module.Mod.Path, loaded)
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return loaded, nil
-}
 
 func ensureOtelcRequireVersion(f *modfile.File, version string) (bool, error) {
 	if !semver.IsValid(version) || version == "v0.0.0" || module.IsPseudoVersion(version) {
@@ -309,7 +239,7 @@ func ensureOtelcRequire(moduleDir, version string) (bool, error) {
 
 func matchInstrumentationImports(
 	deps []*Dependency,
-	ruleset map[string][]yamlRule,
+	manifestEntries manifest.Manifest,
 	warn func(msg string, args ...any),
 ) map[string]bool {
 	imports := make(map[string]bool)
@@ -321,25 +251,23 @@ func matchInstrumentationImports(
 
 	// Match only on target + version.
 	for _, dep := range deps {
-		for modPath, rules := range ruleset {
-			for _, r := range rules {
-				tm := instrumentationRuleMatchesDep(dep, r)
-				if tm.isRoot {
-					// always add root targets; they are further matched in setup
-					imports[modPath] = true
-					continue
-				}
-				if !tm.matched {
-					continue
-				}
-
-				if !util.VersionInRange(dep.Version, r.VersionRange) {
-					recordUnresolvedSkip(skipped, modPath, dep, r.VersionRange)
-					continue
-				}
-
-				imports[modPath] = true
+		for _, entry := range manifestEntries {
+			tm := instrumentationEntryMatchesDep(dep, entry)
+			if tm.isRoot {
+				// always add root targets; they are further matched in setup
+				imports[entry.ModulePath] = true
+				continue
 			}
+			if !tm.matched {
+				continue
+			}
+
+			if !util.VersionInRange(dep.Version, entry.VersionRange) {
+				recordUnresolvedSkip(skipped, entry.ModulePath, dep, entry.VersionRange)
+				continue
+			}
+
+			imports[entry.ModulePath] = true
 		}
 	}
 
@@ -357,16 +285,16 @@ type instrumentationTargetMatch struct {
 	isRoot  bool
 }
 
-// instrumentationRuleMatchesDep reports whether r's target matches dep.
+// instrumentationEntryMatchesDep reports whether entry's target matches dep.
 // Root targets always pin the instrumentation module.
-func instrumentationRuleMatchesDep(dep *Dependency, r yamlRule) instrumentationTargetMatch {
+func instrumentationEntryMatchesDep(dep *Dependency, entry manifest.Entry) instrumentationTargetMatch {
 	switch {
-	case rule.IsRootTarget(r.Target):
+	case rule.IsRootTarget(entry.Target):
 		return instrumentationTargetMatch{matched: true, isRoot: true}
-	case rule.IsGlobTarget(r.Target):
-		return instrumentationTargetMatch{matched: rule.MatchGlobTarget(r.Target, dep.ImportPath)}
+	case rule.IsGlobTarget(entry.Target):
+		return instrumentationTargetMatch{matched: rule.MatchGlobTarget(entry.Target, dep.ImportPath)}
 	default:
-		return instrumentationTargetMatch{matched: r.Target == dep.ImportPath}
+		return instrumentationTargetMatch{matched: entry.Target == dep.ImportPath}
 	}
 }
 
@@ -525,18 +453,13 @@ func generatePinnedProjects(ctx context.Context, moduleDirs map[string]bool, opt
 		return nil, ex.Wrapf(findDepsErr, "finding dependencies")
 	}
 
-	extractErr := extractOtelcBundle()
-	if extractErr != nil {
-		return nil, ex.Wrapf(extractErr, "extracting otelc package")
-	}
-
-	ruleset, err := loadMinimalRules(filepath.Join(util.GetBuildTempDir(), unzippedInstDir))
+	manifestEntries, err := manifest.Load()
 	if err != nil {
-		return nil, ex.Wrapf(err, "loading instrumentation rules")
+		return nil, ex.Wrapf(err, "loading instrumentation manifest")
 	}
 
 	// We expect every built-in instrumentation module to be importable
-	imports := matchInstrumentationImports(deps, ruleset, func(msg string, args ...any) {
+	imports := matchInstrumentationImports(deps, manifestEntries, func(msg string, args ...any) {
 		logger.WarnContext(ctx, msg, args...)
 	})
 
@@ -552,6 +475,11 @@ func generatePinnedProjects(ctx context.Context, moduleDirs map[string]bool, opt
 
 		// Ok to re-use deps here, because we do not run "go mod tidy".
 		return &PinResult{AllDeps: deps}, nil
+	}
+
+	extractErr := extractOtelcBundle()
+	if extractErr != nil {
+		return nil, ex.Wrapf(extractErr, "extracting otelc package")
 	}
 
 	// Generate otel.instrumentation.go file with imports for all matched rules.

--- a/tool/internal/setup/pin_test.go
+++ b/tool/internal/setup/pin_test.go
@@ -18,6 +18,7 @@ import (
 	"gotest.tools/v3/golden"
 
 	"go.opentelemetry.io/otelc/tool/internal/ast"
+	"go.opentelemetry.io/otelc/tool/internal/manifest"
 	"go.opentelemetry.io/otelc/tool/internal/rule"
 	"go.opentelemetry.io/otelc/tool/util"
 )
@@ -438,10 +439,10 @@ require %s v1.0.0
 
 func TestMatchInstrumentationImports(t *testing.T) {
 	for _, tt := range []struct {
-		name  string
-		deps  []*Dependency
-		rules map[string][]yamlRule
-		want  map[string]bool
+		name     string
+		deps     []*Dependency
+		manifest manifest.Manifest
+		want     map[string]bool
 	}{
 		{
 			name: "single match",
@@ -451,11 +452,12 @@ func TestMatchInstrumentationImports(t *testing.T) {
 					Version:    "v1.2.3",
 				},
 			},
-			rules: map[string][]yamlRule{
-				"example.com/instrumentation/foo": {{
+			manifest: manifest.Manifest{
+				{
+					ModulePath:   "example.com/instrumentation/foo",
 					Target:       "example.com/foo",
 					VersionRange: "v1.2.3",
-				}},
+				},
 			},
 			want: map[string]bool{
 				"example.com/instrumentation/foo": true,
@@ -469,11 +471,12 @@ func TestMatchInstrumentationImports(t *testing.T) {
 					Version:    "v1.2.3",
 				},
 			},
-			rules: map[string][]yamlRule{
-				"example.com/instrumentation/bar": {{
+			manifest: manifest.Manifest{
+				{
+					ModulePath:   "example.com/instrumentation/bar",
 					Target:       "example.com/bar",
 					VersionRange: "v1.2.3",
-				}},
+				},
 			},
 			want: map[string]bool{},
 		},
@@ -485,11 +488,12 @@ func TestMatchInstrumentationImports(t *testing.T) {
 					Version:    "v1.2.3",
 				},
 			},
-			rules: map[string][]yamlRule{
-				"example.com/instrumentation/foo": {{
+			manifest: manifest.Manifest{
+				{
+					ModulePath:   "example.com/instrumentation/foo",
 					Target:       "example.com/foo",
 					VersionRange: "v1.2.4",
-				}},
+				},
 			},
 			want: map[string]bool{},
 		},
@@ -501,11 +505,12 @@ func TestMatchInstrumentationImports(t *testing.T) {
 					Version:    "", // replace/local path: findModVersion returns empty
 				},
 			},
-			rules: map[string][]yamlRule{
-				"example.com/instrumentation/foo": {{
+			manifest: manifest.Manifest{
+				{
+					ModulePath:   "example.com/instrumentation/foo",
 					Target:       "example.com/foo",
 					VersionRange: "v1.0.0",
-				}},
+				},
 			},
 			want: map[string]bool{},
 		},
@@ -517,11 +522,12 @@ func TestMatchInstrumentationImports(t *testing.T) {
 					Version:    "",
 				},
 			},
-			rules: map[string][]yamlRule{
-				"example.com/instrumentation/foo": {{
+			manifest: manifest.Manifest{
+				{
+					ModulePath:   "example.com/instrumentation/foo",
 					Target:       "example.com/foo",
 					VersionRange: "",
-				}},
+				},
 			},
 			want: map[string]bool{
 				"example.com/instrumentation/foo": true,
@@ -535,11 +541,12 @@ func TestMatchInstrumentationImports(t *testing.T) {
 					Version:    "v1.2.3",
 				},
 			},
-			rules: map[string][]yamlRule{
-				"example.com/instrumentation/foo": {{
+			manifest: manifest.Manifest{
+				{
+					ModulePath:   "example.com/instrumentation/foo",
 					Target:       "example.com/*",
 					VersionRange: "v1.2.3",
-				}},
+				},
 			},
 			want: map[string]bool{
 				"example.com/instrumentation/foo": true,
@@ -553,11 +560,12 @@ func TestMatchInstrumentationImports(t *testing.T) {
 					Version:    "v1.2.3",
 				},
 			},
-			rules: map[string][]yamlRule{
-				"example.com/instrumentation/foo": {{
+			manifest: manifest.Manifest{
+				{
+					ModulePath:   "example.com/instrumentation/foo",
 					Target:       "example.com/*",
 					VersionRange: "v1.2.3",
-				}},
+				},
 			},
 			want: map[string]bool{},
 		},
@@ -568,10 +576,11 @@ func TestMatchInstrumentationImports(t *testing.T) {
 					ImportPath: "example.com/foo",
 				},
 			},
-			rules: map[string][]yamlRule{
-				"example.com/instrumentation/foo": {{
-					Target: rule.TargetRoot,
-				}},
+			manifest: manifest.Manifest{
+				{
+					ModulePath: "example.com/instrumentation/foo",
+					Target:     rule.TargetRoot,
+				},
 			},
 			want: map[string]bool{
 				"example.com/instrumentation/foo": true,
@@ -589,15 +598,17 @@ func TestMatchInstrumentationImports(t *testing.T) {
 					Version:    "v2.0.0",
 				},
 			},
-			rules: map[string][]yamlRule{
-				"example.com/instrumentation/foo": {{
+			manifest: manifest.Manifest{
+				{
+					ModulePath:   "example.com/instrumentation/foo",
 					Target:       "example.com/foo",
 					VersionRange: "v1.0.0",
-				}},
-				"example.com/instrumentation/bar": {{
+				},
+				{
+					ModulePath:   "example.com/instrumentation/bar",
 					Target:       "example.com/bar",
 					VersionRange: "v2.0.0",
-				}},
+				},
 			},
 			want: map[string]bool{
 				"example.com/instrumentation/foo": true,
@@ -606,7 +617,7 @@ func TestMatchInstrumentationImports(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got := matchInstrumentationImports(tt.deps, tt.rules, nil)
+			got := matchInstrumentationImports(tt.deps, tt.manifest, nil)
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -618,16 +629,17 @@ func TestMatchInstrumentationImports_WarnsOnUnresolvedVersion(t *testing.T) {
 			ImportPath: "example.com/foo",
 			Version:    "",
 		}}
-		rules := map[string][]yamlRule{
-			"example.com/instrumentation/foo": {{
+		manifestEntries := manifest.Manifest{
+			{
+				ModulePath:   "example.com/instrumentation/foo",
 				Target:       "example.com/foo",
 				VersionRange: "v1.0.0",
-			}},
+			},
 		}
 
 		var warned bool
 		var warnedMsg string
-		got := matchInstrumentationImports(deps, rules, func(msg string, args ...any) {
+		got := matchInstrumentationImports(deps, manifestEntries, func(msg string, args ...any) {
 			warned = true
 			warnedMsg = msg
 			_ = args
@@ -646,15 +658,13 @@ func TestMatchInstrumentationImports_WarnsOnUnresolvedVersion(t *testing.T) {
 			{ImportPath: "example.com/foo/v1", Version: ""},
 			{ImportPath: "example.com/foo/v1/sub", Version: "v1.0.0"},
 		}
-		rules := map[string][]yamlRule{
-			"example.com/instrumentation/foo": {
-				{Target: "example.com/foo/v1", VersionRange: "v1.0.0"},
-				{Target: "example.com/foo/v1/sub", VersionRange: ""},
-			},
+		manifestEntries := manifest.Manifest{
+			{ModulePath: "example.com/instrumentation/foo", Target: "example.com/foo/v1", VersionRange: "v1.0.0"},
+			{ModulePath: "example.com/instrumentation/foo", Target: "example.com/foo/v1/sub", VersionRange: ""},
 		}
 
 		var warned bool
-		got := matchInstrumentationImports(deps, rules, func(msg string, args ...any) {
+		got := matchInstrumentationImports(deps, manifestEntries, func(msg string, args ...any) {
 			warned = true
 			_ = msg
 			_ = args
@@ -669,15 +679,13 @@ func TestMatchInstrumentationImports_WarnsOnUnresolvedVersion(t *testing.T) {
 			ImportPath: "example.com/foo",
 			Version:    "",
 		}}
-		rules := map[string][]yamlRule{
-			"example.com/instrumentation/foo": {
-				{Target: "example.com/foo", VersionRange: "v1.0.0"},
-				{Target: "example.com/foo", VersionRange: "v2.0.0"},
-			},
+		manifestEntries := manifest.Manifest{
+			{ModulePath: "example.com/instrumentation/foo", Target: "example.com/foo", VersionRange: "v1.0.0"},
+			{ModulePath: "example.com/instrumentation/foo", Target: "example.com/foo", VersionRange: "v2.0.0"},
 		}
 
 		warnCount := 0
-		got := matchInstrumentationImports(deps, rules, func(msg string, args ...any) {
+		got := matchInstrumentationImports(deps, manifestEntries, func(msg string, args ...any) {
 			warnCount++
 			_ = msg
 			_ = args
@@ -686,71 +694,6 @@ func TestMatchInstrumentationImports_WarnsOnUnresolvedVersion(t *testing.T) {
 		require.Empty(t, got)
 		require.Equal(t, 1, warnCount)
 	})
-}
-
-func TestLoadMinimalRules_HappyPath(t *testing.T) {
-	// root directory
-	dir := t.TempDir()
-
-	// Create sub1 submodule
-	sub1 := filepath.Join(dir, "sub1")
-	require.NoError(t, os.Mkdir(sub1, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(sub1, "go.mod"), []byte("module example.com/sub1\n"), 0o644))
-
-	ruleContent := `
-rule1:
-  target: example.com/target
-  version: v1.0.0
-`
-	require.NoError(t, os.WriteFile(filepath.Join(sub1, "otelc.yaml"), []byte(ruleContent), 0o644))
-
-	// Create nested submodule within sub1, which should be iterated separately
-	nested := filepath.Join(sub1, "nested")
-	require.NoError(t, os.Mkdir(nested, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(nested, "go.mod"), []byte("module example.com/sub1/nested\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(nested, "otelc.yaml"), []byte(`
-ruleNested:
-  target: example.com/nested-target
-  version: v1.0.0
-`), 0o644))
-
-	rules, err := loadMinimalRules(dir)
-	require.NoError(t, err)
-
-	// make sure only 2 rules are loaded (sub1 and nested, sub1 doesn't load nested rules)
-	require.Len(t, rules, 2)
-	require.Contains(t, rules, "example.com/sub1")
-	require.Contains(t, rules, "example.com/sub1/nested")
-
-	require.Len(t, rules["example.com/sub1"], 1)
-	require.Equal(t, "example.com/target", rules["example.com/sub1"][0].Target)
-	require.Equal(t, "v1.0.0", rules["example.com/sub1"][0].VersionRange)
-
-	require.Len(t, rules["example.com/sub1/nested"], 1)
-	require.Equal(t, "example.com/nested-target", rules["example.com/sub1/nested"][0].Target)
-}
-
-func TestLoadMinimalRules_InvalidGoMod(t *testing.T) {
-	dir := t.TempDir()
-
-	sub1 := filepath.Join(dir, "sub1")
-	require.NoError(t, os.Mkdir(sub1, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(sub1, "go.mod"), []byte("invalid"), 0o644))
-
-	_, err := loadMinimalRules(dir)
-	require.Error(t, err)
-}
-
-func TestLoadMinimalRules_InvalidRuleYAML(t *testing.T) {
-	dir := t.TempDir()
-
-	sub1 := filepath.Join(dir, "sub1")
-	require.NoError(t, os.Mkdir(sub1, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(sub1, "go.mod"), []byte("module example.com/sub1\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(sub1, "otelc.yaml"), []byte("invalid: yaml: {"), 0o644))
-
-	_, err := loadMinimalRules(dir)
-	require.Error(t, err)
 }
 
 func TestUpdateToolFile(t *testing.T) {


### PR DESCRIPTION
## Description

Refactors `generatePinnedProjects` in `tool/internal/setup/pin.go` to consume `manifest.Load()` from `tool/internal/manifest` instead of decompressing `otelc-bundle.tgz` and walking directories to parse YAML rules.

- Removes redundant `yamlRule`, `loadModuleRules`, and `loadMinimalRules` functions.
- Updates `matchInstrumentationImports` to operate directly on `manifest.Manifest`.
- Defers bundle extraction to only run when matching instrumentation packages exist (`len(imports) > 0`).

Closes #1060

## Type of Change

- [x] Refactoring / Code cleanup
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist

- [x] Follows conventional commit format for PR title (`refactor(tool/internal/setup): ...`)
- [x] Tests added / updated and passing (`go test -race ./...`)
- [x] Code adheres to the repository's coding style
