### PR TITLE
fix(tool): re-scope recovered generic constraints to receiver names

### DIFF
--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -923,22 +923,24 @@ func extractReceiverTypeParams(file *dst.File, recvType dst.Expr) *dst.FieldList
 		// GenStruct[T] - single type parameter
 		if ident, ok := t.Index.(*dst.Ident); ok {
 			original := findGenericTypeDecl(file, receiverBaseTypeName(t.X))
+			nameMap := receiverNameMap(original, []dst.Expr{t.Index})
 			return &dst.FieldList{
 				List: []*dst.Field{{
 					Names: []*dst.Ident{ident},
-					Type:  receiverConstraintAt(original, 0),
+					Type:  remapConstraintNames(receiverConstraintAt(original, 0), nameMap),
 				}},
 			}
 		}
 	case *dst.IndexListExpr:
 		// GenStruct[T, U, ...] - multiple type parameters
 		original := findGenericTypeDecl(file, receiverBaseTypeName(t.X))
+		nameMap := receiverNameMap(original, t.Indices)
 		fields := make([]*dst.Field, 0, len(t.Indices))
 		for i, idx := range t.Indices {
 			if ident, ok := idx.(*dst.Ident); ok {
 				fields = append(fields, &dst.Field{
 					Names: []*dst.Ident{ident},
-					Type:  receiverConstraintAt(original, i),
+					Type:  remapConstraintNames(receiverConstraintAt(original, i), nameMap),
 				})
 			}
 		}
@@ -947,6 +949,69 @@ func extractReceiverTypeParams(file *dst.File, recvType dst.Expr) *dst.FieldList
 		}
 	}
 	return nil
+}
+
+// receiverNameMap maps a generic type declaration's parameter names to the
+// names the method receiver uses for them. A receiver is free to rename the
+// type parameters (type M[K any, V any] with func (m M[A, B]) M()), and the
+// mapping is positional, so declaration parameter K at position 0 maps to
+// receiver name A. Only genuine renames are recorded; identical names are left
+// out so the returned map is empty in the common case.
+func receiverNameMap(declParams *dst.FieldList, recvArgs []dst.Expr) map[string]string {
+	declNames := typeParamDeclNames(declParams)
+	nameMap := make(map[string]string)
+	for i, arg := range recvArgs {
+		ident, ok := arg.(*dst.Ident)
+		if !ok || i >= len(declNames) {
+			continue
+		}
+		if declNames[i] != "" && declNames[i] != ident.Name {
+			nameMap[declNames[i]] = ident.Name
+		}
+	}
+	return nameMap
+}
+
+// typeParamDeclNames returns a type parameter list's names in positional order,
+// flattening grouped parameters (type M[K, V any] declares K then V).
+func typeParamDeclNames(params *dst.FieldList) []string {
+	if params == nil {
+		return nil
+	}
+	var names []string
+	for _, field := range params.List {
+		if len(field.Names) == 0 {
+			names = append(names, "")
+			continue
+		}
+		for _, name := range field.Names {
+			names = append(names, name.Name)
+		}
+	}
+	return names
+}
+
+// remapConstraintNames rewrites type parameter identifiers inside a constraint
+// so it reads in the receiver's naming rather than the declaration's. An
+// inter-parameter constraint refers to a sibling parameter by the declaration's
+// name (type M[K any, V ~[]K] carries ~[]K on V), and the receiver may have
+// renamed that sibling. Cloning the constraint verbatim would leave the
+// trampoline referring to a name it never declares, so the generated code would
+// not compile; renaming the identifiers keeps every reference in scope. With no
+// renames the constraint is returned untouched.
+func remapConstraintNames(constraint dst.Expr, nameMap map[string]string) dst.Expr {
+	if len(nameMap) == 0 {
+		return constraint
+	}
+	dst.Inspect(constraint, func(node dst.Node) bool {
+		if ident, ok := node.(*dst.Ident); ok {
+			if renamed, found := nameMap[ident.Name]; found {
+				ident.Name = renamed
+			}
+		}
+		return true
+	})
+	return constraint
 }
 
 // receiverBaseTypeName returns the local identifier naming a receiver's generic

--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -1003,11 +1003,40 @@ func remapConstraintNames(constraint dst.Expr, nameMap map[string]string) dst.Ex
 	if len(nameMap) == 0 {
 		return constraint
 	}
+	// Not every identifier inside a constraint references a type parameter.
+	// A qualified type names a package and a symbol (the fmt and Stringer in
+	// fmt.Stringer), and an interface method or struct field declares its own
+	// name. Those positions belong to unrelated symbols that may happen to
+	// match a declaration parameter's name, so renaming them would rewrite the
+	// wrong thing: with type M[Stringer any, V fmt.Stringer] and receiver
+	// M[A, B], a blanket rename turns fmt.Stringer into the nonexistent fmt.A.
+	// Collect them first, then rename only what is left.
+	named := make(map[*dst.Ident]struct{})
 	dst.Inspect(constraint, func(node dst.Node) bool {
-		if ident, ok := node.(*dst.Ident); ok {
-			if renamed, found := nameMap[ident.Name]; found {
-				ident.Name = renamed
+		switch n := node.(type) {
+		case *dst.SelectorExpr:
+			named[n.Sel] = struct{}{}
+			if pkg, ok := n.X.(*dst.Ident); ok {
+				named[pkg] = struct{}{}
 			}
+		case *dst.Field:
+			for _, name := range n.Names {
+				named[name] = struct{}{}
+			}
+		}
+		return true
+	})
+
+	dst.Inspect(constraint, func(node dst.Node) bool {
+		ident, ok := node.(*dst.Ident)
+		if !ok {
+			return true
+		}
+		if _, isName := named[ident]; isName {
+			return true
+		}
+		if renamed, found := nameMap[ident.Name]; found {
+			ident.Name = renamed
 		}
 		return true
 	})

--- a/tool/internal/instrument/trampoline_test.go
+++ b/tool/internal/instrument/trampoline_test.go
@@ -932,3 +932,30 @@ func TestExtractReceiverTypeParamsNestedPointer(t *testing.T) {
 	require.NotNil(t, params)
 	assert.Equal(t, []string{"T"}, typeParamNames(t, params))
 }
+
+// TestExtractReceiverTypeParamsConstraint_RenamedInterParam covers a receiver
+// that renames the type parameters while a constraint refers to a sibling
+// parameter. type M[K any, V ~[]K] used as func (m M[A, B]) must recover V's
+// constraint as ~[]A, following the receiver's names, not the declaration's ~[]K.
+// A verbatim ~[]K would refer to a name the trampoline never declares and would
+// not compile.
+func TestExtractReceiverTypeParamsConstraint_RenamedInterParam(t *testing.T) {
+	file, recvType := parseReceiverTypeWithDecl(t, "",
+		"type M[K any, V ~[]K] struct{ k K; v V }", "M[A, B]")
+
+	params := extractReceiverTypeParams(file, recvType)
+	require.NotNil(t, params)
+	assert.Equal(t, []string{"A", "B"}, typeParamNames(t, params))
+	require.Len(t, params.List, 2)
+
+	// The second parameter's constraint is ~[]A: a ~ over a slice of the first
+	// receiver parameter, re-scoped from the declaration's ~[]K.
+	tilde, ok := params.List[1].Type.(*dst.UnaryExpr)
+	require.True(t, ok, "constraint should be a ~ expression")
+	slice, ok := tilde.X.(*dst.ArrayType)
+	require.True(t, ok, "constraint should be ~[]T")
+	elem, ok := slice.Elt.(*dst.Ident)
+	require.True(t, ok)
+	assert.Equal(t, "A", elem.Name,
+		"inter-parameter constraint must use the receiver name A, not the declaration name K")
+}

--- a/tool/internal/instrument/trampoline_test.go
+++ b/tool/internal/instrument/trampoline_test.go
@@ -881,6 +881,51 @@ func TestExtractReceiverTypeParamsConstraint_MultipleParams(t *testing.T) {
 	}
 }
 
+// TestExtractReceiverTypeParamsConstraint_NameCollision covers a declaration
+// whose type parameter shares its name with the selector of a qualified
+// constraint. Remapping to the receiver's names must rewrite only genuine type
+// parameter references, so fmt.Stringer keeps its selector instead of becoming
+// the nonexistent fmt.A.
+func TestExtractReceiverTypeParamsConstraint_NameCollision(t *testing.T) {
+	file, recvType := parseReceiverTypeWithDecl(t, `import "fmt"`,
+		"type GenStruct[Stringer any, V fmt.Stringer] struct{}",
+		"GenStruct[A, B]")
+
+	params := extractReceiverTypeParams(file, recvType)
+	require.NotNil(t, params)
+	require.Len(t, params.List, 2)
+	assert.Equal(t, []string{"A", "B"}, typeParamNames(t, params))
+
+	sel, ok := params.List[1].Type.(*dst.SelectorExpr)
+	require.True(t, ok, "expected the constraint to be a package-qualified selector")
+	pkgIdent, ok := sel.X.(*dst.Ident)
+	require.True(t, ok)
+	assert.Equal(t, "fmt", pkgIdent.Name)
+	assert.Equal(t, "Stringer", sel.Sel.Name,
+		"the selector names fmt.Stringer and must not be renamed to the receiver's parameter")
+}
+
+// TestExtractReceiverTypeParamsConstraint_MethodNameCollision covers the same
+// hazard for a name a constraint declares rather than references: an interface
+// method whose name matches a type parameter must keep its own name.
+func TestExtractReceiverTypeParamsConstraint_MethodNameCollision(t *testing.T) {
+	file, recvType := parseReceiverTypeWithDecl(t, "",
+		"type GenStruct[T any, V interface{ T() string }] struct{}",
+		"GenStruct[A, B]")
+
+	params := extractReceiverTypeParams(file, recvType)
+	require.NotNil(t, params)
+	require.Len(t, params.List, 2)
+	assert.Equal(t, []string{"A", "B"}, typeParamNames(t, params))
+
+	iface, ok := params.List[1].Type.(*dst.InterfaceType)
+	require.True(t, ok, "expected the constraint to be an interface")
+	require.Len(t, iface.Methods.List, 1)
+	require.Len(t, iface.Methods.List[0].Names, 1)
+	assert.Equal(t, "T", iface.Methods.List[0].Names[0].Name,
+		"the interface declares the method name and must not be renamed")
+}
+
 // TestReceiverBaseTypeName_NonIdent covers the defensive fallback directly: a
 // non-identifier base expression, which no valid Go receiver form actually
 // produces, returns "" rather than panicking.

--- a/tool/internal/instrument/trampoline_test.go
+++ b/tool/internal/instrument/trampoline_test.go
@@ -959,3 +959,22 @@ func TestExtractReceiverTypeParamsConstraint_RenamedInterParam(t *testing.T) {
 	assert.Equal(t, "A", elem.Name,
 		"inter-parameter constraint must use the receiver name A, not the declaration name K")
 }
+
+// TestTypeParamDeclNames covers the positional flattening directly: a nil list
+// yields no names, a grouped field (type M[K, V any] declares K then V under
+// one field) contributes each name in order, and a field with no names, which
+// valid Go does not produce, still advances by one empty slot rather than being
+// dropped.
+func TestTypeParamDeclNames(t *testing.T) {
+	assert.Nil(t, typeParamDeclNames(nil))
+
+	params := &dst.FieldList{
+		List: []*dst.Field{
+			{Names: []*dst.Ident{ast.Ident("K"), ast.Ident("V")}, Type: ast.Ident("any")},
+			{Names: nil, Type: ast.Ident("comparable")},
+			{Names: []*dst.Ident{ast.Ident("T")}, Type: ast.Ident("any")},
+		},
+	}
+
+	assert.Equal(t, []string{"K", "V", "", "T"}, typeParamDeclNames(params))
+}

--- a/tool/internal/instrument/trampoline_test.go
+++ b/tool/internal/instrument/trampoline_test.go
@@ -926,6 +926,30 @@ func TestExtractReceiverTypeParamsConstraint_MethodNameCollision(t *testing.T) {
 		"the interface declares the method name and must not be renamed")
 }
 
+// TestExtractReceiverTypeParamsConstraint_SingleParamNameCollision covers the
+// single type parameter path, which builds its field list separately from the
+// multi-parameter one. A one parameter receiver cannot carry an inter-parameter
+// constraint, having no sibling to reference, but it can still collide with the
+// selector of its own qualified constraint.
+func TestExtractReceiverTypeParamsConstraint_SingleParamNameCollision(t *testing.T) {
+	file, recvType := parseReceiverTypeWithDecl(t, `import "fmt"`,
+		"type GenStruct[Stringer fmt.Stringer] struct{}",
+		"GenStruct[A]")
+
+	params := extractReceiverTypeParams(file, recvType)
+	require.NotNil(t, params)
+	require.Len(t, params.List, 1)
+	assert.Equal(t, []string{"A"}, typeParamNames(t, params))
+
+	sel, ok := params.List[0].Type.(*dst.SelectorExpr)
+	require.True(t, ok, "expected the constraint to be a package-qualified selector")
+	pkgIdent, ok := sel.X.(*dst.Ident)
+	require.True(t, ok)
+	assert.Equal(t, "fmt", pkgIdent.Name)
+	assert.Equal(t, "Stringer", sel.Sel.Name,
+		"the selector names fmt.Stringer and must not be renamed to the receiver's parameter")
+}
+
 // TestReceiverBaseTypeName_NonIdent covers the defensive fallback directly: a
 // non-identifier base expression, which no valid Go receiver form actually
 // produces, returns "" rather than panicking.


### PR DESCRIPTION
## Description

`extractReceiverTypeParams` recovers a generic type parameter constraint from the receiver's own type declaration and attaches it to the receiver's parameter name. When the receiver renames a parameter, an inter-parameter constraint kept the declaration's name instead of the receiver's.

Concretely, for:

```go
type M[K any, V ~[]K] struct{ /* ... */ }

func (m M[A, B]) InstrumentedMethod() { /* ... */ }
```

the recovered type parameter list came out as `[A any, B ~[]K]`. The `~[]K` refers to `K`, which the generated trampoline never declares (it declares `A` and `B`), so the emitted code fails to compile with `undefined: K`.

The fix maps the declaration's parameter names to the receiver's names positionally (`K -> A`, `V -> B`), then rewrites the identifiers inside each recovered constraint, so `~[]K` becomes `~[]A` and every reference stays in scope. Constraints with no rename are returned untouched, so the common case allocates nothing extra.

## Motivation

A receiver is free to rename a generic type's parameters, and constraints that reference a sibling parameter (`~[]K`, `map[K]V`, and similar) are common on container types. Without this, instrumenting a method on such a type emits code that does not build, which fails the whole compile-time rewrite for that package.

New unit test `TestExtractReceiverTypeParamsConstraint_RenamedInterParam` covers the renamed receiver with an inter-parameter constraint and asserts the recovered constraint reads `~[]A`.

Fixes #1169

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.