### PR TITLE
fix(tool/setup): ignore GOWORK=off sentinel when getting backup files

### DIFF
--- a/tool/internal/setup/state.go
+++ b/tool/internal/setup/state.go
@@ -129,7 +129,7 @@ func getBackupFiles(ctx context.Context, moduleDirs map[string]bool) ([]string, 
 		return nil, ex.Wrapf(err, "failed to get GOWORK environment variable")
 	}
 	goWorkPath := strings.TrimSpace(string(goWorkOutput))
-	if goWorkPath != "" {
+	if goWorkPath != "" && goWorkPath != "off" {
 		goWorkSumPath := filepath.Join(filepath.Dir(goWorkPath), "go.work.sum")
 		files = append(files, goWorkSumPath)
 	}

--- a/tool/internal/setup/state.go
+++ b/tool/internal/setup/state.go
@@ -23,6 +23,7 @@ import (
 const (
 	stateDir      = "state"
 	stateFileName = "state.json"
+	goWorkOff     = "off"
 )
 
 // StateManager tracks the original state of files so they can later be restored.
@@ -129,7 +130,7 @@ func getBackupFiles(ctx context.Context, moduleDirs map[string]bool) ([]string, 
 		return nil, ex.Wrapf(err, "failed to get GOWORK environment variable")
 	}
 	goWorkPath := strings.TrimSpace(string(goWorkOutput))
-	if goWorkPath != "" && goWorkPath != "off" {
+	if goWorkPath != "" && goWorkPath != goWorkOff {
 		goWorkSumPath := filepath.Join(filepath.Dir(goWorkPath), "go.work.sum")
 		files = append(files, goWorkSumPath)
 	}

--- a/tool/internal/setup/state_test.go
+++ b/tool/internal/setup/state_test.go
@@ -169,6 +169,23 @@ func TestGetBackupFiles(t *testing.T) {
 			},
 		},
 		{
+			name: "GOWORK=off disabled workspace",
+			setup: func(t *testing.T, tmp string) string {
+				t.Setenv("GOWORK", "off")
+				moduleDir := filepath.Join(tmp, "mod")
+				mustWriteFile(t, filepath.Join(moduleDir, "go.mod"), "module example.com")
+				mustWriteFile(t, filepath.Join(tmp, "go.work.sum"), "worksum")
+				return moduleDir
+			},
+			wantFiles: func(_, moduleDir string) []string {
+				return []string{
+					filepath.Join(moduleDir, "go.mod"),
+					filepath.Join(moduleDir, "go.sum"),
+					filepath.Join(moduleDir, ToolFileCanonical),
+				}
+			},
+		},
+		{
 			name: "missing go.mod",
 			setup: func(t *testing.T, tmp string) string {
 				return filepath.Join(tmp, "mod")

--- a/tool/internal/setup/state_test.go
+++ b/tool/internal/setup/state_test.go
@@ -169,12 +169,13 @@ func TestGetBackupFiles(t *testing.T) {
 			},
 		},
 		{
-			name: "GOWORK=off disabled workspace",
+			name: "workspace explicitly disabled",
 			setup: func(t *testing.T, tmp string) string {
-				t.Setenv("GOWORK", "off")
 				moduleDir := filepath.Join(tmp, "mod")
 				mustWriteFile(t, filepath.Join(moduleDir, "go.mod"), "module example.com")
+				mustWriteFile(t, filepath.Join(tmp, "go.work"), "go 1.25.0\n")
 				mustWriteFile(t, filepath.Join(tmp, "go.work.sum"), "worksum")
+				t.Setenv("GOWORK", goWorkOff)
 				return moduleDir
 			},
 			wantFiles: func(_, moduleDir string) []string {


### PR DESCRIPTION
Fixes #1065

### Summary of changes
When `GOWORK=off` is set, `go env GOWORK` returns the string `"off"`. `getBackupFiles` was treating `"off"` as a workspace path, causing `filepath.Dir("off")` to evaluate to `"."` and adding `./go.work.sum` to tracked backup files.

This change ignores the `"off"` sentinel value so `go.work.sum` is not tracked when workspace mode is disabled.

### Testing
Added unit test case `GOWORK=off disabled workspace` in `TestGetBackupFiles`.
