### PR TITLE
fix(tool/internal/setup): guard against GOWORK="off" in getBackupFiles

### DIFF
--- a/tool/internal/setup/state.go
+++ b/tool/internal/setup/state.go
@@ -129,7 +129,7 @@ func getBackupFiles(ctx context.Context, moduleDirs map[string]bool) ([]string, 
 		return nil, ex.Wrapf(err, "failed to get GOWORK environment variable")
 	}
 	goWorkPath := strings.TrimSpace(string(goWorkOutput))
-	if goWorkPath != "" {
+	if goWorkPath != "" && goWorkPath != "off" {
 		goWorkSumPath := filepath.Join(filepath.Dir(goWorkPath), "go.work.sum")
 		files = append(files, goWorkSumPath)
 	}

--- a/tool/internal/setup/state_test.go
+++ b/tool/internal/setup/state_test.go
@@ -193,6 +193,22 @@ func TestGetBackupFiles(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "GOWORK=off does not track go.work.sum",
+			setup: func(t *testing.T, tmp string) string {
+				t.Setenv("GOWORK", "off")
+				moduleDir := filepath.Join(tmp, "mod")
+				mustWriteFile(t, filepath.Join(moduleDir, "go.mod"), "module example.com")
+				return moduleDir
+			},
+			wantFiles: func(_, moduleDir string) []string {
+				return []string{
+					filepath.Join(moduleDir, "go.mod"),
+					filepath.Join(moduleDir, "go.sum"),
+					filepath.Join(moduleDir, ToolFileCanonical),
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

When `GOWORK=off` is set, `go env GOWORK` outputs `"off"`. Previously, `getBackupFiles` only checked `goWorkPath != ""`, treating `"off"` as a relative path and erroneously appending `go.work.sum` to the backup file list.

This PR adds an explicit guard `if goWorkPath != "" && goWorkPath != "off"` in `getBackupFiles` to prevent tracking `go.work.sum` when workspaces are disabled, and adds unit test coverage in `state_test.go`.

## Motivation

Prevents invalid `go.work.sum` path tracking when Go workspaces are disabled via `GOWORK=off`.

Fixes #1113

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [x] Documentation updated (if applicable)
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
