### PR TITLE
fix(tool/internal/setup): ensure deterministic rule load order

### DIFF
--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -62,7 +62,8 @@ func parseRuleFromYaml(content []byte) ([]rule.InstRule, error) {
 		return nil, ex.Wrap(err)
 	}
 	rules := make([]rule.InstRule, 0)
-	for name, fields := range h {
+	for _, name := range slices.Sorted(maps.Keys(h)) {
+		fields := h[name]
 		flatRules, normErr := rule.Normalize(fields)
 		if normErr != nil {
 			return nil, normErr
@@ -477,7 +478,15 @@ func loadCustomRules(ruleConfig string) ([]rule.InstRule, error) {
 		}
 	}
 
-	return slices.Concat(slices.Collect(maps.Values(ruleSet))...), nil
+	total := 0
+	for _, rules := range ruleSet {
+		total += len(rules)
+	}
+	result := make([]rule.InstRule, 0, total)
+	for _, name := range slices.Sorted(maps.Keys(ruleSet)) {
+		result = append(result, ruleSet[name]...)
+	}
+	return result, nil
 }
 
 func loadRulesFromToolFiles(ctx context.Context, toolFiles []string) ([]rule.InstRule, error) {

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -1168,6 +1168,60 @@ func Target(value string) error { return nil }
 	assert.Equal(t, "matching", matchedFuncRules[0].Name)
 }
 
+func TestParseRuleFromYamlDeterministicOrder(t *testing.T) {
+	yamlContent := []byte(`
+zebra:
+  target: main
+  func: Example
+  raw: "_ = 1"
+alpha:
+  target: main
+  func: Example
+  raw: "_ = 1"
+mangle:
+  target: main
+  func: Example
+  raw: "_ = 1"
+`)
+
+	rules, err := parseRuleFromYaml(yamlContent)
+	require.NoError(t, err)
+	require.Len(t, rules, 3)
+
+	names := make([]string, len(rules))
+	for i, r := range rules {
+		names[i] = r.GetName()
+	}
+	require.Equal(t, []string{"alpha", "mangle", "zebra"}, names)
+}
+
+func TestLoadCustomRulesDeterministicOrder(t *testing.T) {
+	content := `zebra:
+  target: main
+  func: Example
+  raw: "_ = 1"
+alpha:
+  target: main
+  func: Example
+  raw: "_ = 1"
+mangle:
+  target: main
+  func: Example
+  raw: "_ = 1"`
+
+	p := writeCustomRules(t, "order.yaml", content)
+
+	rules, err := loadCustomRules(p)
+	require.NoError(t, err)
+	require.Len(t, rules, 3)
+
+	names := make([]string, len(rules))
+	for i, r := range rules {
+		names[i] = r.GetName()
+	}
+	require.Equal(t, []string{"alpha", "mangle", "zebra"}, names)
+}
+
 func TestRunMatch_EmptyRules(t *testing.T) {
 	dep := &Dependency{
 		ImportPath: "example.com/noop",


### PR DESCRIPTION
<!--
Thank you for contributing to OpenTelemetry Go Compile Instrumentation!

INSTRUCTIONS:
1. Fill in the description and motivation sections below
2. Complete the checklist before submitting
3. Ensure PR title follows conventional commits format (enforced by CI)

PR TITLE FORMAT (required):
  type(scope): description

  Types: chore, doc, docs, feat, fix, release, refactor, test
  Scopes: tool, pkg, demo, test, docs

  Examples:
  - feat(pkg): add gRPC client instrumentation
  - fix(tool): resolve hook signature matching issue
  - docs(api): update instrumenter interface documentation
  - refactor(pkg): simplify attribute extractor composition

BEFORE SUBMITTING:
  make format  # Format Go code and YAML files
  make lint    # Run all linters
  make test    # Run all tests (unit + integration + e2e)

If your PR adds a new user-facing instrumentation, please also submit a corresponding OpenTelemetry Registry PR:
https://opentelemetry.io/ecosystem/registry/adding/

For detailed contribution guidelines, see CONTRIBUTING.md
For available make targets, run: make help
-->

## Description

`parseRuleFromYaml` iterates over a Go map (`for name, fields := range h`) which has nondeterministic iteration order. This causes rule application order to vary across runs, leading to non-reproducible instrumentation behavior. Similarly, `loadCustomRules` collects rule values via `slices.Concat(slices.Collect(maps.Values(ruleSet))...)` which also depends on map iteration order.

Both functions now iterate over map keys in sorted (lexicographic) order using `slices.Sorted(maps.Keys(...))`.

## Motivation

Reproducible builds and deterministic instrumentation output are important for debugging and correctness. With nondeterministic map iteration, the same YAML rule file can produce different instrumentation results across runs.

Fixes #1144

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
