### PR TITLE
fix(ci): trigger Makefile checks on workflow changes

### DIFF
--- a/.github/workflows/check-makefile.yaml
+++ b/.github/workflows/check-makefile.yaml
@@ -7,12 +7,12 @@ on:
     paths:
       - "**/*Makefile*"
       - ".tools/checkmake"
-      - ".github/workflows/checkmake.yaml"
+      - ".github/workflows/check-makefile.yaml"
   pull_request:
     paths:
       - "**/*Makefile*"
       - ".tools/checkmake"
-      - ".github/workflows/checkmake.yaml"
+      - ".github/workflows/check-makefile.yaml"
 
 jobs:
   checkmake:


### PR DESCRIPTION
## Description

Correct both `Check Makefiles` path filters to watch the workflow's actual filename.

The filters currently reference `.github/workflows/checkmake.yaml`, which does not exist. They now reference `.github/workflows/check-makefile.yaml`.

## Motivation

A pull request that changes only the `Check Makefiles` workflow should schedule that workflow. The stale paths prevent GitHub from doing so.

Fixes #1062



