### PR TITLE
test(instrument): cover trampoline jump point discovery

### DIFF
--- a/tool/internal/instrument/apply_func_test.go
+++ b/tool/internal/instrument/apply_func_test.go
@@ -301,3 +301,94 @@ func requireTypeChecks(t *testing.T, src string) {
 	_, err = conf.Check("main", fset, []*goast.File{parsed}, nil)
 	require.NoErrorf(t, err, "generated code does not type-check:\n%s", src)
 }
+
+// newTrampolineJump builds an if statement shaped like the one buildTJump
+// produces: a labelled if whose else block holds the deferred after-call. The
+// label is what findJumpPoint keys on, so a jump without it is just an
+// ordinary if as far as this function is concerned.
+func newTrampolineJump(labelled bool) *dst.IfStmt {
+	// Mirrors buildTJump: the init defines the hook context and skip flag from
+	// the before-call, and the else block defers the after-call.
+	init := ast.DefineStmts(
+		ast.Exprs(ast.Ident("hookCtx"), ast.Ident("skip")),
+		ast.Exprs(ast.CallTo("beforeCall", nil, nil)),
+	)
+	elseBlock := ast.Block(ast.DeferStmt(ast.CallTo("afterCall", nil, nil)))
+
+	jump := ast.IfStmt(init, ast.Ident("skip"), ast.Block(ast.EmptyStmt()), elseBlock)
+	if labelled {
+		jump.Decs.If.Append(tJumpLabel)
+	}
+	return jump
+}
+
+// chainJump nests inner inside outer's else block the way insertToFunc does,
+// separating the existing statement from the new jump with an empty statement.
+// That leaves the else block with more than one statement, which is the
+// condition findJumpPoint recurses on.
+func chainJump(t *testing.T, outer, inner *dst.IfStmt) {
+	t.Helper()
+
+	elseBlock, ok := outer.Else.(*dst.BlockStmt)
+	require.True(t, ok, "a trampoline jump should always carry a block else")
+	elseBlock.List = append(elseBlock.List, ast.EmptyStmt(), inner)
+}
+
+func TestFindJumpPointIgnoresUnlabelledIf(t *testing.T) {
+	// Without the trampoline label this is an ordinary if statement that
+	// happened to be first in the function body. Returning a block here would
+	// splice a trampoline into unrelated user code.
+	jump := newTrampolineJump(false)
+
+	assert.Nil(t, findJumpPoint(jump))
+}
+
+func TestFindJumpPointReturnsElseBlockOfLoneJump(t *testing.T) {
+	jump := newTrampolineJump(true)
+
+	point := findJumpPoint(jump)
+
+	require.NotNil(t, point)
+	assert.Equal(t, jump.Else, point, "the only jump present is the insertion point")
+}
+
+func TestFindJumpPointDescendsToLastJumpInChain(t *testing.T) {
+	// Two rules already applied to the same function, so the second jump lives
+	// inside the first one's else block. A third has to land inside the second,
+	// not the first, or the rules stop nesting in the order they were applied.
+	first := newTrampolineJump(true)
+	second := newTrampolineJump(true)
+	chainJump(t, first, second)
+
+	point := findJumpPoint(first)
+
+	require.NotNil(t, point)
+	assert.Equal(t, second.Else, point, "insertion belongs in the innermost jump")
+	assert.NotEqual(t, first.Else, point)
+}
+
+func TestFindJumpPointDescendsThroughSeveralJumps(t *testing.T) {
+	// The descent is recursive, so a longer chain must still reach the end
+	// rather than stopping one level in.
+	first := newTrampolineJump(true)
+	second := newTrampolineJump(true)
+	third := newTrampolineJump(true)
+	chainJump(t, first, second)
+	chainJump(t, second, third)
+
+	point := findJumpPoint(first)
+
+	require.NotNil(t, point)
+	assert.Equal(t, third.Else, point, "insertion belongs at the end of the chain")
+}
+
+func TestFindJumpPointStopsAtUnlabelledTail(t *testing.T) {
+	// A chain whose last statement is not a labelled jump has no further
+	// insertion point beneath it, so the descent reports nothing rather than
+	// guessing at a block.
+	first := newTrampolineJump(true)
+	tail := newTrampolineJump(false)
+	chainJump(t, first, tail)
+
+	assert.Nil(t, findJumpPoint(first))
+}


### PR DESCRIPTION
## Description

Adds tests for `findJumpPoint`, which decides where a new trampoline jump gets spliced when several func rules apply to the same function. It had no tests and sat at 57.1%, with both interesting branches unreached: the recursive descent into an existing chain, and the nil return for an `if` that is not a trampoline jump.

Five cases:

- an unlabelled `if` yields no insertion point
- a lone jump yields its own else block
- a two-jump chain yields the inner block, not the outer one
- a three-jump chain descends the whole way rather than stopping one level in
- a chain whose tail is unlabelled yields nothing rather than guessing

`findJumpPoint` goes from 57.1% to 100%, and the package from 92.7% to 93.0%.

## Motivation

The nil case matters more than the percentage suggests. `insertToFunc` hands `findJumpPoint` the first statement of a function body, which is frequently an ordinary `if` belonging to the author. Returning a block there would splice a trampoline into unrelated user code, so the label check is load-bearing rather than an optimisation, and nothing was pinning it.

The fixtures are built the way `buildTJump` and `insertToFunc` build them, so the recursion is exercised the way it happens during a real build rather than through a structure invented for the test.

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable)
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
