### PR TITLE
chore(test): add multi-process e2e for HTTP→OpenAI GenAI client propagation (#1107)

### DIFF
--- a/test/apps/httpserveropenaiclient/go.mod
+++ b/test/apps/httpserveropenaiclient/go.mod
@@ -1,0 +1,12 @@
+module go.opentelemetry.io/otelc/test/apps/httpserveropenaiclient
+
+go 1.25.0
+
+require github.com/openai/openai-go v1.12.0
+
+require (
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
+)

--- a/test/apps/httpserveropenaiclient/go.sum
+++ b/test/apps/httpserveropenaiclient/go.sum
@@ -1,0 +1,12 @@
+github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
+github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=

--- a/test/apps/httpserveropenaiclient/main.go
+++ b/test/apps/httpserveropenaiclient/main.go
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main is a complex demo app combining HTTP server and OpenAI client for e2e testing.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+)
+
+var (
+	frontPort = flag.Int("front-port", 8080, "port for HTTP frontend")
+	addr      = flag.String("addr", "http://localhost:8080/v1", "The OpenAI API base URL")
+	apiKey    = flag.String("api-key", "test-key", "The API key")
+	model     = flag.String("model", "gpt-4", "The model to use")
+)
+
+func main() {
+	flag.Parse()
+
+	client := openai.NewClient(
+		option.WithBaseURL(*addr),
+		option.WithAPIKey(*apiKey),
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		completion, err := client.Chat.Completions.New(r.Context(), openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				openai.UserMessage("Say hello in one word"),
+			},
+			Model: openai.ChatModel(*model),
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(completion.Choices[0].Message.Content))
+	})
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", *frontPort),
+		Handler: mux,
+	}
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("frontend server failed: %v", err)
+		}
+	}()
+
+	// Wait for shutdown signal
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	<-ctx.Done()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		log.Fatalf("server shutdown failed: %v", err)
+	}
+}

--- a/test/e2e/httpserver_openaiclient_test.go
+++ b/test/e2e/httpserver_openaiclient_test.go
@@ -1,0 +1,115 @@
+//go:build e2e
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+
+	"go.opentelemetry.io/otelc/test/testutil"
+)
+
+func TestHTTPServerOpenAIClient(t *testing.T) {
+	server := startMockOpenAIServer(t)
+
+	f := testutil.NewTestFixture(t)
+
+	frontPort := testutil.FreePort(t)
+	addr := fmt.Sprintf("http://127.0.0.1:%d", frontPort)
+
+	f.BuildAndStart(
+		"httpserveropenaiclient",
+		fmt.Sprintf("-front-port=%d", frontPort),
+		fmt.Sprintf("-addr=%s/v1", server.URL),
+	)
+	testutil.WaitForTCP(t, fmt.Sprintf("127.0.0.1:%d", frontPort))
+
+	f.BuildAndRun("httpclient", "-addr", addr, "-name", "test")
+
+	// BuildAndRun returns once the client exits, but the server span ends after
+	// the response is written, so it may still be in flight. Wait for all three.
+	f.WaitForSpans(3)
+
+	// One distributed trace with three spans:
+	// HTTP client -> HTTP server -> OpenAI client
+	f.RequireTraceCount(1)
+	f.RequireSpansPerTrace(3)
+
+	httpClientSpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsClient,
+		testutil.HasAttributeContaining(string(semconv.URLFullKey), "/hello"),
+	)
+	httpServerSpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsServer,
+		testutil.HasAttribute(string(semconv.URLPathKey), "/hello"),
+		testutil.HasAttribute(string(semconv.HTTPResponseStatusCodeKey), int64(200)),
+	)
+	genAISpan := testutil.RequireSpan(t, f.Traces(),
+		testutil.IsClient,
+		testutil.HasAttribute("gen_ai.system", "openai"),
+	)
+
+	require.Equal(t, httpClientSpan.TraceID(), httpServerSpan.TraceID(), "HTTP client and server must share a trace ID")
+	require.Equal(
+		t,
+		httpServerSpan.TraceID(),
+		genAISpan.TraceID(),
+		"HTTP server and GenAI client must share a trace ID",
+	)
+	require.Equal(t, httpClientSpan.SpanID(), httpServerSpan.ParentSpanID(), "HTTP server parent must be HTTP client")
+	require.Equal(t, httpServerSpan.SpanID(), genAISpan.ParentSpanID(), "GenAI client parent must be HTTP server")
+	require.True(t, httpClientSpan.ParentSpanID().IsEmpty(), "HTTP client span must be the trace root")
+}
+
+func startMockOpenAIServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		var reqBody struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"id":     "chatcmpl-test-123",
+			"object": "chat.completion",
+			"model":  reqBody.Model,
+			"choices": []map[string]any{
+				{
+					"index": 0,
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": "Hello!",
+					},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]any{
+				"prompt_tokens":     10,
+				"completion_tokens": 20,
+				"total_tokens":      30,
+			},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}


### PR DESCRIPTION
### Description
Adds a multi-process end-to-end (E2E) test verifying trace context propagation across a distributed chain:
HTTP Client (`httpclient`) → HTTP Server with OpenAI Go Client (`httpserveropenaiclient`) → Mock OpenAI Server.

### Related Issue
Closes #1107

### Changes
- Created `test/apps/httpserveropenaiclient` test application using `github.com/openai/openai-go v1.12.0`.
- Added `TestHTTPServerOpenAIClient` in `test/e2e/httpserver_openaiclient_test.go`.

### Testing
- Executed `go -C test test -v -tags=e2e ./e2e -run TestHTTPServerOpenAIClient` (Passed).
