### PR TITLE
fix(tool/internal/instrument): normalize composite types in checkHookDecl

### DIFF
--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -36,6 +36,7 @@ const (
 	trampolineHookContextName       = "hookContext"
 	trampolineHookContextType       = "HookContext"
 	trampolineInterfaceType         = "interface{}"
+	trampolineEmptyStructType       = "struct{}"
 	trampolineSkipName              = "skip"
 	trampolineSetParamName          = "SetParam"
 	trampolineGetParamName          = "GetParam"
@@ -277,6 +278,58 @@ func funcTypeName(t *dst.FuncType) string {
 	return "func(" + strings.Join(params, ", ") + ")" + resStr
 }
 
+// structTypeName builds a normalized name for an anonymous struct type from its
+// field names and types, so structurally different struct types (e.g. distinct
+// field sets) don't collide on a shared "struct{...}" placeholder in
+// hookTypeMatches. Named struct types never reach here: baseTypeName resolves a
+// *dst.SelectorExpr/*dst.Ident (a named type reference) to its name before
+// getting to the underlying type declaration.
+func structTypeName(t *dst.StructType) string {
+	if t.Fields == nil || len(t.Fields.List) == 0 {
+		return trampolineEmptyStructType
+	}
+	parts := make([]string, 0, len(t.Fields.List))
+	for _, f := range t.Fields.List {
+		fType := baseTypeName(f.Type)
+		if len(f.Names) == 0 {
+			// Embedded field.
+			parts = append(parts, fType)
+			continue
+		}
+		for _, n := range f.Names {
+			parts = append(parts, n.Name+" "+fType)
+		}
+	}
+	return "struct{" + strings.Join(parts, "; ") + "}"
+}
+
+// interfaceTypeName builds a normalized name for an anonymous interface type from
+// its method set, so structurally different interfaces (e.g. io.Reader vs.
+// io.Writer) don't collide on a shared "interface{...}" placeholder in
+// hookTypeMatches. The empty interface still normalizes to trampolineInterfaceType
+// so it keeps matching any/interface{} via isAnyOrInterface.
+func interfaceTypeName(t *dst.InterfaceType) string {
+	if t.Methods == nil || len(t.Methods.List) == 0 {
+		return trampolineInterfaceType
+	}
+	parts := make([]string, 0, len(t.Methods.List))
+	for _, m := range t.Methods.List {
+		if len(m.Names) == 0 {
+			// Embedded interface.
+			parts = append(parts, baseTypeName(m.Type))
+			continue
+		}
+		for _, n := range m.Names {
+			sig := baseTypeName(m.Type)
+			if ft, ok := m.Type.(*dst.FuncType); ok {
+				sig = strings.TrimPrefix(funcTypeName(ft), "func")
+			}
+			parts = append(parts, n.Name+sig)
+		}
+	}
+	return "interface{" + strings.Join(parts, "; ") + "}"
+}
+
 // baseTypeName extracts the normalized type name for signature matching, stripping package prefixes
 // and outermost pointer indirection so that target types and hook types can be compared directly.
 // This is necessary because trampolines take pointers (*T) to allow mutating/capturing arguments and return values,
@@ -305,15 +358,9 @@ func baseTypeName(expr dst.Expr) string {
 	case *dst.ChanType:
 		return chanTypeName(t)
 	case *dst.InterfaceType:
-		if t.Methods == nil || len(t.Methods.List) == 0 {
-			return trampolineInterfaceType
-		}
-		return "interface{...}"
+		return interfaceTypeName(t)
 	case *dst.StructType:
-		if t.Fields == nil || len(t.Fields.List) == 0 {
-			return "struct{}"
-		}
-		return "struct{...}"
+		return structTypeName(t)
 	case *dst.FuncType:
 		return funcTypeName(t)
 	case *dst.IndexExpr:
@@ -347,15 +394,20 @@ func sliceOrEllipsisElt(s string) (string, bool) {
 
 // hookTypeMatches reports whether hookBase matches the expected trampBase type.
 func hookTypeMatches(trampBase, hookBase string) bool {
+	// hookBase is checked for any/interface{} first, so by the time trampBase is
+	// considered below, hookBase is already known not to be any/interface{} —
+	// isAnyOrInterface(trampBase) && isAnyOrInterface(hookBase) can never hold.
 	if isAnyOrInterface(hookBase) {
 		return true
 	}
-	if trampBase != "" && (trampBase == hookBase || (isAnyOrInterface(trampBase) && isAnyOrInterface(hookBase))) {
+	if trampBase != "" && trampBase == hookBase {
 		return true
 	}
 	if tElt, tOk := sliceOrEllipsisElt(trampBase); tOk {
 		if hElt, hOk := sliceOrEllipsisElt(hookBase); hOk {
-			return tElt == hElt || isAnyOrInterface(hElt) || (isAnyOrInterface(tElt) && isAnyOrInterface(hElt))
+			// isAnyOrInterface(hElt) alone already covers the case where both
+			// tElt and hElt are any/interface{}.
+			return tElt == hElt || isAnyOrInterface(hElt)
 		}
 	}
 	return false

--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -232,6 +232,8 @@ func arrayTypeName(t *dst.ArrayType) string {
 			lenStr = l.Value
 		case *dst.Ident:
 			lenStr = l.Name
+		default:
+			lenStr = ""
 		}
 	}
 	return "[" + lenStr + "]" + baseTypeName(t.Elt)
@@ -278,12 +280,6 @@ func funcTypeName(t *dst.FuncType) string {
 	return "func(" + strings.Join(params, ", ") + ")" + resStr
 }
 
-// structTypeName builds a normalized name for an anonymous struct type from its
-// field names and types, so structurally different struct types (e.g. distinct
-// field sets) don't collide on a shared "struct{...}" placeholder in
-// hookTypeMatches. Named struct types never reach here: baseTypeName resolves a
-// *dst.SelectorExpr/*dst.Ident (a named type reference) to its name before
-// getting to the underlying type declaration.
 func structTypeName(t *dst.StructType) string {
 	if t.Fields == nil || len(t.Fields.List) == 0 {
 		return trampolineEmptyStructType
@@ -303,11 +299,6 @@ func structTypeName(t *dst.StructType) string {
 	return "struct{" + strings.Join(parts, "; ") + "}"
 }
 
-// interfaceTypeName builds a normalized name for an anonymous interface type from
-// its method set, so structurally different interfaces (e.g. io.Reader vs.
-// io.Writer) don't collide on a shared "interface{...}" placeholder in
-// hookTypeMatches. The empty interface still normalizes to trampolineInterfaceType
-// so it keeps matching any/interface{} via isAnyOrInterface.
 func interfaceTypeName(t *dst.InterfaceType) string {
 	if t.Methods == nil || len(t.Methods.List) == 0 {
 		return trampolineInterfaceType
@@ -330,15 +321,11 @@ func interfaceTypeName(t *dst.InterfaceType) string {
 	return "interface{" + strings.Join(parts, "; ") + "}"
 }
 
-// baseTypeName extracts the normalized type name for signature matching, stripping package prefixes
-// and outermost pointer indirection so that target types and hook types can be compared directly.
-// This is necessary because trampolines take pointers (*T) to allow mutating/capturing arguments and return values,
-// and hooks may use package-qualified types (hook.HookContext) while trampolines use local types (HookContext).
-// Examples: *int → int, pkg.Type → Type, *pkg.Type → Type, interface{} → interface{}, []int → []int, ...string → ...string
+// baseTypeName normalizes a type expression for signature matching by stripping
+// package qualifiers and the outermost pointer while preserving composite type
+// constructors, so trampoline and hook parameter types can be compared directly.
+// Examples: *pkg.Type → Type, []int → []int, ...string → ...string
 func baseTypeName(expr dst.Expr) string {
-	if expr == nil {
-		return ""
-	}
 	switch t := expr.(type) {
 	case *dst.Ident:
 		if t.Name == "any" {
@@ -364,16 +351,22 @@ func baseTypeName(expr dst.Expr) string {
 	case *dst.FuncType:
 		return funcTypeName(t)
 	case *dst.IndexExpr:
-		return baseTypeName(t.X) + "[" + baseTypeName(t.Index) + "]"
+		return indexListType(t.X, []dst.Expr{t.Index})
 	case *dst.IndexListExpr:
-		indices := make([]string, 0, len(t.Indices))
-		for _, idx := range t.Indices {
-			indices = append(indices, baseTypeName(idx))
-		}
-		return baseTypeName(t.X) + "[" + strings.Join(indices, ", ") + "]"
+		return indexListType(t.X, t.Indices)
 	default:
 		return ""
 	}
+}
+
+// indexListType builds a normalized name for a generic type instantiation
+// (X[Index] or X[Index1, Index2, ...]) from its base type and index expressions.
+func indexListType(x dst.Expr, indices []dst.Expr) string {
+	parts := make([]string, 0, len(indices))
+	for _, idx := range indices {
+		parts = append(parts, baseTypeName(idx))
+	}
+	return baseTypeName(x) + "[" + strings.Join(parts, ", ") + "]"
 }
 
 // isAnyOrInterface reports whether the type string represents an empty interface (any / interface{}).
@@ -392,11 +385,9 @@ func sliceOrEllipsisElt(s string) (string, bool) {
 	return "", false
 }
 
-// hookTypeMatches reports whether hookBase matches the expected trampBase type.
-func hookTypeMatches(trampBase, hookBase string) bool {
-	// hookBase is checked for any/interface{} first, so by the time trampBase is
-	// considered below, hookBase is already known not to be any/interface{} —
-	// isAnyOrInterface(trampBase) && isAnyOrInterface(hookBase) can never hold.
+// matchBaseType reports whether hookBase matches the expected trampBase type.
+func matchBaseType(trampBase, hookBase string) bool {
+	// The any-typed parameter can accept any trampoline parameter.
 	if isAnyOrInterface(hookBase) {
 		return true
 	}
@@ -439,7 +430,7 @@ func (ip *InstrumentPhase) checkHookDecl(hookFunc *dst.FuncDecl, before bool) er
 		for i, trampField := range beforeTrampParams.List {
 			trampBase := baseTypeName(trampField.Type)
 			hookBase := baseTypeName(beforeHookParams.List[i+1].Type)
-			if !hookTypeMatches(trampBase, hookBase) {
+			if !matchBaseType(trampBase, hookBase) {
 				return ex.Newf("hook func param %d type mismatch, expected %s, got %s",
 					i+1, trampBase, hookBase)
 			}
@@ -463,7 +454,7 @@ func (ip *InstrumentPhase) checkHookDecl(hookFunc *dst.FuncDecl, before bool) er
 	for i, trampField := range afterTrampParams.List {
 		trampBase := baseTypeName(trampField.Type)
 		hookBase := baseTypeName(afterHookParams.List[i].Type)
-		if !hookTypeMatches(trampBase, hookBase) {
+		if !matchBaseType(trampBase, hookBase) {
 			return ex.Newf("hook func param %d type mismatch, expected %s, got %s",
 				i, trampBase, hookBase)
 		}

--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"go/token"
 	"strconv"
+	"strings"
 
 	"github.com/dave/dst"
 
@@ -222,27 +223,142 @@ func getHookFunc(t *rule.InstFuncRule, before bool) (*dst.FuncDecl, error) {
 	return target, nil
 }
 
-// baseTypeName returns the unqualified type name, stripping pointers and package prefixes.
-// This is needed because trampolines use pointer types (*string) while hooks use value types (string),
+func arrayTypeName(t *dst.ArrayType) string {
+	lenStr := ""
+	if t.Len != nil {
+		switch l := t.Len.(type) {
+		case *dst.BasicLit:
+			lenStr = l.Value
+		case *dst.Ident:
+			lenStr = l.Name
+		}
+	}
+	return "[" + lenStr + "]" + baseTypeName(t.Elt)
+}
+
+func chanTypeName(t *dst.ChanType) string {
+	switch t.Dir {
+	case dst.SEND:
+		return "chan<- " + baseTypeName(t.Value)
+	case dst.RECV:
+		return "<-chan " + baseTypeName(t.Value)
+	default:
+		return "chan " + baseTypeName(t.Value)
+	}
+}
+
+func fieldListTypes(fl *dst.FieldList) []string {
+	if fl == nil {
+		return nil
+	}
+	var res []string
+	for _, f := range fl.List {
+		fType := baseTypeName(f.Type)
+		if len(f.Names) > 0 {
+			for range f.Names {
+				res = append(res, fType)
+			}
+		} else {
+			res = append(res, fType)
+		}
+	}
+	return res
+}
+
+func funcTypeName(t *dst.FuncType) string {
+	params := fieldListTypes(t.Params)
+	results := fieldListTypes(t.Results)
+	resStr := ""
+	if len(results) == 1 {
+		resStr = " " + results[0]
+	} else if len(results) > 1 {
+		resStr = " (" + strings.Join(results, ", ") + ")"
+	}
+	return "func(" + strings.Join(params, ", ") + ")" + resStr
+}
+
+// baseTypeName extracts the normalized type name for signature matching, stripping package prefixes
+// and outermost pointer indirection so that target types and hook types can be compared directly.
+// This is necessary because trampolines take pointers (*T) to allow mutating/capturing arguments and return values,
 // and hooks may use package-qualified types (hook.HookContext) while trampolines use local types (HookContext).
-// Examples: *int → int, pkg.Type → Type, *pkg.Type → Type, interface{} → interface{}, []int → int, ...string → string
+// Examples: *int → int, pkg.Type → Type, *pkg.Type → Type, interface{} → interface{}, []int → []int, ...string → ...string
 func baseTypeName(expr dst.Expr) string {
+	if expr == nil {
+		return ""
+	}
 	switch t := expr.(type) {
 	case *dst.Ident:
+		if t.Name == "any" {
+			return trampolineInterfaceType
+		}
 		return t.Name
 	case *dst.StarExpr:
 		return baseTypeName(t.X)
 	case *dst.SelectorExpr:
 		return t.Sel.Name
 	case *dst.ArrayType:
-		return baseTypeName(t.Elt)
+		return arrayTypeName(t)
 	case *dst.Ellipsis:
-		return baseTypeName(t.Elt)
+		return "..." + baseTypeName(t.Elt)
+	case *dst.MapType:
+		return "map[" + baseTypeName(t.Key) + "]" + baseTypeName(t.Value)
+	case *dst.ChanType:
+		return chanTypeName(t)
 	case *dst.InterfaceType:
-		return trampolineInterfaceType
+		if t.Methods == nil || len(t.Methods.List) == 0 {
+			return trampolineInterfaceType
+		}
+		return "interface{...}"
+	case *dst.StructType:
+		if t.Fields == nil || len(t.Fields.List) == 0 {
+			return "struct{}"
+		}
+		return "struct{...}"
+	case *dst.FuncType:
+		return funcTypeName(t)
+	case *dst.IndexExpr:
+		return baseTypeName(t.X) + "[" + baseTypeName(t.Index) + "]"
+	case *dst.IndexListExpr:
+		indices := make([]string, 0, len(t.Indices))
+		for _, idx := range t.Indices {
+			indices = append(indices, baseTypeName(idx))
+		}
+		return baseTypeName(t.X) + "[" + strings.Join(indices, ", ") + "]"
 	default:
 		return ""
 	}
+}
+
+// isAnyOrInterface reports whether the type string represents an empty interface (any / interface{}).
+func isAnyOrInterface(s string) bool {
+	return s == "any" || s == trampolineInterfaceType
+}
+
+// sliceOrEllipsisElt returns the element type and true if s is a slice or ellipsis type.
+func sliceOrEllipsisElt(s string) (string, bool) {
+	if strings.HasPrefix(s, "[]") {
+		return s[2:], true
+	}
+	if strings.HasPrefix(s, "...") {
+		return s[3:], true
+	}
+	return "", false
+}
+
+// hookTypeMatches reports whether hookBase matches the expected trampBase type.
+func hookTypeMatches(trampBase, hookBase string) bool {
+	if isAnyOrInterface(hookBase) {
+		return true
+	}
+	if trampBase != "" && (trampBase == hookBase || (isAnyOrInterface(trampBase) && isAnyOrInterface(hookBase))) {
+		return true
+	}
+	if tElt, tOk := sliceOrEllipsisElt(trampBase); tOk {
+		if hElt, hOk := sliceOrEllipsisElt(hookBase); hOk {
+			return tElt == hElt || isAnyOrInterface(hElt) || (isAnyOrInterface(tElt) && isAnyOrInterface(hElt))
+		}
+	}
+	return false
 }
 
 // checkHookDecl checks if the hook function declaration is correct, i.e. if they
@@ -271,7 +387,7 @@ func (ip *InstrumentPhase) checkHookDecl(hookFunc *dst.FuncDecl, before bool) er
 		for i, trampField := range beforeTrampParams.List {
 			trampBase := baseTypeName(trampField.Type)
 			hookBase := baseTypeName(beforeHookParams.List[i+1].Type)
-			if hookBase != trampolineInterfaceType && hookBase != "any" && trampBase != hookBase {
+			if !hookTypeMatches(trampBase, hookBase) {
 				return ex.Newf("hook func param %d type mismatch, expected %s, got %s",
 					i+1, trampBase, hookBase)
 			}
@@ -295,7 +411,7 @@ func (ip *InstrumentPhase) checkHookDecl(hookFunc *dst.FuncDecl, before bool) er
 	for i, trampField := range afterTrampParams.List {
 		trampBase := baseTypeName(trampField.Type)
 		hookBase := baseTypeName(afterHookParams.List[i].Type)
-		if hookBase != trampolineInterfaceType && hookBase != "any" && trampBase != hookBase {
+		if !hookTypeMatches(trampBase, hookBase) {
 			return ex.Newf("hook func param %d type mismatch, expected %s, got %s",
 				i, trampBase, hookBase)
 		}

--- a/tool/internal/instrument/trampoline_test.go
+++ b/tool/internal/instrument/trampoline_test.go
@@ -191,7 +191,7 @@ func TestBaseTypeName(t *testing.T) {
 }
 
 func TestBaseTypeName_NilExpr(t *testing.T) {
-	assert.Equal(t, "", baseTypeName(nil))
+	assert.Empty(t, baseTypeName(nil))
 }
 
 func TestCheckHookDecl(t *testing.T) {

--- a/tool/internal/instrument/trampoline_test.go
+++ b/tool/internal/instrument/trampoline_test.go
@@ -49,6 +49,21 @@ func TestBaseTypeName(t *testing.T) {
 			expected: "interface{}",
 		},
 		{
+			name:     "non-empty interface type",
+			typeSrc:  "interface{ Read(p []byte) (n int, err error) }",
+			expected: "interface{Read([]byte) (int, error)}",
+		},
+		{
+			name:     "empty struct type",
+			typeSrc:  "struct{}",
+			expected: "struct{}",
+		},
+		{
+			name:     "non-empty struct type",
+			typeSrc:  "struct{ Name string }",
+			expected: "struct{Name string}",
+		},
+		{
 			name:     "array type",
 			typeSrc:  "[]int",
 			expected: "[]int",
@@ -279,6 +294,48 @@ func H1Before(ctx hook.HookContext, p1 []int) {}`,
 			before:      true,
 			expectError: true,
 			errorMsg:    "type mismatch, expected []string, got []int",
+		},
+		{
+			// Regression: baseTypeName used to normalize every non-empty
+			// interface to the literal placeholder "interface{...}", so
+			// structurally distinct interfaces collided and falsely matched.
+			name: "invalid - distinct anonymous interfaces don't collide",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *interface{ Read(p []byte) (n int, err error) }) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1Before(ctx hook.HookContext, p1 interface{ Write(p []byte) (n int, err error) }) {}`,
+			before:      true,
+			expectError: true,
+			errorMsg:    "type mismatch",
+		},
+		{
+			name: "valid before hook - matching anonymous interfaces",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *interface{ Read(p []byte) (n int, err error) }) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1Before(ctx hook.HookContext, p1 interface{ Read(p []byte) (n int, err error) }) {}`,
+			before: true,
+		},
+		{
+			// Same class of bug as the anonymous interface case above, but for
+			// anonymous struct types.
+			name: "invalid - distinct anonymous structs don't collide",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *struct{ Name string }) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1Before(ctx hook.HookContext, p1 struct{ Age int }) {}`,
+			before:      true,
+			expectError: true,
+			errorMsg:    "type mismatch",
 		},
 	}
 

--- a/tool/internal/instrument/trampoline_test.go
+++ b/tool/internal/instrument/trampoline_test.go
@@ -74,6 +74,41 @@ func TestBaseTypeName(t *testing.T) {
 			expected: "struct{Base}",
 		},
 		{
+			name:     "fixed-size array type with literal length",
+			typeSrc:  "[5]int",
+			expected: "[5]int",
+		},
+		{
+			name:     "fixed-size array type with named length",
+			typeSrc:  "[N]int",
+			expected: "[N]int",
+		},
+		{
+			name:     "func type with no params or results",
+			typeSrc:  "func()",
+			expected: "func()",
+		},
+		{
+			name:     "func type with unnamed params and multiple results",
+			typeSrc:  "func(int, string) (bool, error)",
+			expected: "func(int, string) (bool, error)",
+		},
+		{
+			name:     "func type with a single result",
+			typeSrc:  "func(int) string",
+			expected: "func(int) string",
+		},
+		{
+			name:     "generic type with one type argument",
+			typeSrc:  "Foo[int]",
+			expected: "Foo[int]",
+		},
+		{
+			name:     "generic type with multiple type arguments",
+			typeSrc:  "Foo[int, string]",
+			expected: "Foo[int, string]",
+		},
+		{
 			name:     "array type",
 			typeSrc:  "[]int",
 			expected: "[]int",
@@ -153,6 +188,10 @@ func TestBaseTypeName(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestBaseTypeName_NilExpr(t *testing.T) {
+	assert.Equal(t, "", baseTypeName(nil))
 }
 
 func TestCheckHookDecl(t *testing.T) {
@@ -240,6 +279,44 @@ package testdata
 import "go.opentelemetry.io/otelc/pkg/hook"
 func H1After(ctx hook.HookContext, r1 float32, r2 error) {}`,
 			before: false,
+		},
+		{
+			name: "invalid - before hook first param is not HookContext",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *string) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+func H1Before(notCtx int, p1 string) {}`,
+			before:      true,
+			expectError: true,
+			errorMsg:    "hook func first param must be HookContext, got int",
+		},
+		{
+			name: "invalid - after hook param count mismatch",
+			trampSrc: `
+package main
+func OtelAfterTrampoline(hookContext *HookContext, ret0 *string) {}`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1After(ctx hook.HookContext) {}`,
+			before:      false,
+			expectError: true,
+			errorMsg:    "expected 2 params, got 1",
+		},
+		{
+			name: "invalid - after hook type mismatch",
+			trampSrc: `
+package main
+func OtelAfterTrampoline(hookContext *HookContext, ret0 *string) {}`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1After(ctx hook.HookContext, r1 int) {}`,
+			before:      false,
+			expectError: true,
+			errorMsg:    "type mismatch, expected string, got int",
 		},
 		{
 			name: "invalid - missing HookContext in hook",

--- a/tool/internal/instrument/trampoline_test.go
+++ b/tool/internal/instrument/trampoline_test.go
@@ -54,6 +54,11 @@ func TestBaseTypeName(t *testing.T) {
 			expected: "interface{Read([]byte) (int, error)}",
 		},
 		{
+			name:     "interface type with embedded interface",
+			typeSrc:  "interface{ pkg.Reader }",
+			expected: "interface{Reader}",
+		},
+		{
 			name:     "empty struct type",
 			typeSrc:  "struct{}",
 			expected: "struct{}",
@@ -62,6 +67,11 @@ func TestBaseTypeName(t *testing.T) {
 			name:     "non-empty struct type",
 			typeSrc:  "struct{ Name string }",
 			expected: "struct{Name string}",
+		},
+		{
+			name:     "struct type with embedded field",
+			typeSrc:  "struct{ pkg.Base }",
+			expected: "struct{Base}",
 		},
 		{
 			name:     "array type",

--- a/tool/internal/instrument/trampoline_test.go
+++ b/tool/internal/instrument/trampoline_test.go
@@ -51,37 +51,62 @@ func TestBaseTypeName(t *testing.T) {
 		{
 			name:     "array type",
 			typeSrc:  "[]int",
-			expected: "int",
+			expected: "[]int",
 		},
 		{
 			name:     "nested array type",
 			typeSrc:  "[][]string",
-			expected: "string",
+			expected: "[][]string",
 		},
 		{
 			name:     "array of pointer type",
 			typeSrc:  "[]*int",
-			expected: "int",
+			expected: "[]int",
 		},
 		{
 			name:     "array of package qualified type",
 			typeSrc:  "[]pkg.Type",
-			expected: "Type",
+			expected: "[]Type",
 		},
 		{
 			name:     "ellipsis type",
 			typeSrc:  "...int",
-			expected: "int",
+			expected: "...int",
 		},
 		{
 			name:     "ellipsis of pointer type",
 			typeSrc:  "...*string",
-			expected: "string",
+			expected: "...string",
 		},
 		{
 			name:     "ellipsis of package qualified type",
 			typeSrc:  "...pkg.Type",
-			expected: "Type",
+			expected: "...Type",
+		},
+		{
+			name:     "map type",
+			typeSrc:  "map[string]int",
+			expected: "map[string]int",
+		},
+		{
+			name:     "map of package qualified types",
+			typeSrc:  "map[pkg.Key]*pkg.Val",
+			expected: "map[Key]Val",
+		},
+		{
+			name:     "channel type",
+			typeSrc:  "chan bool",
+			expected: "chan bool",
+		},
+		{
+			name:     "receive channel type",
+			typeSrc:  "<-chan int",
+			expected: "<-chan int",
+		},
+		{
+			name:     "send channel type",
+			typeSrc:  "chan<- string",
+			expected: "chan<- string",
 		},
 	}
 
@@ -126,6 +151,61 @@ func H1Before(ctx hook.HookContext, p1 string, p2 int) {}`,
 			before: true,
 		},
 		{
+			name: "valid before hook - slice and variadic compatibility",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *[]string, param1 *[]int) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1Before(ctx hook.HookContext, p1 []string, p2 ...int) {}`,
+			before: true,
+		},
+		{
+			name: "valid before hook - map and chan types",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *map[string]int, param1 *chan bool) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1Before(ctx hook.HookContext, p1 map[string]int, p2 chan bool) {}`,
+			before: true,
+		},
+		{
+			name: "valid before hook - any/interface{} wildcard",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *string) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1Before(ctx hook.HookContext, p1 any) {}`,
+			before: true,
+		},
+		{
+			name: "valid before hook - slice of any matching variadic interface{}",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *[]any) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1Before(ctx hook.HookContext, p1 ...interface{}) {}`,
+			before: true,
+		},
+		{
+			name: "valid before hook - slice of concrete type matching variadic interface{}",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *[]SpanEndOption) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1Before(ctx hook.HookContext, p1 ...interface{}) {}`,
+			before: true,
+		},
+		{
 			name: "valid after hook - pointer types match value types",
 			trampSrc: `
 package main
@@ -149,7 +229,7 @@ func H1Before(p1 string) {}`,
 			errorMsg:    "expected 2 params, got 1",
 		},
 		{
-			name: "invalid - type mismatch",
+			name: "invalid - type mismatch basic",
 			trampSrc: `
 package main
 func OtelBeforeTrampoline(param0 *string, param1 *int) (hookContext *HookContext, skipCall bool) { return nil, false }`,
@@ -159,7 +239,46 @@ import "go.opentelemetry.io/otelc/pkg/hook"
 func H1Before(ctx hook.HookContext, p1 string, p2 string) {}`,
 			before:      true,
 			expectError: true,
-			errorMsg:    "type mismatch",
+			errorMsg:    "type mismatch, expected int, got string",
+		},
+		{
+			name: "invalid - scalar vs slice mismatch",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *string) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1Before(ctx hook.HookContext, p1 []string) {}`,
+			before:      true,
+			expectError: true,
+			errorMsg:    "type mismatch, expected string, got []string",
+		},
+		{
+			name: "invalid - map vs chan mismatch",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *map[string]int) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1Before(ctx hook.HookContext, p1 chan bool) {}`,
+			before:      true,
+			expectError: true,
+			errorMsg:    "type mismatch, expected map[string]int, got chan bool",
+		},
+		{
+			name: "invalid - slice element type mismatch",
+			trampSrc: `
+package main
+func OtelBeforeTrampoline(param0 *[]string) (hookContext *HookContext, skipCall bool) { return nil, false }`,
+			hookSrc: `
+package testdata
+import "go.opentelemetry.io/otelc/pkg/hook"
+func H1Before(ctx hook.HookContext, p1 []int) {}`,
+			before:      true,
+			expectError: true,
+			errorMsg:    "type mismatch, expected []string, got []int",
 		},
 	}
 


### PR DESCRIPTION
## Description

This PR improves type normalization and signature verification in `tool/internal/instrument/trampoline.go`:
- Updates `baseTypeName()` to preserve composite type constructors, including slices (`[]T`), multi-dimensional slices (`[][]T`), variadics (`...T`), maps (`map[K]V`), channels (`chan T`, `<-chan T`, `chan<- T`), structs (`struct{}`), function types (`func(...) ...`), and generic indexing while stripping package qualifiers and outermost pointer indirections.
- Introduces `hookTypeMatches()` to validate compatibility between trampoline parameters and hook function parameters, properly handling exact normalized matches, `any` / `interface{}` wildcards, and variadic-to-slice (`...T` vs `[]T`) parameter passing.
- Adds comprehensive unit test cases in `tool/internal/instrument/trampoline_test.go` covering `baseTypeName` normalization on composite types and `checkHookDecl` validation against valid and invalid hook declarations (including scalar vs slice mismatches, slice element mismatches, and map vs channel mismatches).

## Motivation

In `tool/internal/instrument/trampoline.go`, `baseTypeName()` previously stripped `*dst.ArrayType` and `*dst.Ellipsis` down to `baseTypeName(t.Elt)` (e.g. `[]string` returned `"string"`) and defaulted unhandled composite types (`*dst.MapType`, `*dst.ChanType`, etc.) to `""`. Because `checkHookDecl` compared `trampBase != hookBase`, scalar parameters falsely matched slice/variadic parameters (e.g. `string` matched `[]string`), and unhandled composite types compared `"" == ""` and falsely matched each other (e.g. `map[string]int` matched `chan bool`).

This prevented `checkHookDecl` from rejecting incompatible hook signatures at compile-time validation, leading to invalid AST injection and cryptic downstream compiler errors during `toolexec`.

Fixes #1129

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
