### PR TITLE
fix(tool/internal/instrument): strip build-ignore tag per line, not by substring

### DIFF
--- a/tool/internal/instrument/apply_file.go
+++ b/tool/internal/instrument/apply_file.go
@@ -6,6 +6,7 @@ package instrument
 import (
 	"context"
 	"fmt"
+	"go/build/constraint"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,8 +17,19 @@ import (
 	"go.opentelemetry.io/otelc/tool/util"
 )
 
+// stripBuildIgnoreTag removes genuine "//go:build ignore" constraint lines
+// from content, line by line. It leaves every other occurrence of that text —
+// inside a string literal, inside comment prose, anywhere that isn't itself a
+// build-constraint line — untouched. See #1069: a whole-file substring
+// replace corrupted both of those.
 func stripBuildIgnoreTag(content string) string {
-	return strings.ReplaceAll(content, "//go:build ignore", "")
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if constraint.IsGoBuild(line) {
+			lines[i] = ""
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // applyFileRule introduces the new file to the target package at compile time.

--- a/tool/internal/instrument/apply_file_test.go
+++ b/tool/internal/instrument/apply_file_test.go
@@ -66,6 +66,27 @@ func main() {}
 			input:    "",
 			expected: "",
 		},
+		{
+			// Regression test for #1069: a whole-file substring replace
+			// deleted this text from the string literal and the comment,
+			// since both happen to contain "//go:build ignore" without being
+			// a build-constraint line themselves.
+			name: "preserves the tag text inside a string literal and comment prose",
+			input: `//go:build ignore
+
+package hooks
+
+// Every file rule source must carry //go:build ignore at the top.
+const marker = "//go:build ignore"
+`,
+			expected: `
+
+package hooks
+
+// Every file rule source must carry //go:build ignore at the top.
+const marker = "//go:build ignore"
+`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

`stripBuildIgnoreTag` strips the `//go:build ignore` constraint from a file rule's source
before it gets spliced into the target package, using a whole-file substring replace:

```go
func stripBuildIgnoreTag(content string) string {
	return strings.ReplaceAll(content, "//go:build ignore", "")
}
```

`strings.ReplaceAll` has no notion of Go syntax, so it deletes that text from anywhere in
the file — a string literal, a doc comment describing the convention, anywhere the text
happens to appear — not just the leading build-constraint line. The corruption is silent:
the result still parses as valid Go, so nothing fails to compile.

The fix uses the standard library's `go/build/constraint.IsGoBuild`, applied per line
instead of as a whole-file substring match:

```go
func stripBuildIgnoreTag(content string) string {
	lines := strings.Split(content, "\n")
	for i, line := range lines {
		if constraint.IsGoBuild(line) {
			lines[i] = ""
		}
	}
	return strings.Join(lines, "\n")
}
```

A line only gets blanked if it *is* a build-constraint line (matching the same syntax the
Go toolchain itself recognizes), not merely if it contains that text somewhere within a
larger line.

### Known limitation — not fixed, flagging for visibility

This checks every line in the file, not just the leading comment block before `package`
that real Go build-constraint semantics restrict `//go:build` to. So a standalone line that
trims to exactly `//go:build ignore` — with nothing else on that physical line — occurring
later in the file (e.g. as one line inside a multi-line raw string literal) would still be
incorrectly blanked, since this is a textual line scan, not an AST-aware one that tracks
whether a line falls inside a string or comment token.

I considered restricting the scan to the leading block, which is what I originally proposed
in #1069 and what would close this gap entirely. I didn't do that here because it changes
existing, unrelated test behavior: `TestStripBuildIgnoreTag`'s `multiple go:build ignore
comments` case has a second `//go:build ignore` line positioned *after* `package main`, and
restricting to the leading block would stop that second occurrence from being stripped —
a real behavior change beyond what this issue reported, not something I wanted to decide
unilaterally. Happy to make that change too if you'd rather have it closed now.

### Tests

Added a case to the existing `TestStripBuildIgnoreTag` table: a source with the tag text
inside both a comment and a string literal, asserting both survive. I verified the test
actually catches the regression it's meant to catch — reverting the fix to the old
`strings.ReplaceAll` implementation makes it fail with the exact corruption described in
the issue (`marker` becomes `""`, the comment gets a hole in it). All four pre-existing
cases pass unchanged, byte-for-byte, including the mid-file second occurrence in
`multiple go:build ignore comments`.

## Motivation

Fixes #1069

## Verification

`make format` and `go test -shuffle=on -timeout=15m -count=1 ./tool/...` pass locally. The
integration and e2e halves of `make test` were verified through this PR's CI jobs rather
than locally, since the testcontainers-based suites had no usable Docker host here.

`make lint` was checked with golangci-lint **v2.11.3**, the version
`.github/workflows/lint-golang.yaml` pins — 0 issues. As noted on prior PRs in this
series: `.tools/go.mod` pins a newer local linter version, and pristine `main` already
reports pre-existing findings under it in files this PR does not touch.

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).

