### PR TITLE
fix(tool): sort replace directives in syncDeps for deterministic go.mod updates

### DIFF
--- a/tool/internal/setup/sync.go
+++ b/tool/internal/setup/sync.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"golang.org/x/mod/modfile"
@@ -231,9 +232,10 @@ func syncDeps(ctx context.Context, modPaths map[string]bool, moduleDir string) e
 	// instrumentation module contains shared semconv packages.
 	replaces[util.OtelcInstRoot] = filepath.Join(util.GetBuildTempDir(), unzippedInstDir)
 
-	// Okay, now add all the replace directives to go.mod
+	// Okay, now add all the replace directives to go.mod in deterministic sorted order
 	changed := false
-	for oldPath, newPath := range replaces {
+	for _, oldPath := range slices.Sorted(maps.Keys(replaces)) {
+		newPath := replaces[oldPath]
 		added, addErr := addReplace(modfile, oldPath, newPath)
 		if addErr != nil {
 			return addErr

--- a/tool/internal/setup/sync_test.go
+++ b/tool/internal/setup/sync_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -633,4 +634,41 @@ go 1.25.0
 	require.NoError(t, warnVersion(ctx, gomodPath, before))
 
 	assert.Empty(t, buf.String())
+}
+
+func TestSyncDeps_DeterministicReplaceOrder(t *testing.T) {
+	goMod := `module example.com/test
+
+go 1.21
+`
+	instPaths := []string{
+		"google.golang.org/grpc",
+		"github.com/segmentio/kafka-go",
+		"github.com/gin-gonic/gin",
+		"net/http/client",
+	}
+
+	tempDir, _, goModPath := setupSyncDepsTest(t, goMod, instPaths)
+	modPaths := make(map[string]bool, len(instPaths))
+	for _, p := range instPaths {
+		modPaths[util.OtelcInstRoot+"/"+p] = true
+	}
+
+	require.NoError(t, syncDeps(t.Context(), modPaths, tempDir))
+
+	mf, err := parseGoMod(goModPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, mf.Replace)
+
+	replacedPaths := make([]string, 0, len(mf.Replace))
+	for _, r := range mf.Replace {
+		replacedPaths = append(replacedPaths, r.Old.Path)
+	}
+
+	assert.True(
+		t,
+		slices.IsSorted(replacedPaths),
+		"expected replace directives to be sorted alphabetically, got: %v",
+		replacedPaths,
+	)
 }


### PR DESCRIPTION
## Description

Iterate over replace directive keys in deterministic alphabetical order (`slices.Sorted(maps.Keys(replaces))`) instead of iterating over the unsorted map directly in `syncDeps()`. Also added `TestSyncDeps_DeterministicReplaceOrder` to verify alphabetical ordering of injected `replace` directives.

## Motivation

In `tool/internal/setup/sync.go`, `syncDeps()` iterates over `replaces` (`map[string]string`). Because Go map iteration order is intentionally non-deterministic, `replace` directives were appended to `go.mod` in unpredictable order across builds. Sorting the keys ensures deterministic `go.mod` updates and log output.

Fixes #1119

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
