### PR TITLE
chore(tool): unexport rule schema identifiers with no cross-package use

### DIFF
--- a/tool/internal/rule/normalize.go
+++ b/tool/internal/rule/normalize.go
@@ -50,8 +50,8 @@ import (
 //	imports:
 //	  fmt: fmt
 func Normalize(fields map[string]any) ([]map[string]any, error) {
-	_, hasWhere := fields[KeyWhere]
-	_, hasDo := fields[KeyDo]
+	_, hasWhere := fields[keyWhere]
+	_, hasDo := fields[keyDo]
 	if !hasWhere && !hasDo {
 		return []map[string]any{fields}, nil
 	}
@@ -63,12 +63,12 @@ func Normalize(fields map[string]any) ([]map[string]any, error) {
 
 	// Copy top-level fields (e.g. imports, name) that sit outside where/do.
 	for k, v := range fields {
-		if k != KeyWhere && k != KeyDo {
+		if k != keyWhere && k != keyDo {
 			common[k] = v
 		}
 	}
 
-	if whereRaw, ok := fields[KeyWhere]; ok {
+	if whereRaw, ok := fields[keyWhere]; ok {
 		whereMap, isMap := whereRaw.(map[string]any)
 		if !isMap {
 			return nil, ex.Newf("where must be a map")
@@ -78,11 +78,11 @@ func Normalize(fields map[string]any) ([]map[string]any, error) {
 			return nil, err
 		}
 		if len(normalizedWhere) > 0 {
-			common[KeyWhere] = normalizedWhere
+			common[keyWhere] = normalizedWhere
 		}
 	}
 
-	doItems, err := normalizeDo(fields[KeyDo])
+	doItems, err := normalizeDo(fields[keyDo])
 	if err != nil {
 		return nil, err
 	}
@@ -108,32 +108,32 @@ func Normalize(fields map[string]any) ([]map[string]any, error) {
 // target/version are explicitly rejected here because they belong to the
 // top-level package selector slot per ADR-0003.
 func normalizeWhere(common, where map[string]any) (map[string]any, error) {
-	if _, exists := where[SelTarget]; exists {
+	if _, exists := where[selTarget]; exists {
 		return nil, ex.Newf("target must be top-level, not inside where")
 	}
-	if _, exists := where[SelVersion]; exists {
+	if _, exists := where[selVersion]; exists {
 		return nil, ex.Newf("version must be top-level, not inside where")
 	}
 
 	normalized := make(map[string]any)
 	for key, value := range where {
-		if !IsValidSelector(key) {
+		if !isValidSelector(key) {
 			return nil, ex.Newf("unsupported where key %q", key)
 		}
 		switch key {
-		case SelFunc, SelRecv, SelStruct, SelFunctionCall, SelDirective, SelKind, SelIdentifier,
-			SelSignature, SelSignatureContains, SelResult, SelLastResult, SelParam,
-			SelPattern, SelPlacement:
+		case SelFunc, selRecv, SelStruct, SelFunctionCall, SelDirective, selKind, SelIdentifier,
+			selSignature, selSignatureContains, selResult, selLastResult, selParam,
+			selPattern, selPlacement:
 			common[key] = value
 		case WhereFile:
 			if _, ok := value.(map[string]any); !ok {
 				return nil, ex.Newf("where.file must be a map")
 			}
 			normalized[key] = value
-		case CombAllOf, CombOneOf, CombNot:
+		case combAllOf, combOneOf, combNot:
 			normalized[key] = value
 		default:
-			// IsValidSelector includes target/version, which are rejected above,
+			// isValidSelector includes target/version, which are rejected above,
 			// and any future registry entry must be handled explicitly here.
 			return nil, ex.Newf("unsupported where key %q", key)
 		}
@@ -175,7 +175,7 @@ func normalizeDoSequence(items []any) ([]map[string]any, error) {
 			return nil, ex.Newf("do[%d] must contain exactly one modifier key", idx)
 		}
 		for modifierName, modifierRaw := range modifierMap {
-			if !IsValidModifier(modifierName) {
+			if !isValidModifier(modifierName) {
 				return nil, ex.Newf("do[%d]: unsupported modifier %q", idx, modifierName)
 			}
 			modifierFields, hasModifierFields := modifierRaw.(map[string]any)
@@ -200,7 +200,7 @@ func normalizeDoMap(modifier map[string]any) ([]map[string]any, error) {
 		)
 	}
 	for modifierName, modifierRaw := range modifier {
-		if !IsValidModifier(modifierName) {
+		if !isValidModifier(modifierName) {
 			return nil, ex.Newf("unsupported modifier %q", modifierName)
 		}
 		modifierFields, ok := modifierRaw.(map[string]any)

--- a/tool/internal/rule/schema.go
+++ b/tool/internal/rule/schema.go
@@ -3,75 +3,75 @@
 
 package rule
 
-// Selector is a where-clause key recognized by the structured rule schema
+// selector is a where-clause key recognized by the structured rule schema
 // (ADR-0003). Point selectors are hoisted to flat fields by Normalize; file
 // and combinator keys stay nested under where.
-type Selector string
+type selector string
 
-// Modifier is a do-clause key that names the instrumentation action and,
+// modifier is a do-clause key that names the instrumentation action and,
 // per docs/rules.md, declares the rule type.
-type Modifier string
+type modifier string
 
-// Selector keys in the structured rule schema (where selectors, file/combinator keys, plus top-level target/version).
+// selector keys in the structured rule schema (where selectors, file/combinator keys, plus top-level target/version).
 const (
-	SelectorTarget            Selector = "target"
-	SelectorVersion           Selector = "version"
-	SelectorFunc              Selector = "func"
-	SelectorRecv              Selector = "recv"
-	SelectorStruct            Selector = "struct"
-	SelectorFunctionCall      Selector = "function_call"
-	SelectorDirective         Selector = "directive"
-	SelectorKind              Selector = "kind"
-	SelectorIdentifier        Selector = "identifier"
-	SelectorSignature         Selector = "signature"
-	SelectorSignatureContains Selector = "signature_contains"
-	SelectorResult            Selector = "result"
-	SelectorLastResult        Selector = "last_result"
-	SelectorParam             Selector = "param"
-	SelectorPattern           Selector = "pattern"
-	SelectorPlacement         Selector = "placement"
-	SelectorFile              Selector = "file"
-	SelectorAllOf             Selector = "all-of"
-	SelectorOneOf             Selector = "one-of"
-	SelectorNot               Selector = "not"
+	selectorTarget            selector = "target"
+	selectorVersion           selector = "version"
+	selectorFunc              selector = "func"
+	selectorRecv              selector = "recv"
+	selectorStruct            selector = "struct"
+	selectorFunctionCall      selector = "function_call"
+	selectorDirective         selector = "directive"
+	selectorKind              selector = "kind"
+	selectorIdentifier        selector = "identifier"
+	selectorSignature         selector = "signature"
+	selectorSignatureContains selector = "signature_contains"
+	selectorResult            selector = "result"
+	selectorLastResult        selector = "last_result"
+	selectorParam             selector = "param"
+	selectorPattern           selector = "pattern"
+	selectorPlacement         selector = "placement"
+	selectorFile              selector = "file"
+	selectorAllOf             selector = "all-of"
+	selectorOneOf             selector = "one-of"
+	selectorNot               selector = "not"
 )
 
 // do modifiers (docs/rules.md § modifier names → rule types).
 const (
-	ModifierInjectHooks     Modifier = "inject_hooks"
-	ModifierInjectCode      Modifier = "inject_code"
-	ModifierAddStructFields Modifier = "add_struct_fields"
-	ModifierAddFile         Modifier = "add_file"
-	ModifierWrapCall        Modifier = "wrap_call"
-	ModifierExpandDirective Modifier = "expand_directive"
-	ModifierAssignValue     Modifier = "assign_value"
+	modifierInjectHooks     modifier = "inject_hooks"
+	modifierInjectCode      modifier = "inject_code"
+	modifierAddStructFields modifier = "add_struct_fields"
+	modifierAddFile         modifier = "add_file"
+	modifierWrapCall        modifier = "wrap_call"
+	modifierExpandDirective modifier = "expand_directive"
+	modifierAssignValue     modifier = "assign_value"
 )
 
 // String forms used as YAML / map keys. Existing call sites (normalize,
 // match) keep using these aliases so the registry is a single source of truth
-// without forcing every consumer onto the typed Selector/Modifier APIs.
+// without forcing every consumer onto the typed selector/modifier APIs.
 const (
-	SelTarget            = string(SelectorTarget)
-	SelVersion           = string(SelectorVersion)
-	SelFunc              = string(SelectorFunc)
-	SelRecv              = string(SelectorRecv)
-	SelStruct            = string(SelectorStruct)
-	SelFunctionCall      = string(SelectorFunctionCall)
-	SelDirective         = string(SelectorDirective)
-	SelKind              = string(SelectorKind)
-	SelIdentifier        = string(SelectorIdentifier)
-	SelSignature         = string(SelectorSignature)
-	SelSignatureContains = string(SelectorSignatureContains)
-	SelResult            = string(SelectorResult)
-	SelLastResult        = string(SelectorLastResult)
-	SelParam             = string(SelectorParam)
-	SelPattern           = string(SelectorPattern)
-	SelPlacement         = string(SelectorPlacement)
+	selTarget            = string(selectorTarget)
+	selVersion           = string(selectorVersion)
+	SelFunc              = string(selectorFunc)
+	selRecv              = string(selectorRecv)
+	SelStruct            = string(selectorStruct)
+	SelFunctionCall      = string(selectorFunctionCall)
+	SelDirective         = string(selectorDirective)
+	selKind              = string(selectorKind)
+	SelIdentifier        = string(selectorIdentifier)
+	selSignature         = string(selectorSignature)
+	selSignatureContains = string(selectorSignatureContains)
+	selResult            = string(selectorResult)
+	selLastResult        = string(selectorLastResult)
+	selParam             = string(selectorParam)
+	selPattern           = string(selectorPattern)
+	selPlacement         = string(selectorPlacement)
 
-	WhereFile = string(SelectorFile)
-	CombAllOf = string(SelectorAllOf)
-	CombOneOf = string(SelectorOneOf)
-	CombNot   = string(SelectorNot)
+	WhereFile = string(selectorFile)
+	combAllOf = string(selectorAllOf)
+	combOneOf = string(selectorOneOf)
+	combNot   = string(selectorNot)
 
 	// RawField is the modifier-output key produced by normalize for raw rules
 	// (inject_code payload). It is not a where selector; tool/internal/setup/match.go shares it.
@@ -80,17 +80,17 @@ const (
 
 // Structured top-level keys.
 const (
-	KeyWhere = "where"
-	KeyDo    = "do"
+	keyWhere = "where"
+	keyDo    = "do"
 )
 
 // selectors lists every key that may appear inside where (point selectors,
 // file group, and combinators). target/version are intentionally included so
-// IsValidSelector can distinguish "known but misplaced" from "unknown";
+// isValidSelector can distinguish "known but misplaced" from "unknown";
 // normalizeWhere still rejects them inside where.
 
-//nolint:gochecknoglobals // lookup set derived from AllSelectors(); intentionally package-level so IsValidSelector can query it without reconstruction
-var selectors = toSet(AllSelectors())
+//nolint:gochecknoglobals // lookup set derived from allSelectors(); intentionally package-level so isValidSelector can query it without reconstruction
+var selectors = toSet(allSelectors())
 
 // toSet builds a lookup set from an ordered slice, so the set can never
 // drift from the slice it is derived from.
@@ -102,59 +102,59 @@ func toSet[T comparable](items []T) map[T]struct{} {
 	return set
 }
 
-//nolint:gochecknoglobals // lookup set derived from AllModifiers(); intentionally package-level so IsValidModifier can query it without reconstruction
-var modifiers = toSet(AllModifiers())
+//nolint:gochecknoglobals // lookup set derived from allModifiers(); intentionally package-level so isValidModifier can query it without reconstruction
+var modifiers = toSet(allModifiers())
 
-// IsValidSelector reports whether s is part of the rule schema's selector
+// isValidSelector reports whether s is part of the rule schema's selector
 // vocabulary. This includes target/version, which are valid selectors but
 // are rejected specifically when used inside a where block — see
 // normalizeWhere.
-func IsValidSelector(s string) bool {
-	_, ok := selectors[Selector(s)]
+func isValidSelector(s string) bool {
+	_, ok := selectors[selector(s)]
 	return ok
 }
 
-// IsValidModifier reports whether s is a known do-clause modifier name.
-func IsValidModifier(s string) bool {
-	_, ok := modifiers[Modifier(s)]
+// isValidModifier reports whether s is a known do-clause modifier name.
+func isValidModifier(s string) bool {
+	_, ok := modifiers[modifier(s)]
 	return ok
 }
 
-// AllSelectors returns every registered where selector in a stable order.
-func AllSelectors() []Selector {
-	return []Selector{
-		SelectorTarget,
-		SelectorVersion,
-		SelectorFunc,
-		SelectorRecv,
-		SelectorStruct,
-		SelectorFunctionCall,
-		SelectorDirective,
-		SelectorKind,
-		SelectorIdentifier,
-		SelectorSignature,
-		SelectorSignatureContains,
-		SelectorResult,
-		SelectorLastResult,
-		SelectorParam,
-		SelectorPattern,
-		SelectorPlacement,
-		SelectorFile,
-		SelectorAllOf,
-		SelectorOneOf,
-		SelectorNot,
+// allSelectors returns every registered where selector in a stable order.
+func allSelectors() []selector {
+	return []selector{
+		selectorTarget,
+		selectorVersion,
+		selectorFunc,
+		selectorRecv,
+		selectorStruct,
+		selectorFunctionCall,
+		selectorDirective,
+		selectorKind,
+		selectorIdentifier,
+		selectorSignature,
+		selectorSignatureContains,
+		selectorResult,
+		selectorLastResult,
+		selectorParam,
+		selectorPattern,
+		selectorPlacement,
+		selectorFile,
+		selectorAllOf,
+		selectorOneOf,
+		selectorNot,
 	}
 }
 
-// AllModifiers returns every registered do modifier in a stable order.
-func AllModifiers() []Modifier {
-	return []Modifier{
-		ModifierInjectHooks,
-		ModifierInjectCode,
-		ModifierAddStructFields,
-		ModifierAddFile,
-		ModifierWrapCall,
-		ModifierExpandDirective,
-		ModifierAssignValue,
+// allModifiers returns every registered do modifier in a stable order.
+func allModifiers() []modifier {
+	return []modifier{
+		modifierInjectHooks,
+		modifierInjectCode,
+		modifierAddStructFields,
+		modifierAddFile,
+		modifierWrapCall,
+		modifierExpandDirective,
+		modifierAssignValue,
 	}
 }

--- a/tool/internal/rule/schema_test.go
+++ b/tool/internal/rule/schema_test.go
@@ -11,90 +11,90 @@ import (
 )
 
 func TestIsValidSelector(t *testing.T) {
-	for _, sel := range AllSelectors() {
-		assert.Truef(t, IsValidSelector(string(sel)), "AllSelectors entry %q must be valid", sel)
+	for _, sel := range allSelectors() {
+		assert.Truef(t, isValidSelector(string(sel)), "allSelectors entry %q must be valid", sel)
 	}
-	assert.False(t, IsValidSelector("bogus"))
-	assert.False(t, IsValidSelector(""))
-	assert.False(t, IsValidSelector("inject_hooks")) // modifier, not selector
+	assert.False(t, isValidSelector("bogus"))
+	assert.False(t, isValidSelector(""))
+	assert.False(t, isValidSelector("inject_hooks")) // modifier, not selector
 }
 
 func TestIsValidModifier(t *testing.T) {
-	for _, mod := range AllModifiers() {
-		assert.Truef(t, IsValidModifier(string(mod)), "AllModifiers entry %q must be valid", mod)
+	for _, mod := range allModifiers() {
+		assert.Truef(t, isValidModifier(string(mod)), "allModifiers entry %q must be valid", mod)
 	}
-	assert.False(t, IsValidModifier("bogus"))
-	assert.False(t, IsValidModifier(""))
-	assert.False(t, IsValidModifier("inject_hook")) // typo of inject_hooks
-	assert.False(t, IsValidModifier("func"))        // selector, not modifier
+	assert.False(t, isValidModifier("bogus"))
+	assert.False(t, isValidModifier(""))
+	assert.False(t, isValidModifier("inject_hook")) // typo of inject_hooks
+	assert.False(t, isValidModifier("func"))        // selector, not modifier
 }
 
 func TestAllSelectorsComplete(t *testing.T) {
-	got := AllSelectors()
+	got := allSelectors()
 	require.Len(t, got, len(selectors))
-	seen := make(map[Selector]struct{}, len(got))
+	seen := make(map[selector]struct{}, len(got))
 	for _, sel := range got {
 		_, dup := seen[sel]
-		assert.Falsef(t, dup, "duplicate selector %q in AllSelectors", sel)
+		assert.Falsef(t, dup, "duplicate selector %q in allSelectors", sel)
 		seen[sel] = struct{}{}
 		_, registered := selectors[sel]
-		assert.Truef(t, registered, "AllSelectors entry %q missing from selectors map", sel)
+		assert.Truef(t, registered, "allSelectors entry %q missing from selectors map", sel)
 	}
 }
 
 func TestAllModifiersComplete(t *testing.T) {
-	got := AllModifiers()
+	got := allModifiers()
 	require.Len(t, got, len(modifiers))
-	seen := make(map[Modifier]struct{}, len(got))
+	seen := make(map[modifier]struct{}, len(got))
 	for _, mod := range got {
 		_, dup := seen[mod]
-		assert.Falsef(t, dup, "duplicate modifier %q in AllModifiers", mod)
+		assert.Falsef(t, dup, "duplicate modifier %q in allModifiers", mod)
 		seen[mod] = struct{}{}
 		_, registered := modifiers[mod]
-		assert.Truef(t, registered, "AllModifiers entry %q missing from modifiers map", mod)
+		assert.Truef(t, registered, "allModifiers entry %q missing from modifiers map", mod)
 	}
 }
 
 func TestStringAliasesMatchTypedConstants(t *testing.T) {
 	selectorCases := []struct {
 		alias string
-		typed Selector
+		typed selector
 	}{
-		{SelTarget, SelectorTarget},
-		{SelVersion, SelectorVersion},
-		{SelFunc, SelectorFunc},
-		{SelRecv, SelectorRecv},
-		{SelStruct, SelectorStruct},
-		{SelFunctionCall, SelectorFunctionCall},
-		{SelDirective, SelectorDirective},
-		{SelKind, SelectorKind},
-		{SelIdentifier, SelectorIdentifier},
-		{SelSignature, SelectorSignature},
-		{SelSignatureContains, SelectorSignatureContains},
-		{SelResult, SelectorResult},
-		{SelLastResult, SelectorLastResult},
-		{SelParam, SelectorParam},
-		{SelPattern, SelectorPattern},
-		{SelPlacement, SelectorPlacement},
-		{WhereFile, SelectorFile},
-		{CombAllOf, SelectorAllOf},
-		{CombOneOf, SelectorOneOf},
-		{CombNot, SelectorNot},
+		{selTarget, selectorTarget},
+		{selVersion, selectorVersion},
+		{SelFunc, selectorFunc},
+		{selRecv, selectorRecv},
+		{SelStruct, selectorStruct},
+		{SelFunctionCall, selectorFunctionCall},
+		{SelDirective, selectorDirective},
+		{selKind, selectorKind},
+		{SelIdentifier, selectorIdentifier},
+		{selSignature, selectorSignature},
+		{selSignatureContains, selectorSignatureContains},
+		{selResult, selectorResult},
+		{selLastResult, selectorLastResult},
+		{selParam, selectorParam},
+		{selPattern, selectorPattern},
+		{selPlacement, selectorPlacement},
+		{WhereFile, selectorFile},
+		{combAllOf, selectorAllOf},
+		{combOneOf, selectorOneOf},
+		{combNot, selectorNot},
 	}
 	for _, c := range selectorCases {
 		assert.Equalf(t, string(c.typed), c.alias, "alias must equal string(%v)", c.typed)
 	}
 	modifierCases := []struct {
 		alias string
-		typed Modifier
+		typed modifier
 	}{
-		{"inject_hooks", ModifierInjectHooks},
-		{"inject_code", ModifierInjectCode},
-		{"add_struct_fields", ModifierAddStructFields},
-		{"add_file", ModifierAddFile},
-		{"wrap_call", ModifierWrapCall},
-		{"expand_directive", ModifierExpandDirective},
-		{"assign_value", ModifierAssignValue},
+		{"inject_hooks", modifierInjectHooks},
+		{"inject_code", modifierInjectCode},
+		{"add_struct_fields", modifierAddStructFields},
+		{"add_file", modifierAddFile},
+		{"wrap_call", modifierWrapCall},
+		{"expand_directive", modifierExpandDirective},
+		{"assign_value", modifierAssignValue},
 	}
 	for _, c := range modifierCases {
 		assert.Equalf(t, string(c.typed), c.alias, "alias must equal string(%v)", c.typed)


### PR DESCRIPTION
## Description

Fourth and last slice of #1143 (#1146, the `ast` PR, and the `setup` PR precede this one). This one covers `tool/internal/rule`.

Unexported 49 identifiers with zero references outside the package: the selector-name constants (`SelKind`, `SelLastResult`, `SelParam`, `SelPattern`, `SelPlacement`, `SelRecv`, `SelResult`, `SelSignature`, `SelSignatureContains`, `SelTarget`, `SelVersion`), the human-readable selector labels (`SelectorAllOf`/`Directive`/`File`/`Func`/`FunctionCall`/`Identifier`/`Kind`/`LastResult`/`Not`/`OneOf`/`Param`/`Pattern`/`Placement`/`Recv`/`Result`/`Signature`/`SignatureContains`/`Struct`/`Target`/`Version`), the combinator/key constants (`CombAllOf`, `CombNot`, `CombOneOf`, `KeyDo`, `KeyWhere`), the `Modifier` and `Selector` types, and their validation helpers (`AllModifiers`, `AllSelectors`, `IsValidModifier`, `IsValidSelector`).

Unlike the `ast` and `setup` PRs, none of these 49 are reachable from an exported signature, so nothing needs to stay exported here.

### `normalize_test.go` and `target_glob_test.go` stay as external `rule_test` packages

Two of this package's test files are black-box `package rule_test`, but neither needed converting: they only reference `Normalize`, `ValidateTarget`, `MatchGlobTarget`, `IsGlobTarget`, `IsRootTarget`, `TargetRoot`, none of which are on this rename list. Checked before touching anything, matching the same due-diligence pattern as the `setup` PR's `filter_test.go` conversion — this time the answer was "no conversion needed" rather than "yes."

### Smoothest of the four slices

Ran the same hazard checks as the other three PRs (external test packages, third-party import collisions, existing-lowercase collisions, struct-field-access collisions) before touching any code — all came back clean, and the mechanical rename compiled, vetted, and passed the full suite on the first attempt. The exported schema surface turned out to be concentrated in just three files: `schema.go` (declarations), `normalize.go` (one internal switch using the combinator constants), `schema_test.go` (tests).

## Motivation

Part of #1143. Closes out the issue once merged alongside #1146 and the `ast`/`setup` PRs — all four together account for the full 98-identifier count from the `go/packages`-based usage scan described in #1146's description (100 in the issue's own estimate, minus the 6 that must stay exported for `unexported-return` reasons, explained there and in the `ast`/`setup` PRs).

## Verification

`go build ./tool/...`, `go vet ./tool/...`, and `go test -shuffle=on -timeout=15m -count=1 ./tool/...` all pass locally, run from a clean scratch checkout.

`make lint` was checked with golangci-lint **v2.11.3**, the version `.github/workflows/lint-golang.yaml` pins, run across the whole repo the way CI invokes it — 0 issues.

The integration and e2e halves of `make test` were verified through this PR's CI jobs rather than locally, since the testcontainers-based suites had no usable Docker host here.

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality (N/A — pure rename, no behaviour change)
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
