### PR TITLE
fix(ast): handle qualified pointer receivers in stripGenericTypes

### DIFF
--- a/tool/internal/ast/shared.go
+++ b/tool/internal/ast/shared.go
@@ -55,19 +55,32 @@ func stripGenericTypes(recvTypeExpr dst.Expr) string {
 		case *dst.Ident:
 			// Non-generic pointer receiver: *MyStruct
 			return "*" + x.Name
+		case *dst.SelectorExpr:
+			// Qualified pointer receiver: *bufio.Writer
+			return "*" + x.Sel.Name
 		case *dst.IndexExpr:
 			// Generic pointer receiver with single type param: *GenStruct[T]
+			// or *pkg.GenStruct[T]
 			if baseIdent, ok := x.X.(*dst.Ident); ok {
 				return "*" + baseIdent.Name
+			}
+			if sel, ok := x.X.(*dst.SelectorExpr); ok {
+				return "*" + sel.Sel.Name
 			}
 		case *dst.IndexListExpr:
 			// Generic pointer receiver with multiple type params: *GenStruct[T, U]
 			if baseIdent, ok := x.X.(*dst.Ident); ok {
 				return "*" + baseIdent.Name
 			}
+			if sel, ok := x.X.(*dst.SelectorExpr); ok {
+				return "*" + sel.Sel.Name
+			}
 		}
 	case *dst.Ident: // func (Recv)T
 		return expr.Name
+	case *dst.SelectorExpr:
+		// Qualified value receiver: bufio.Writer
+		return expr.Sel.Name
 	case *dst.IndexExpr:
 		// Generic value receiver with single type param: GenStruct[T]
 		if baseIdent, ok := expr.X.(*dst.Ident); ok {

--- a/tool/internal/ast/shared_helpers_test.go
+++ b/tool/internal/ast/shared_helpers_test.go
@@ -109,8 +109,18 @@ func TestStripGenericTypes(t *testing.T) {
 			want: "*GenStruct",
 		},
 		{
-			name: "unrecognized expression yields empty",
+			name: "qualified value receiver",
 			expr: &dst.SelectorExpr{X: Ident("pkg"), Sel: Ident("Type")},
+			want: "Type",
+		},
+		{
+			name: "qualified pointer receiver",
+			expr: &dst.StarExpr{X: &dst.SelectorExpr{X: Ident("bufio"), Sel: Ident("Writer")}},
+			want: "*Writer",
+		},
+		{
+			name: "unrecognized expression yields empty",
+			expr: &dst.BasicLit{Value: "1"},
 			want: "",
 		},
 	}

--- a/tool/internal/ast/shared_test.go
+++ b/tool/internal/ast/shared_test.go
@@ -231,6 +231,29 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {}
 	assert.Equal(t, "handleRoot", fn.Name.Name)
 }
 
+func TestFindFuncDeclQualifiedPointerReceiver(t *testing.T) {
+	// *pkg.Type used to fatal in stripGenericTypes ("unexpected receiver type:
+	// *dst.StarExpr") instead of matching recv: "*Writer".
+	p := NewAstParser()
+	file, err := p.ParseSource(`package main
+
+import "bufio"
+
+func (*bufio.Writer) Write(p []byte) (n int, err error) { return 0, nil }
+`)
+	require.NoError(t, err)
+
+	r := &rule.InstFuncRule{
+		Func: "Write",
+		Recv: "*Writer",
+	}
+	fn, ok, err := FindFuncDecl(file, r)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, fn)
+	assert.Equal(t, "Write", fn.Name.Name)
+}
+
 func TestFindVarDecl(t *testing.T) {
 	file := parseSharedFixture(t)
 


### PR DESCRIPTION
## Summary
\`stripGenericTypes\` fatals on qualified pointer receivers (\`func (*bufio.Writer) Write\`) with \`unexpected receiver type: *dst.StarExpr\`. Rules with \`recv: \"*Writer\"\` could not match.

## Changes
- Handle \`*dst.SelectorExpr\` (value and pointer) and qualified generic index forms
- Tests: table cases + parse-source \`(*bufio.Writer).Write\` lookup

## Test plan
- [x] \`go test ./tool/internal/ast/\`

Fixes #766

Note: I will sign the OTel CLA if CI requests it.