### PR TITLE
refactor(tool): name the GOWORK off sentinel

### DIFF
--- a/tool/internal/setup/state.go
+++ b/tool/internal/setup/state.go
@@ -23,6 +23,7 @@ import (
 const (
 	stateDir      = "state"
 	stateFileName = "state.json"
+	goWorkOff     = "off"
 )
 
 // StateManager tracks the original state of files so they can later be restored.
@@ -129,7 +130,7 @@ func getBackupFiles(ctx context.Context, moduleDirs map[string]bool) ([]string, 
 		return nil, ex.Wrapf(err, "failed to get GOWORK environment variable")
 	}
 	goWorkPath := strings.TrimSpace(string(goWorkOutput))
-	if goWorkPath != "" && goWorkPath != "off" {
+	if goWorkPath != "" && goWorkPath != goWorkOff {
 		goWorkSumPath := filepath.Join(filepath.Dir(goWorkPath), "go.work.sum")
 		files = append(files, goWorkSumPath)
 	}


### PR DESCRIPTION
## Description

Define `goWorkOff` for Go's `GOWORK=off` sentinel and use it in `getBackupFiles`.

The behavioral fix and regression test originally included in this PR were merged in #1117. This PR now retains only the small constant improvement requested in review.

## Motivation

Using a named constant documents that `"off"` is a special value returned by `go env GOWORK`, rather than an ordinary workspace path.

Related to #1065.
Follow-up to #1117.