### PR TITLE
chore: replace panic() with log.Fatal() in test mocks

### DIFF
--- a/test/integration/toolexec_goflags_test.go
+++ b/test/integration/toolexec_goflags_test.go
@@ -30,6 +30,7 @@ const preparedMainSource = `package main
 import (
 	"flag"
 	"io"
+	"log"
 	"net/http"
 )
 
@@ -39,14 +40,14 @@ func main() {
 
 	resp, err := http.Get(*addr + "/hello")
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 		_ = resp.Body.Close()
-		panic(err)
+		log.Fatal(err)
 	}
 	if err := resp.Body.Close(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }
 `

--- a/test/integration/vendor_test.go
+++ b/test/integration/vendor_test.go
@@ -32,6 +32,7 @@ const vendoredAppMain = `package main
 import (
 	"flag"
 	"fmt"
+	"log"
 
 	"github.com/gin-gonic/gin"
 )
@@ -46,7 +47,7 @@ func main() {
 	})
 
 	if err := r.Run(fmt.Sprintf(":%d", *port)); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }
 `


### PR DESCRIPTION
Assisted-by: Antigravity

## Description

This PR replaces instances of `panic(err)` with `log.Fatal(err)` inside the mock Go applications used for testing in `test/integration/toolexec_goflags_test.go` and `test/integration/vendor_test.go`. It also adds the necessary `"log"` imports to the mock source code blocks.

## Motivation

While `panic()` works in a test subprocess, using `log.Fatal()` is generally considered best practice for top-level error handling in `main()` functions. This update ensures our mock applications better reflect real-world Go applications and standard error-handling practices.

Fixes # (replace with actual issue number)

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
