### PR TITLE
chore(tool): unexport internal identifiers with no cross-package use

### DIFF
--- a/tool/internal/manifest/manifest.go
+++ b/tool/internal/manifest/manifest.go
@@ -73,7 +73,7 @@ func Generate(instrumentationRoot string) (Manifest, error) {
 	return manifest, nil
 }
 
-func Load() (Manifest, error) {
+func load() (Manifest, error) {
 	var manifest Manifest
 	if err := json.Unmarshal(data.GetManifestJSON(), &manifest); err != nil {
 		return nil, ex.Wrapf(err, "loading embedded instrumentation manifest")

--- a/tool/internal/manifest/manifest_test.go
+++ b/tool/internal/manifest/manifest_test.go
@@ -147,7 +147,7 @@ func TestIsRuleFile(t *testing.T) {
 }
 
 func TestLoad(t *testing.T) {
-	got, err := Load()
+	got, err := load()
 	require.NoError(t, err)
 	require.NotEmpty(t, got)
 

--- a/tool/internal/pkgload/pkgload.go
+++ b/tool/internal/pkgload/pkgload.go
@@ -207,8 +207,8 @@ func ResolveModule(ctx context.Context, pkgDir string) (*packages.Module, error)
 	return pkg.Module, nil
 }
 
-// ResolveModuleDir returns the module directory for a given package directory.
-func ResolveModuleDir(ctx context.Context, pkgDir string) (string, error) {
+// resolveModuleDir returns the module directory for a given package directory.
+func resolveModuleDir(ctx context.Context, pkgDir string) (string, error) {
 	mod, err := ResolveModule(ctx, pkgDir)
 	if err != nil {
 		return "", err
@@ -237,7 +237,7 @@ func FindModuleDirs(ctx context.Context, pkgs []*packages.Package) (map[string]b
 		if pkg.Module != nil {
 			moduleDir = pkg.Module.Dir
 		} else {
-			modDir, err := ResolveModuleDir(ctx, pkgDir)
+			modDir, err := resolveModuleDir(ctx, pkgDir)
 			if err != nil {
 				return nil, ex.Wrapf(err, "finding module dir for package %s", pkg.PkgPath)
 			}

--- a/tool/internal/pkgload/pkgload_test.go
+++ b/tool/internal/pkgload/pkgload_test.go
@@ -306,7 +306,7 @@ func TestResolveModuleDir(t *testing.T) {
 			}
 
 			require.Equal(t, expectedDir, mod.Dir)
-			moduleDir, err := ResolveModuleDir(ctx, workDir)
+			moduleDir, err := resolveModuleDir(ctx, workDir)
 			require.NoError(t, err)
 			require.Equal(t, expectedDir, moduleDir)
 		})

--- a/tool/internal/profile/profile.go
+++ b/tool/internal/profile/profile.go
@@ -33,9 +33,9 @@ const (
 type Type string
 
 const (
-	CPU   Type = "cpu"
-	Heap  Type = "heap"
-	Trace Type = "trace"
+	typeCPU   Type = "cpu"
+	typeHeap  Type = "heap"
+	typeTrace Type = "trace"
 )
 
 // Session manages the lifecycle of active profiles for a single process.
@@ -61,7 +61,7 @@ func ParseTypes(s string) ([]Type, error) {
 	for _, p := range parts {
 		p = strings.TrimSpace(p)
 		switch Type(p) {
-		case CPU, Heap, Trace:
+		case typeCPU, typeHeap, typeTrace:
 			types = append(types, Type(p))
 		default:
 			return nil, ex.Newf("unrecognized profile type %q (valid: cpu, heap, trace)", p)
@@ -82,7 +82,7 @@ func Start(dir string, types []Type) (*Session, error) {
 
 	for _, t := range types {
 		switch t {
-		case CPU:
+		case typeCPU:
 			path := s.filePath("otelc-cpu-%d.pprof")
 			f, err := os.Create(path)
 			if err != nil {
@@ -96,7 +96,7 @@ func Start(dir string, types []Type) (*Session, error) {
 				return nil, ex.Wrapf(startErr, "start CPU profile")
 			}
 			s.cpuFile = f
-		case Trace:
+		case typeTrace:
 			path := s.filePath("otelc-%d.trace")
 			f, err := os.Create(path)
 			if err != nil {
@@ -110,7 +110,7 @@ func Start(dir string, types []Type) (*Session, error) {
 				return nil, ex.Wrapf(startErr, "start execution trace")
 			}
 			s.traceFile = f
-		case Heap:
+		case typeHeap:
 			// Heap snapshot is taken at Stop time, nothing to start.
 		}
 	}
@@ -143,7 +143,7 @@ func (s *Session) Stop() error {
 	}
 
 	// Write heap snapshot at the end (captures final allocation state).
-	if slices.Contains(s.types, Heap) {
+	if slices.Contains(s.types, typeHeap) {
 		if err := s.writeHeapProfile(); err != nil {
 			errs = append(errs, ex.Wrapf(err, "write heap profile %q", s.filePath("otelc-heap-%d.pprof")))
 		}
@@ -162,7 +162,7 @@ func (s *Session) Stop() error {
 func Merge(ctx context.Context, dir string, types []Type) error {
 	var errs []error
 	for _, t := range types {
-		if t == Trace {
+		if t == typeTrace {
 			// Execution traces cannot be merged; leave them as-is.
 			continue
 		}

--- a/tool/internal/profile/profile_extra_test.go
+++ b/tool/internal/profile/profile_extra_test.go
@@ -18,11 +18,11 @@ import (
 
 func TestStartCPUCreateFileError(t *testing.T) {
 	dir := t.TempDir()
-	// A directory occupying the CPU profile path makes os.Create fail.
+	// A directory occupying the typeCPU profile path makes os.Create fail.
 	path := filepath.Join(dir, fmt.Sprintf("otelc-cpu-%d.pprof", os.Getpid()))
 	require.NoError(t, os.Mkdir(path, 0o755))
 
-	_, err := Start(dir, []Type{CPU})
+	_, err := Start(dir, []Type{typeCPU})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "create CPU profile")
 }
@@ -35,7 +35,7 @@ func TestStartCPUProfileAlreadyRunning(t *testing.T) {
 	require.NoError(t, pprof.StartCPUProfile(f))
 	defer pprof.StopCPUProfile()
 
-	_, err = Start(dir, []Type{CPU})
+	_, err = Start(dir, []Type{typeCPU})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "start CPU profile")
 }
@@ -45,7 +45,7 @@ func TestStartTraceCreateFileError(t *testing.T) {
 	path := filepath.Join(dir, fmt.Sprintf("otelc-%d.trace", os.Getpid()))
 	require.NoError(t, os.Mkdir(path, 0o755))
 
-	_, err := Start(dir, []Type{Trace})
+	_, err := Start(dir, []Type{typeTrace})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "create trace file")
 }
@@ -58,14 +58,14 @@ func TestStartTraceAlreadyRunning(t *testing.T) {
 	require.NoError(t, trace.Start(f))
 	defer trace.Stop()
 
-	_, err = Start(dir, []Type{Trace})
+	_, err = Start(dir, []Type{typeTrace})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "start execution trace")
 }
 
 func TestStopCPUCloseError(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Start(dir, []Type{CPU})
+	s, err := Start(dir, []Type{typeCPU})
 	require.NoError(t, err)
 	require.NotNil(t, s.cpuFile)
 	require.NoError(t, s.cpuFile.Close())
@@ -77,7 +77,7 @@ func TestStopCPUCloseError(t *testing.T) {
 
 func TestStopTraceCloseError(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Start(dir, []Type{Trace})
+	s, err := Start(dir, []Type{typeTrace})
 	require.NoError(t, err)
 	require.NotNil(t, s.traceFile)
 	require.NoError(t, s.traceFile.Close())
@@ -100,13 +100,13 @@ func TestWriteHeapProfileCreateError(t *testing.T) {
 func TestMergeTypeGlobError(t *testing.T) {
 	// An unclosed bracket in the directory name makes filepath.Glob fail.
 	dir := filepath.Join(t.TempDir(), "a[")
-	err := mergeType(context.Background(), dir, CPU)
+	err := mergeType(context.Background(), dir, typeCPU)
 	require.Error(t, err)
 }
 
 func TestMergeReturnsMergeError(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "a[")
-	err := Merge(context.Background(), dir, []Type{CPU})
+	err := Merge(context.Background(), dir, []Type{typeCPU})
 	require.Error(t, err)
 }
 
@@ -116,7 +116,7 @@ func TestMergeTypeCreateOutputError(t *testing.T) {
 	// The merged output path is blocked by a directory.
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "otelc-cpu.pprof"), 0o755))
 
-	err := mergeType(context.Background(), dir, CPU)
+	err := mergeType(context.Background(), dir, typeCPU)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "create merged")
 }
@@ -135,7 +135,7 @@ func TestMergeTypeGoToolFailsWithStderr(t *testing.T) {
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	err := mergeType(context.Background(), dir, CPU)
+	err := mergeType(context.Background(), dir, typeCPU)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "merge failed")
 }
@@ -154,13 +154,13 @@ func TestMergeTypeGoToolFailsWithoutStderr(t *testing.T) {
 	}
 	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	err := mergeType(context.Background(), dir, CPU)
+	err := mergeType(context.Background(), dir, typeCPU)
 	require.Error(t, err)
 }
 
 func TestStopHeapWriteError(t *testing.T) {
 	dir := t.TempDir()
-	s, err := Start(dir, []Type{Heap})
+	s, err := Start(dir, []Type{typeHeap})
 	require.NoError(t, err)
 	require.NotNil(t, s)
 
@@ -177,7 +177,7 @@ func TestMergeTypeGoToolNotFound(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "otelc-cpu-1.pprof"), []byte("data"), 0o644))
 	t.Setenv("PATH", "")
 
-	err := mergeType(context.Background(), dir, CPU)
+	err := mergeType(context.Background(), dir, typeCPU)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "merge cpu profiles")
 }

--- a/tool/internal/profile/profile_test.go
+++ b/tool/internal/profile/profile_test.go
@@ -24,32 +24,32 @@ func TestParseTypes(t *testing.T) {
 		{
 			name:  "single cpu",
 			input: "cpu",
-			want:  []Type{CPU},
+			want:  []Type{typeCPU},
 		},
 		{
 			name:  "single heap",
 			input: "heap",
-			want:  []Type{Heap},
+			want:  []Type{typeHeap},
 		},
 		{
 			name:  "single trace",
 			input: "trace",
-			want:  []Type{Trace},
+			want:  []Type{typeTrace},
 		},
 		{
 			name:  "all three",
 			input: "cpu,heap,trace",
-			want:  []Type{CPU, Heap, Trace},
+			want:  []Type{typeCPU, typeHeap, typeTrace},
 		},
 		{
 			name:  "spaces around entries trimmed",
 			input: "cpu, heap",
-			want:  []Type{CPU, Heap},
+			want:  []Type{typeCPU, typeHeap},
 		},
 		{
 			name:  "leading and trailing whitespace",
 			input: "  cpu,heap  ",
-			want:  []Type{CPU, Heap},
+			want:  []Type{typeCPU, typeHeap},
 		},
 		{
 			name:  "empty string",
@@ -105,7 +105,7 @@ func TestParseTypes(t *testing.T) {
 func TestStartStopCPU(t *testing.T) {
 	dir := t.TempDir()
 
-	s, err := Start(dir, []Type{CPU})
+	s, err := Start(dir, []Type{typeCPU})
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestStartStopCPU(t *testing.T) {
 func TestStartStopHeap(t *testing.T) {
 	dir := t.TempDir()
 
-	s, err := Start(dir, []Type{Heap})
+	s, err := Start(dir, []Type{typeHeap})
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestStartStopHeap(t *testing.T) {
 func TestStartStopTrace(t *testing.T) {
 	dir := t.TempDir()
 
-	s, err := Start(dir, []Type{Trace})
+	s, err := Start(dir, []Type{typeTrace})
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestStartStopAll(t *testing.T) {
 	dir := t.TempDir()
 	pid := os.Getpid()
 
-	s, err := Start(dir, []Type{CPU, Heap, Trace})
+	s, err := Start(dir, []Type{typeCPU, typeHeap, typeTrace})
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestStartCreatesDirectory(t *testing.T) {
 	base := t.TempDir()
 	dir := filepath.Join(base, "nested", "profile", "dir")
 
-	s, err := Start(dir, []Type{Heap})
+	s, err := Start(dir, []Type{typeHeap})
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestStartInvalidDir(t *testing.T) {
 	}
 	_ = f.Close()
 
-	_, err := Start(filepath.Join(f.Name(), "subdir"), []Type{Heap})
+	_, err := Start(filepath.Join(f.Name(), "subdir"), []Type{typeHeap})
 	if err == nil {
 		t.Fatal("Start() with invalid dir returned nil error, want error")
 	}
@@ -212,7 +212,7 @@ func TestMerge(t *testing.T) {
 	dir := t.TempDir()
 
 	// Produce a real PID-stamped heap profile to merge.
-	s, err := Start(dir, []Type{Heap})
+	s, err := Start(dir, []Type{typeHeap})
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestMerge(t *testing.T) {
 	pidFile := filepath.Join(dir, fmt.Sprintf("otelc-heap-%d.pprof", os.Getpid()))
 	assertFileExists(t, pidFile)
 
-	if mergeErr := Merge(context.Background(), dir, []Type{Heap}); mergeErr != nil {
+	if mergeErr := Merge(context.Background(), dir, []Type{typeHeap}); mergeErr != nil {
 		t.Fatalf("Merge() error: %v", mergeErr)
 	}
 
@@ -236,9 +236,9 @@ func TestMerge(t *testing.T) {
 func TestMergeTraceSkipped(t *testing.T) {
 	dir := t.TempDir()
 
-	// Trace profiles cannot be merged, so Merge is a no-op for them and must not
+	// typeTrace profiles cannot be merged, so Merge is a no-op for them and must not
 	// create a merged trace file.
-	if err := Merge(context.Background(), dir, []Type{Trace}); err != nil {
+	if err := Merge(context.Background(), dir, []Type{typeTrace}); err != nil {
 		t.Fatalf("Merge() error: %v", err)
 	}
 	if _, statErr := os.Stat(filepath.Join(dir, "otelc-trace.pprof")); !os.IsNotExist(statErr) {
@@ -248,7 +248,7 @@ func TestMergeTraceSkipped(t *testing.T) {
 
 func TestMergeNoFiles(t *testing.T) {
 	// With no matching profile files present, Merge succeeds without writing anything.
-	if err := Merge(context.Background(), t.TempDir(), []Type{Heap, CPU}); err != nil {
+	if err := Merge(context.Background(), t.TempDir(), []Type{typeHeap, typeCPU}); err != nil {
 		t.Fatalf("Merge() error: %v", err)
 	}
 }

--- a/tool/util/helpers_extra_test.go
+++ b/tool/util/helpers_extra_test.go
@@ -89,7 +89,7 @@ func TestContextLogger(t *testing.T) {
 func TestIsUnixAndIsWindows(t *testing.T) {
 	// Exactly the current platform family must report true; the two are
 	// mutually exclusive on every supported OS.
-	assert.NotEqual(t, IsUnix(), IsWindows())
+	assert.NotEqual(t, isUnix(), IsWindows())
 }
 
 func TestNormalizePath(t *testing.T) {

--- a/tool/util/sys.go
+++ b/tool/util/sys.go
@@ -58,7 +58,7 @@ func IsWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
-func IsUnix() bool {
+func isUnix() bool {
 	return runtime.GOOS == "linux" || runtime.GOOS == "darwin"
 }
 


### PR DESCRIPTION
## Description

First slice of #1143, covering the packages with only a handful of affected symbols so the
approach can be reviewed cheaply before the larger ones (`ast`, `setup`, `rule`) follow.

Unexported:

- `util.IsUnix` → `isUnix`
- `pkgload.ResolveModuleDir` → `resolveModuleDir`
- `manifest.Load` → `load`
- `profile.CPU` / `Heap` / `Trace` → `typeCPU` / `typeHeap` / `typeTrace`

The profile constants get a `type` prefix rather than plain `cpu`/`heap`/`trace` because
`profile.go` imports `runtime/trace`; a bare `trace` constant would shadow the package
within that file.

### How the list was produced

Rather than work from a hand-written list, I wrote a `go/packages` analyzer (full type
info, `Tests: true`) that collapses a package with its internal test variant
(`p [p.test]`) and its external test package (`p_test`) into one logical package — an
external `_test` package is not a real API consumer, since it can be converted to an
internal test instead. It then reports exported package-scope identifiers with zero
references from any other logical package.

I sanity-checked it against ground truth before trusting it: `cmd/otelc` references
`setup.{Cleanup,GoBuild,Pin,PinOptions,Setup}` and `instrument.{Toolexec,EnableNestedToolexec}`,
and none of those appear in the analyzer's output, while `setup.Build`/`AutoPin`/
`BuildWithToolexec` (distinct from `GoBuild`) correctly do.

### One correction to the issue's count

Six of the ~100 identifiers **cannot** be unexported, because they are reachable from the
signature of an exported function that external code calls. Callers never name them —
they get them via `:=` inference — so a naive reference scan reports them as unused:

| Type | Reached through |
|---|---|
| `profile.Type` | `ParseTypes`, `Start`, `Merge` |
| `setup.PinResult` | `Pin`, `AutoPin` |
| `setup.Dependency` | exported setup signatures |
| `imports.Resolution` | exported imports signature |
| `manifest.Entry` | exported manifest signature |
| `ast.FuncDirectiveMatch` | exported ast signature |

Unexporting these would leave an exported function returning a type callers cannot name,
which revive's `unexported-return` flags — so the PR would fail lint. They are left
exported here and called out so the same trap does not catch the later PRs.

Note `setup.Filter` is *not* in that group: `Build`, which returns it, is itself
unexportable, so the two move together in a later PR.

### Deferred to its own PR

`instrument.InstrumentPhase` and `instrument.TJump` are only two symbols but 94 occurrences
across 23 files. Bundling that rename here would bury this diff, so it gets its own PR.

## Motivation

Part of #1143

## Verification

This is a pure rename with no behaviour change, so the check that matters is that the whole
suite still passes and nothing outside the four packages moved.

`go build ./tool/...`, `go vet ./tool/...` and `go test -shuffle=on -timeout=15m -count=1
./tool/...` all pass locally. The integration and e2e halves of `make test` were verified
through this PR's CI jobs rather than locally, since the testcontainers-based suites had no
usable Docker host here.

`make lint` was checked with golangci-lint **v2.11.3**, the version
`.github/workflows/lint-golang.yaml` pins, run across the whole repo the way CI invokes it
— 0 issues.

Two over-eager substitutions were caught by the compiler and test suite during the rename
and fixed: a `manifest_test.go` call site, and three assertions comparing against runtime
error strings that legitimately contain the word "CPU". Re-running the analyzer afterwards
confirms `util`, `pkgload` and `manifest.Load` no longer appear, and `manifest`/`profile`
now list only their signature-blocked types.

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality (N/A — rename only, no behaviour change)
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
