### PR TITLE
fix(tool): centralize rule file name matching

### DIFF
--- a/.github/workflows/test-latestlibbuild.yaml
+++ b/.github/workflows/test-latestlibbuild.yaml
@@ -30,6 +30,8 @@ jobs:
               - 'Makefile'
               - 'tool/**'
               - 'pkg/**'
+              - 'instrumentation/**/*.yaml'
+              - 'instrumentation/**/*.yml'
               - 'test/**'
               - '.github/workflows/test-latestlibbuild.yaml'
 

--- a/test/testutil/latestlib.go
+++ b/test/testutil/latestlib.go
@@ -36,7 +36,7 @@ type yamlRule struct {
 	Version string `yaml:"version"`
 }
 
-// InstrumentedTargets walks rulesRoot, parses every *.yaml file as an
+// InstrumentedTargets walks rulesRoot, parses every otelc rule file as an
 // instrumentation rule set, and returns instrumented targets mapped
 // to their supported version ranges.
 func InstrumentedTargets(t *testing.T, rulesRoot string) map[string][]string {
@@ -45,7 +45,7 @@ func InstrumentedTargets(t *testing.T, rulesRoot string) map[string][]string {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() || filepath.Ext(path) != ".yaml" {
+		if d.IsDir() || !util.IsRuleFileName(d.Name()) {
 			return nil
 		}
 		data, readErr := os.ReadFile(path) //nolint:gosec

--- a/test/testutil/latestlib.go
+++ b/test/testutil/latestlib.go
@@ -45,7 +45,7 @@ func InstrumentedTargets(t *testing.T, rulesRoot string) map[string][]string {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() || !util.IsRuleFileName(d.Name()) {
+		if d.IsDir() || !util.IsRuleFile(d.Name()) {
 			return nil
 		}
 		data, readErr := os.ReadFile(path) //nolint:gosec

--- a/test/testutil/latestlib_test.go
+++ b/test/testutil/latestlib_test.go
@@ -11,6 +11,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestInstrumentedTargets(t *testing.T) {
+	rulesRoot := t.TempDir()
+	ruleFiles := map[string]string{
+		"otelc.yaml":        "example.com/yaml",
+		"otelc.yml":         "example.com/yml",
+		"client.otelc.yaml": "example.com/prefixed-yaml",
+		"server.otelc.yml":  "example.com/prefixed-yml",
+	}
+
+	for filename, target := range ruleFiles {
+		content := "rule:\n  target: " + target + "\n  version: v1.0.0\n"
+		require.NoError(t, os.WriteFile(filepath.Join(rulesRoot, filename), []byte(content), 0o600))
+	}
+
+	// Unrelated YAML files are not otelc rule files and must be ignored.
+	require.NoError(t, os.WriteFile(filepath.Join(rulesRoot, "rules.yaml"), []byte("invalid: ["), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(rulesRoot, "rules.yml"), []byte("invalid: ["), 0o600))
+
+	targets := InstrumentedTargets(t, rulesRoot)
+	require.Len(t, targets, len(ruleFiles))
+	for _, target := range ruleFiles {
+		require.Equal(t, []string{"v1.0.0"}, targets[target])
+	}
+}
+
 func TestFindMatchingVersionRanges(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/tool/internal/manifest/manifest.go
+++ b/tool/internal/manifest/manifest.go
@@ -17,6 +17,7 @@ import (
 
 	"go.opentelemetry.io/otelc/tool/data"
 	"go.opentelemetry.io/otelc/tool/ex"
+	"go.opentelemetry.io/otelc/tool/util"
 )
 
 // Entry describes a distinct instrumentation module, target package, and
@@ -119,7 +120,7 @@ func loadModuleEntries(moduleDir, modulePath string) (Manifest, error) {
 			}
 			return nil
 		}
-		if !isRuleFile(d.Name()) {
+		if !util.IsRuleFileName(d.Name()) {
 			return nil
 		}
 
@@ -147,11 +148,4 @@ func loadModuleEntries(moduleDir, modulePath string) (Manifest, error) {
 		return nil, ex.Wrapf(err, "loading rules for module %s", modulePath)
 	}
 	return entries, nil
-}
-
-func isRuleFile(name string) bool {
-	return name == "otelc.yml" ||
-		name == "otelc.yaml" ||
-		strings.HasSuffix(name, ".otelc.yml") ||
-		strings.HasSuffix(name, ".otelc.yaml")
 }

--- a/tool/internal/manifest/manifest.go
+++ b/tool/internal/manifest/manifest.go
@@ -120,7 +120,7 @@ func loadModuleEntries(moduleDir, modulePath string) (Manifest, error) {
 			}
 			return nil
 		}
-		if !util.IsRuleFileName(d.Name()) {
+		if !util.IsRuleFile(d.Name()) {
 			return nil
 		}
 

--- a/tool/internal/manifest/manifest_test.go
+++ b/tool/internal/manifest/manifest_test.go
@@ -126,26 +126,6 @@ func TestLoadModuleEntriesRejectsEscapingRuleSymlink(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestIsRuleFile(t *testing.T) {
-	tests := map[string]bool{
-		"otelc.yaml":        true,
-		"otelc.yml":         true,
-		"client.otelc.yaml": true,
-		"server.otelc.yml":  true,
-		"rules.yaml":        false,
-		"otelc.client.yaml": false,
-		"otelc":             false,
-		"otelc.txt":         false,
-		"otelc.yaml.bak":    false,
-	}
-
-	for filename, expected := range tests {
-		t.Run(filename, func(t *testing.T) {
-			assert.Equal(t, expected, isRuleFile(filename))
-		})
-	}
-}
-
 func TestLoad(t *testing.T) {
 	got, err := Load()
 	require.NoError(t, err)

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -406,7 +406,7 @@ func rulesFromDir(path string, skipSubmodules bool) ([]string, error) {
 			return filepath.SkipDir
 		}
 
-		if !d.IsDir() && util.IsRuleFileName(d.Name()) {
+		if !d.IsDir() && util.IsRuleFile(d.Name()) {
 			filesToProcess = append(filesToProcess, p)
 		}
 

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -99,15 +99,6 @@ func parseRuleFromYaml(content []byte) ([]rule.InstRule, error) {
 	return rules, nil
 }
 
-// isRuleFile checks if the given file name matches the following patterns:
-// otelc.yml, otelc.yaml, *.otelc.yml, *.otelc.yaml
-func isRuleFile(name string) bool {
-	return (name == "otelc.yml" ||
-		name == "otelc.yaml" ||
-		strings.HasSuffix(name, ".otelc.yml") ||
-		strings.HasSuffix(name, ".otelc.yaml"))
-}
-
 func matchVersion(dependency *Dependency, rule rule.InstRule) bool {
 	return util.VersionInRange(dependency.Version, rule.GetVersion())
 }
@@ -415,7 +406,7 @@ func rulesFromDir(path string, skipSubmodules bool) ([]string, error) {
 			return filepath.SkipDir
 		}
 
-		if !d.IsDir() && isRuleFile(d.Name()) {
+		if !d.IsDir() && util.IsRuleFileName(d.Name()) {
 			filesToProcess = append(filesToProcess, p)
 		}
 

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -603,29 +603,6 @@ func TestDoSequenceLoadsAllExpandedRules(t *testing.T) {
 	require.Len(t, rules, 2)
 }
 
-func TestIsRuleFile(t *testing.T) {
-	tests := []struct {
-		filename string
-		expected bool
-	}{
-		{"otelc.yaml", true},
-		{"otelc.yml", true},
-		{"client.otelc.yaml", true},
-		{"server.otelc.yml", true},
-		{"rules.yaml", false},
-		{"otelc.client.yaml", false},
-		{"otelc", false},
-		{"otelc.txt", false},
-		{"otelc.yaml.bak", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.filename, func(t *testing.T) {
-			assert.Equal(t, tt.expected, isRuleFile(tt.filename))
-		})
-	}
-}
-
 func TestLoadRulesFromToolFiles(t *testing.T) {
 	t.Run("loads rules from tool files", func(t *testing.T) {
 		tmp := t.TempDir()

--- a/tool/internal/setup/pin.go
+++ b/tool/internal/setup/pin.go
@@ -186,7 +186,7 @@ func loadModuleRules(moduleDir, module string, loaded map[string][]yamlRule) err
 			return nil
 		}
 
-		if !isRuleFile(d.Name()) {
+		if !util.IsRuleFileName(d.Name()) {
 			return nil
 		}
 

--- a/tool/internal/setup/pin.go
+++ b/tool/internal/setup/pin.go
@@ -186,7 +186,7 @@ func loadModuleRules(moduleDir, module string, loaded map[string][]yamlRule) err
 			return nil
 		}
 
-		if !util.IsRuleFileName(d.Name()) {
+		if !util.IsRuleFile(d.Name()) {
 			return nil
 		}
 

--- a/tool/util/shared.go
+++ b/tool/util/shared.go
@@ -36,6 +36,14 @@ const (
 	OtelcToolExe           = "otelc"
 )
 
+// IsRuleFileName reports whether name identifies an otelc rule file.
+func IsRuleFileName(name string) bool {
+	return name == "otelc.yml" ||
+		name == "otelc.yaml" ||
+		strings.HasSuffix(name, ".otelc.yml") ||
+		strings.HasSuffix(name, ".otelc.yaml")
+}
+
 func GetMatchedRuleFile() string {
 	const matchedRuleFile = "matched.json"
 	return GetBuildTemp(matchedRuleFile)

--- a/tool/util/shared.go
+++ b/tool/util/shared.go
@@ -36,8 +36,8 @@ const (
 	OtelcToolExe           = "otelc"
 )
 
-// IsRuleFileName reports whether name identifies an otelc rule file.
-func IsRuleFileName(name string) bool {
+// IsRuleFile reports whether name identifies an otelc rule file.
+func IsRuleFile(name string) bool {
 	return name == "otelc.yml" ||
 		name == "otelc.yaml" ||
 		strings.HasSuffix(name, ".otelc.yml") ||

--- a/tool/util/shared_test.go
+++ b/tool/util/shared_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsRuleFileName(t *testing.T) {
+func TestIsRuleFile(t *testing.T) {
 	tests := map[string]bool{
 		"otelc.yaml":        true,
 		"otelc.yml":         true,
@@ -30,7 +30,7 @@ func TestIsRuleFileName(t *testing.T) {
 
 	for filename, expected := range tests {
 		t.Run(filename, func(t *testing.T) {
-			assert.Equal(t, expected, IsRuleFileName(filename))
+			assert.Equal(t, expected, IsRuleFile(filename))
 		})
 	}
 }

--- a/tool/util/shared_test.go
+++ b/tool/util/shared_test.go
@@ -14,6 +14,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsRuleFileName(t *testing.T) {
+	tests := map[string]bool{
+		"otelc.yaml":        true,
+		"otelc.yml":         true,
+		"client.otelc.yaml": true,
+		"server.otelc.yml":  true,
+		"rules.yaml":        false,
+		"rules.yml":         false,
+		"otelc.client.yaml": false,
+		"otelc":             false,
+		"otelc.txt":         false,
+		"otelc.yaml.bak":    false,
+	}
+
+	for filename, expected := range tests {
+		t.Run(filename, func(t *testing.T) {
+			assert.Equal(t, expected, IsRuleFileName(filename))
+		})
+	}
+}
+
 func TestVersionInRange(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary

Centralize otelc rule-file name matching so setup, pin discovery, manifest generation, and latest-library compatibility tests recognize the same files.

Previously, setup and manifest generation maintained duplicate filename checks, while `InstrumentedTargets` accepted every `.yaml` file and ignored valid `.yml` rule files.

## Changes

- Add a shared matcher for:
  - `otelc.yaml`
  - `otelc.yml`
  - `*.otelc.yaml`
  - `*.otelc.yml`
- Use the shared matcher in setup, pin discovery, manifest generation, and latest-library scanning
- Ignore unrelated YAML files during latest-library rule discovery
- Add focused coverage for valid and invalid filenames
- Run LatestLibBuild when instrumentation YAML or YML files change
- Remove duplicate matcher tests from setup and manifest packages

## Testing

- `go test ./tool/util ./tool/internal/setup ./tool/internal/manifest -count=1`
- `go -C test test ./testutil/... -count=1`
- `make test-unit/tool`
- `make test-unit/helper`
- `make lint/action`
- `make lint/yaml`
- `git diff --check`
