### PR TITLE
fix(tool): exclude OS junk files from otelc bundle archive

### DIFF
--- a/.tools/bundle/main.go
+++ b/.tools/bundle/main.go
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // bundle creates a reproducible .tar.gz archive from the given directories,
-// excluding *.log files. It replaces platform-dependent tar invocations to
-// produce consistent archives across platforms.
+// excluding *.log files and OS-generated junk files such as .DS_Store. It
+// replaces platform-dependent tar invocations to produce consistent archives
+// across platforms.
 // More information: https://reproducible-builds.org/docs/archives/
 package main
 
@@ -135,9 +136,25 @@ func addDir(tw *tar.Writer, dirPath, nameInArchive string) error {
 	})
 }
 
+// junkFileNames are exact filenames that OSes and local tooling create
+// incidentally (e.g. macOS Finder writes .DS_Store as soon as a directory is
+// browsed). They carry no source content, are already listed in .gitignore
+// so they never show up in git status or diffs, but the walk in addDir reads
+// the filesystem directly and would otherwise archive them if they happen to
+// be present on disk, making the archive depend on what the machine that ran
+// "make package" had lying around rather than on tracked source.
+var junkFileNames = map[string]bool{
+	".DS_Store":   true,
+	"Thumbs.db":   true,
+	"desktop.ini": true,
+}
+
 // shouldExclude reports whether an archive entry should be omitted.
 func shouldExclude(name string) bool {
-	return strings.HasSuffix(name, ".log")
+	if strings.HasSuffix(name, ".log") {
+		return true
+	}
+	return junkFileNames[filepath.Base(name)]
 }
 
 // isEffectivelyEmpty reports whether a directory is effectively empty,

--- a/.tools/bundle/main_test.go
+++ b/.tools/bundle/main_test.go
@@ -8,6 +8,7 @@ import (
 	"compress/gzip"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -59,6 +60,35 @@ func TestArchive_ExcludesOSJunk(t *testing.T) {
 	}
 	if !containsSuffix(names, "client.go") {
 		t.Errorf("archive is missing expected source file, got entries: %v", names)
+	}
+}
+
+// TestArchive_PrunesJunkOnlyDir verifies a directory containing only OS junk
+// is treated as effectively empty and omitted from the archive, matching
+// git's behavior for directories with no tracked content.
+func TestArchive_PrunesJunkOnlyDir(t *testing.T) {
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "client.go"), []byte("package redis\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	junkOnlyDir := filepath.Join(srcDir, "empty")
+	if err := os.Mkdir(junkOnlyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(junkOnlyDir, ".DS_Store"), []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "out.tgz")
+	if err := archive(outPath, []string{srcDir}); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	names := readTarNames(t, outPath)
+	for _, name := range names {
+		if strings.Contains(name, "empty") {
+			t.Errorf("archive contains junk-only directory %q, want it pruned", name)
+		}
 	}
 }
 

--- a/.tools/bundle/main_test.go
+++ b/.tools/bundle/main_test.go
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestShouldExclude(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"instrumentation/redis/.DS_Store", true},
+		{".DS_Store", true},
+		{"instrumentation/redis/Thumbs.db", true},
+		{"instrumentation/redis/desktop.ini", true},
+		{"instrumentation/redis/build.log", true},
+		{"instrumentation/redis/client.go", false},
+		{"instrumentation/redis/go.sum", false},
+		// only an exact junk filename is excluded, not anything containing it
+		{"instrumentation/redis/not.DS_Store.go", false},
+	}
+
+	for _, tt := range tests {
+		if got := shouldExclude(tt.name); got != tt.want {
+			t.Errorf("shouldExclude(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+// TestArchive_ExcludesOSJunk reproduces the scenario from the bug report: an
+// untracked .DS_Store dropped into a source directory by macOS Finder must
+// not end up in the produced archive.
+func TestArchive_ExcludesOSJunk(t *testing.T) {
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "client.go"), []byte("package redis\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, ".DS_Store"), []byte("junk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "out.tgz")
+	if err := archive(outPath, []string{srcDir}); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	names := readTarNames(t, outPath)
+	for _, name := range names {
+		if filepath.Base(name) == ".DS_Store" {
+			t.Errorf("archive contains excluded junk file %q", name)
+		}
+	}
+	if !containsSuffix(names, "client.go") {
+		t.Errorf("archive is missing expected source file, got entries: %v", names)
+	}
+}
+
+func readTarNames(t *testing.T, path string) []string {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+
+	var names []string
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			break
+		}
+		names = append(names, hdr.Name)
+	}
+	return names
+}
+
+func containsSuffix(names []string, suffix string) bool {
+	for _, name := range names {
+		if filepath.Base(name) == suffix {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fixes #1123

`make package` walks the filesystem, so any untracked file sitting under `pkg/` or `instrumentation/` gets archived even though it's not part of the source. `.DS_Store` is the common case since macOS Finder writes it as soon as a directory is opened, and it's already in `.gitignore` so nothing about it shows up in git status or diffs. The result is a bundle that depends on what happened to be on the machine that ran `make package`, and Verify Bundle fails with no clue why.

This widens `shouldExclude` to also drop `.DS_Store`, `Thumbs.db`, and `desktop.ini` by exact filename, alongside the existing `.log` suffix check. Added a test for `shouldExclude` and one that reproduces the bug report's repro steps directly (archive a dir with a `.DS_Store` in it, check it's not in the output).

## Test plan
- [x] `go test ./...` in `.tools/bundle`
- [x] `make package` still produces a valid archive