### PR TITLE
fix(tool/instrument): recover generic receiver constraints in trampoline generation

### DIFF
--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -477,10 +477,10 @@ func findTargetResultType(targetFunc *dst.FuncDecl) *dst.FieldList {
 // func (c *Type1[K]) Target[V any]() V
 // ->
 // [K, V]
-func findTargetGenericType(targetFunc *dst.FuncDecl) *dst.FieldList {
+func findTargetGenericType(file *dst.File, targetFunc *dst.FuncDecl) *dst.FieldList {
 	var trampolineTypeParams *dst.FieldList
 	if ast.HasReceiver(targetFunc) {
-		receiverTypeParams := extractReceiverTypeParams(targetFunc.Recv.List[0].Type)
+		receiverTypeParams := extractReceiverTypeParams(file, targetFunc.Recv.List[0].Type)
 		if receiverTypeParams != nil {
 			trampolineTypeParams = receiverTypeParams
 		}
@@ -508,12 +508,12 @@ func (ip *InstrumentPhase) buildTrampSignature(before bool) {
 	if before {
 		beforeTramp := ip.beforeTrampFunc
 		beforeTramp.Type.Params = findTargetParamType(ip.targetFunc)
-		beforeTramp.Type.TypeParams = findTargetGenericType(ip.targetFunc)
+		beforeTramp.Type.TypeParams = findTargetGenericType(ip.target, ip.targetFunc)
 		fields = beforeTramp.Type.Params
 	} else {
 		afterTramp := ip.afterTrampFunc
 		afterTramp.Type.Params = findTargetResultType(ip.targetFunc)
-		afterTramp.Type.TypeParams = findTargetGenericType(ip.targetFunc)
+		afterTramp.Type.TypeParams = findTargetGenericType(ip.target, ip.targetFunc)
 		fields = afterTramp.Type.Params
 	}
 	// All types should be replaced with dereferenced types, so that the trampoline
@@ -543,7 +543,7 @@ func (ip *InstrumentPhase) buildHookSignature(t *rule.InstFuncRule, before bool)
 	addHookContext(paramTypes)
 
 	// Replace type parameters with interface{}
-	genericTypes = findTargetGenericType(ip.targetFunc)
+	genericTypes = findTargetGenericType(ip.target, ip.targetFunc)
 	for _, field := range paramTypes.List {
 		field.Type = replaceTypeParamsWithAny(field.Type, genericTypes)
 	}
@@ -746,29 +746,40 @@ func setReturnValClause(idx int, t dst.Expr) *dst.CaseClause {
 
 // extractReceiverTypeParams extracts type parameters from a receiver type expression
 // For example: *GenStruct[T] or GenStruct[T, U] -> FieldList with T and U as type parameters
-func extractReceiverTypeParams(recvType dst.Expr) *dst.FieldList {
+//
+// file is the source file the receiver was declared in. When it contains the
+// matching generic type declaration (e.g. type GenStruct[T comparable] struct{...}),
+// each parameter's real constraint is recovered from it instead of being widened to
+// any. Constraints are matched positionally against that declaration's own type
+// parameters, since a method receiver is free to use different names for them
+// (type GenStruct[T comparable] struct{} but func (s GenStruct[U]) M(v U) is valid
+// Go; U is still constrained by comparable). If no matching declaration is found in
+// file, the constraint falls back to any, as before.
+func extractReceiverTypeParams(file *dst.File, recvType dst.Expr) *dst.FieldList {
 	switch t := recvType.(type) {
 	case *dst.StarExpr:
 		// *GenStruct[T] - recurse into X
-		return extractReceiverTypeParams(t.X)
+		return extractReceiverTypeParams(file, t.X)
 	case *dst.IndexExpr:
 		// GenStruct[T] - single type parameter
 		if ident, ok := t.Index.(*dst.Ident); ok {
+			original := findGenericTypeDecl(file, receiverBaseTypeName(t.X))
 			return &dst.FieldList{
 				List: []*dst.Field{{
 					Names: []*dst.Ident{ident},
-					Type:  ast.Ident("any"), // Type constraint for the parameter
+					Type:  receiverConstraintAt(original, 0),
 				}},
 			}
 		}
 	case *dst.IndexListExpr:
 		// GenStruct[T, U, ...] - multiple type parameters
+		original := findGenericTypeDecl(file, receiverBaseTypeName(t.X))
 		fields := make([]*dst.Field, 0, len(t.Indices))
-		for _, idx := range t.Indices {
+		for i, idx := range t.Indices {
 			if ident, ok := idx.(*dst.Ident); ok {
 				fields = append(fields, &dst.Field{
 					Names: []*dst.Ident{ident},
-					Type:  ast.Ident("any"), // Type constraint for the parameter
+					Type:  receiverConstraintAt(original, i),
 				})
 			}
 		}
@@ -777,6 +788,63 @@ func extractReceiverTypeParams(recvType dst.Expr) *dst.FieldList {
 		}
 	}
 	return nil
+}
+
+// receiverBaseTypeName returns the local identifier naming a receiver's generic
+// type, e.g. "GenStruct" for the X in GenStruct[T]. Only a plain identifier can be
+// looked up in file's own declarations, so anything else (there is currently no
+// valid Go receiver form that produces anything else) returns "".
+func receiverBaseTypeName(x dst.Expr) string {
+	if ident, ok := x.(*dst.Ident); ok {
+		return ident.Name
+	}
+	return ""
+}
+
+// findGenericTypeDecl searches file's top-level declarations for a generic type
+// declaration named typeName and returns its type parameter list (with each
+// parameter's real constraint, not any), or nil if no such declaration is found in
+// file. The declaration may live in a different file of the same package; that case
+// is not resolved today, so it falls through to the caller's any fallback.
+func findGenericTypeDecl(file *dst.File, typeName string) *dst.FieldList {
+	if file == nil || typeName == "" {
+		return nil
+	}
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*dst.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			typeSpec, isTypeSpec := spec.(*dst.TypeSpec)
+			if isTypeSpec && typeSpec.Name.Name == typeName {
+				return typeSpec.TypeParams
+			}
+		}
+	}
+	return nil
+}
+
+// receiverConstraintAt returns a clone of the constraint type at position idx in
+// original's type parameter list, or the any identifier if original is nil or has
+// no parameter at that position. original's fields are walked positionally, rather
+// than indexed directly, because a single field can carry multiple names sharing one
+// constraint (e.g. [T, U comparable]).
+func receiverConstraintAt(original *dst.FieldList, idx int) dst.Expr {
+	if original != nil {
+		pos := 0
+		for _, field := range original.List {
+			n := len(field.Names)
+			if n == 0 {
+				n = 1
+			}
+			if idx < pos+n {
+				return util.AssertType[dst.Expr](dst.Clone(field.Type))
+			}
+			pos += n
+		}
+	}
+	return ast.Ident("any") // Type constraint for the parameter
 }
 
 // desugarType desugars parameter type to its original type, if parameter
@@ -841,7 +909,7 @@ func (ip *InstrumentPhase) rewriteHookContextMethods() {
 	}
 
 	// For generic functions, we need to panic the methods that are not supported
-	if findTargetGenericType(ip.targetFunc) != nil {
+	if findTargetGenericType(ip.target, ip.targetFunc) != nil {
 		makeMethodPanic(methodGetParam, "GetParam is unsupported for generic functions")
 		makeMethodPanic(methodGetRetVal, "GetReturnVal is unsupported for generic functions")
 		makeMethodPanic(methodSetParam, "SetParam is unsupported for generic functions")

--- a/tool/internal/instrument/trampoline_receiver_test.go
+++ b/tool/internal/instrument/trampoline_receiver_test.go
@@ -12,22 +12,49 @@ import (
 	"go.opentelemetry.io/otelc/tool/internal/ast"
 )
 
-// parseReceiverType returns the receiver type expression of a method declared
-// on the given receiver source, e.g. "*GenStruct[T]".
-func parseReceiverType(t *testing.T, recvSrc string) dst.Expr {
+// parseReceiverType returns the file and the receiver type expression of a
+// method declared on the given receiver source, e.g. "*GenStruct[T]". The
+// synthetic file has no matching type declaration, so constraint recovery
+// attempted against it necessarily falls back to any.
+func parseReceiverType(t *testing.T, recvSrc string) (*dst.File, dst.Expr) {
 	t.Helper()
 
 	src := "package main\nfunc (r " + recvSrc + ") m() {}"
+	return parseReceiverSource(t, src)
+}
+
+// parseReceiverTypeWithDecl returns the file and the receiver type expression
+// of a method declared on recvSrc, where typeDecl is the source of the
+// generic type's own declaration (e.g. "type GenStruct[T comparable] struct{}"),
+// placed ahead of the method in the same file so constraint recovery can find
+// it. imports, if non-empty, is a complete import declaration inserted before
+// typeDecl.
+func parseReceiverTypeWithDecl(t *testing.T, imports, typeDecl, recvSrc string) (*dst.File, dst.Expr) {
+	t.Helper()
+
+	src := "package main\n" + imports + "\n" + typeDecl + "\nfunc (r " + recvSrc + ") m() {}"
+	return parseReceiverSource(t, src)
+}
+
+func parseReceiverSource(t *testing.T, src string) (*dst.File, dst.Expr) {
+	t.Helper()
+
 	parser := ast.NewAstParser()
 	file, err := parser.ParseSource(src)
 	require.NoError(t, err)
 
-	funcDecl, ok := file.Decls[0].(*dst.FuncDecl)
-	require.True(t, ok)
+	var funcDecl *dst.FuncDecl
+	for _, decl := range file.Decls {
+		if fd, ok := decl.(*dst.FuncDecl); ok {
+			funcDecl = fd
+			break
+		}
+	}
+	require.NotNil(t, funcDecl, "source must declare exactly one func")
 	require.NotNil(t, funcDecl.Recv)
 	require.Len(t, funcDecl.Recv.List, 1)
 
-	return funcDecl.Recv.List[0].Type
+	return file, funcDecl.Recv.List[0].Type
 }
 
 // typeParamNames lists the parameter names in a field list, so a test can
@@ -91,9 +118,9 @@ func TestExtractReceiverTypeParams(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recvType := parseReceiverType(t, tt.recvSrc)
+			file, recvType := parseReceiverType(t, tt.recvSrc)
 
-			params := extractReceiverTypeParams(recvType)
+			params := extractReceiverTypeParams(file, recvType)
 
 			if tt.expected == nil {
 				assert.Nil(t, params, "a receiver without type parameters should produce no field list")
@@ -106,14 +133,14 @@ func TestExtractReceiverTypeParams(t *testing.T) {
 	}
 }
 
-// TestExtractReceiverTypeParamsConstraint records that every extracted
-// parameter is given the "any" constraint. The trampoline only needs the
-// parameter to exist and accept whatever the original receiver accepted, so
-// the real constraint is deliberately widened rather than carried across.
-func TestExtractReceiverTypeParamsConstraint(t *testing.T) {
-	recvType := parseReceiverType(t, "*GenStruct[T, U]")
+// TestExtractReceiverTypeParamsConstraint_NoMatchingDecl documents the
+// fallback: when the receiver's generic type declaration can't be found in
+// file (here, because the synthetic source doesn't declare it at all), the
+// constraint widens to any rather than failing.
+func TestExtractReceiverTypeParamsConstraint_NoMatchingDecl(t *testing.T) {
+	file, recvType := parseReceiverType(t, "*GenStruct[T, U]")
 
-	params := extractReceiverTypeParams(recvType)
+	params := extractReceiverTypeParams(file, recvType)
 	require.NotNil(t, params)
 	require.Len(t, params.List, 2)
 
@@ -124,15 +151,99 @@ func TestExtractReceiverTypeParamsConstraint(t *testing.T) {
 	}
 }
 
+// TestExtractReceiverTypeParamsConstraint_Recovered covers recovering the
+// real constraint from the receiver's own type declaration when it's present
+// in the same file: a built-in constraint, a package-qualified one, and a
+// receiver that renames its type parameter relative to the declaration
+// (constraints are matched positionally, not by name).
+func TestExtractReceiverTypeParamsConstraint_Recovered(t *testing.T) {
+	tests := []struct {
+		name         string
+		imports      string
+		typeDecl     string
+		recvSrc      string
+		wantNames    []string
+		wantIdent    string // for a plain identifier constraint, e.g. "comparable"
+		wantSelector string // for a package-qualified constraint, e.g. "constraints.Ordered"
+	}{
+		{
+			name:      "built-in constraint",
+			typeDecl:  "type GenStruct[T comparable] struct{}",
+			recvSrc:   "GenStruct[T]",
+			wantNames: []string{"T"},
+			wantIdent: "comparable",
+		},
+		{
+			name:      "renamed type parameter still resolves by position",
+			typeDecl:  "type GenStruct[T comparable] struct{}",
+			recvSrc:   "GenStruct[U]",
+			wantNames: []string{"U"},
+			wantIdent: "comparable",
+		},
+		{
+			name:         "package-qualified constraint",
+			imports:      `import "golang.org/x/exp/constraints"`,
+			typeDecl:     "type GenStruct[T constraints.Ordered] struct{}",
+			recvSrc:      "GenStruct[T]",
+			wantNames:    []string{"T"},
+			wantSelector: "constraints.Ordered",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, recvType := parseReceiverTypeWithDecl(t, tt.imports, tt.typeDecl, tt.recvSrc)
+
+			params := extractReceiverTypeParams(file, recvType)
+			require.NotNil(t, params)
+			require.Len(t, params.List, 1)
+			assert.Equal(t, tt.wantNames, typeParamNames(t, params))
+
+			switch {
+			case tt.wantIdent != "":
+				constraint, ok := params.List[0].Type.(*dst.Ident)
+				require.True(t, ok, "expected the constraint to be a plain identifier")
+				assert.Equal(t, tt.wantIdent, constraint.Name)
+			case tt.wantSelector != "":
+				sel, ok := params.List[0].Type.(*dst.SelectorExpr)
+				require.True(t, ok, "expected the constraint to be a package-qualified selector")
+				pkgIdent, ok := sel.X.(*dst.Ident)
+				require.True(t, ok)
+				assert.Equal(t, tt.wantSelector, pkgIdent.Name+"."+sel.Sel.Name)
+			}
+		})
+	}
+}
+
+// TestExtractReceiverTypeParamsConstraint_MultipleParams covers positional
+// matching against a declaration with several type parameters and mixed
+// constraints, including one field whose two names share a single constraint.
+func TestExtractReceiverTypeParamsConstraint_MultipleParams(t *testing.T) {
+	file, recvType := parseReceiverTypeWithDecl(t, "",
+		"type GenStruct[T, U comparable, V any] struct{}",
+		"GenStruct[T, U, V]")
+
+	params := extractReceiverTypeParams(file, recvType)
+	require.NotNil(t, params)
+	require.Len(t, params.List, 3)
+	assert.Equal(t, []string{"T", "U", "V"}, typeParamNames(t, params))
+
+	for i, want := range []string{"comparable", "comparable", "any"} {
+		constraint, ok := params.List[i].Type.(*dst.Ident)
+		require.True(t, ok)
+		assert.Equal(t, want, constraint.Name)
+	}
+}
+
 // TestExtractReceiverTypeParamsNestedPointer covers the recursive path. A
 // doubly-indirected receiver is not valid Go, but the function recurses
 // through StarExpr without limit and callers reach it from expressions that
 // have not been validated yet.
 func TestExtractReceiverTypeParamsNestedPointer(t *testing.T) {
-	inner := parseReceiverType(t, "*GenStruct[T]")
+	file, inner := parseReceiverType(t, "*GenStruct[T]")
 	nested := &dst.StarExpr{X: inner}
 
-	params := extractReceiverTypeParams(nested)
+	params := extractReceiverTypeParams(file, nested)
 
 	require.NotNil(t, params)
 	assert.Equal(t, []string{"T"}, typeParamNames(t, params))

--- a/tool/internal/instrument/trampoline_receiver_test.go
+++ b/tool/internal/instrument/trampoline_receiver_test.go
@@ -235,6 +235,44 @@ func TestExtractReceiverTypeParamsConstraint_MultipleParams(t *testing.T) {
 	}
 }
 
+// TestReceiverBaseTypeName_NonIdent covers the defensive fallback directly: a
+// non-identifier base expression, which no valid Go receiver form actually
+// produces, returns "" rather than panicking.
+func TestReceiverBaseTypeName_NonIdent(t *testing.T) {
+	nonIdent := &dst.SelectorExpr{X: ast.Ident("pkg"), Sel: ast.Ident("GenStruct")}
+
+	assert.Empty(t, receiverBaseTypeName(nonIdent))
+}
+
+// TestFindGenericTypeDecl_NilFileOrEmptyName covers both guard conditions in
+// findGenericTypeDecl directly: a nil file and an empty type name should each
+// short-circuit to nil without walking file.Decls.
+func TestFindGenericTypeDecl_NilFileOrEmptyName(t *testing.T) {
+	file, _ := parseReceiverTypeWithDecl(t, "", "type GenStruct[T comparable] struct{}", "GenStruct[T]")
+
+	assert.Nil(t, findGenericTypeDecl(nil, "GenStruct"))
+	assert.Nil(t, findGenericTypeDecl(file, ""))
+}
+
+// TestReceiverConstraintAt_EmptyNamesField covers the defensive n=1 fallback
+// in the position-walking loop. A type parameter field with no names doesn't
+// occur in valid Go, but the loop should still advance past it by one
+// position instead of looping forever or reading out of range.
+func TestReceiverConstraintAt_EmptyNamesField(t *testing.T) {
+	original := &dst.FieldList{
+		List: []*dst.Field{
+			{Names: nil, Type: ast.Ident("comparable")},
+			{Names: []*dst.Ident{ast.Ident("T")}, Type: ast.Ident("any")},
+		},
+	}
+
+	constraint := receiverConstraintAt(original, 1)
+
+	ident, ok := constraint.(*dst.Ident)
+	require.True(t, ok)
+	assert.Equal(t, "any", ident.Name)
+}
+
 // TestExtractReceiverTypeParamsNestedPointer covers the recursive path. A
 // doubly-indirected receiver is not valid Go, but the function recurses
 // through StarExpr without limit and callers reach it from expressions that


### PR DESCRIPTION
## Description

`extractReceiverTypeParams` in `tool/internal/instrument/trampoline.go` widened every extracted receiver type parameter's constraint to `any`, discarding the original constraint declared on the type (e.g. `type Set[T comparable] struct{...}`). If a generated trampoline body ever needed to operate on the parameter under its real constraint, the widened signature would produce generated Go that doesn't compile.

## Changes

- `findGenericTypeDecl` locates the receiver's own generic type declaration in the target file, if present.
- `receiverConstraintAt` recovers the constraint at a given position from that declaration, walking fields positionally so a multi-name field (e.g. `[T, U comparable]`) resolves correctly, and falls back to `any` when no matching declaration is found.
- Type parameters are matched **positionally**, not by name, since a method receiver is free to rename them relative to the declaration (`type Set[T comparable] struct{}` but `func (s Set[U]) Add(v U)` is valid Go; `U` is still constrained by `comparable`).
- `extractReceiverTypeParams` and `findTargetGenericType` now take the source `*dst.File` so the lookup has somewhere to search; all 4 call sites in `trampoline.go` are within `*InstrumentPhase` methods, so `ip.target` was already available at each.
- Package-qualified constraints (e.g. `constraints.Ordered`) resolve for free: since the lookup only searches the receiver's own file, any import the constraint needs is already present there (the file wouldn't compile otherwise), so no new import-resolution logic was needed for that case.

## Known limitation

If the receiver's generic type is declared in a *different* file of the same package, this doesn't resolve it and still falls back to `any` (same as before this change). Solving that would need a whole-package view (e.g. `go/types`/`go/packages`), which nothing in `tool/` currently has (see the linked issue). Left as a follow-up rather than pulled into this PR's scope.

## Testing

- `trampoline_receiver_test.go`: added `TestExtractReceiverTypeParamsConstraint_Recovered` (built-in constraint, renamed type parameter, package-qualified constraint) and `TestExtractReceiverTypeParamsConstraint_MultipleParams` (mixed constraints across multiple type parameters). Renamed the old `TestExtractReceiverTypeParamsConstraint` to `TestExtractReceiverTypeParamsConstraint_NoMatchingDecl` since it now documents the fallback path specifically, not universal behavior.
- `go test ./tool/internal/instrument/...` passes.
- `gofmt`, `golangci-lint run` clean on both changed files.

Fixes #1121

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `golangci-lint run --config .tools/golangci.yml` on changed files
- [x] Tests pass: `go test ./tool/internal/instrument/...`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](docs/instrument-guide.md#4-register-the-instrumentation))