### PR TITLE
fix(ci): run Makefile checks on tool dependency changes

### DIFF
--- a/.github/workflows/check-makefile.yaml
+++ b/.github/workflows/check-makefile.yaml
@@ -7,11 +7,15 @@ on:
     paths:
       - "**/*Makefile*"
       - ".tools/checkmake"
+      - ".tools/go.mod"
+      - ".tools/go.sum"
       - ".github/workflows/check-makefile.yaml"
   pull_request:
     paths:
       - "**/*Makefile*"
       - ".tools/checkmake"
+      - ".tools/go.mod"
+      - ".tools/go.sum"
       - ".github/workflows/check-makefile.yaml"
 
 jobs:


### PR DESCRIPTION
## Description

Run the `Check Makefiles` workflow when `.tools/go.mod` or `.tools/go.sum` changes.

The workflow builds Checkmake from the `.tools` module, so changes to that module can alter the linter without currently triggering the check.

## Verification

- `make lint/action`
- `make lint/makefile`
- `git diff --check`

Related to #1063.
