### PR TITLE
fix(tool/internal/instrument): handle invalid regex pattern gracefully in insertRaw (#1166)

### DIFF
--- a/tool/internal/instrument/apply_raw.go
+++ b/tool/internal/instrument/apply_raw.go
@@ -130,7 +130,10 @@ func insertRaw(ctx context.Context, r *rule.InstRawRule, decl *dst.FuncDecl, roo
 			return ex.Wrapf(restoreErr, "failed to restore the AST")
 		}
 
-		pattern := regexp.MustCompile(r.Pattern)
+		pattern, err := regexp.Compile(r.Pattern)
+		if err != nil {
+			return ex.Wrapf(err, "invalid raw rule pattern %q", r.Pattern)
+		}
 		pos := insertPos{
 			pattern:   pattern,
 			placement: r.Placement,

--- a/tool/internal/instrument/apply_raw.go
+++ b/tool/internal/instrument/apply_raw.go
@@ -130,9 +130,9 @@ func insertRaw(ctx context.Context, r *rule.InstRawRule, decl *dst.FuncDecl, roo
 			return ex.Wrapf(restoreErr, "failed to restore the AST")
 		}
 
-		pattern, err := regexp.Compile(r.Pattern)
-		if err != nil {
-			return ex.Wrapf(err, "invalid raw rule pattern %q", r.Pattern)
+		pattern, compileErr := regexp.Compile(r.Pattern)
+		if compileErr != nil {
+			return ex.Wrapf(compileErr, "invalid raw rule pattern %q", r.Pattern)
 		}
 		pos := insertPos{
 			pattern:   pattern,

--- a/tool/internal/instrument/apply_raw_test.go
+++ b/tool/internal/instrument/apply_raw_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dave/dst/decorator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otelc/tool/internal/rule"
 	"go.opentelemetry.io/otelc/tool/util"
 )
 
@@ -283,3 +284,29 @@ func a() {
 		})
 	}
 }
+
+func TestInsertRawInvalidRegexPattern(t *testing.T) {
+	ctx := util.ContextWithLogger(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", "package main\nfunc main() {}", parser.ParseComments)
+	require.NoError(t, err)
+
+	dec := decorator.NewDecorator(fset)
+	dstFile, err := dec.DecorateFile(f)
+	require.NoError(t, err)
+
+	fn := dstFile.Decls[0].(*dst.FuncDecl)
+
+	rawRule := &rule.InstRawRule{
+		InstBaseRule: rule.InstBaseRule{Name: "invalid-regex"},
+		Func:         "main",
+		Raw:          `println("test")`,
+		Pattern:      `[unclosed-bracket`,
+	}
+
+	err = insertRaw(ctx, rawRule, fn, dstFile)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid raw rule pattern")
+}
+

--- a/tool/internal/instrument/apply_raw_test.go
+++ b/tool/internal/instrument/apply_raw_test.go
@@ -286,7 +286,7 @@ func a() {
 }
 
 func TestInsertRawInvalidRegexPattern(t *testing.T) {
-	ctx := util.ContextWithLogger(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := util.ContextWithLogger(context.Background(), slog.New(slog.DiscardHandler))
 
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "", "package main\nfunc main() {}", parser.ParseComments)
@@ -309,4 +309,3 @@ func TestInsertRawInvalidRegexPattern(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid raw rule pattern")
 }
-


### PR DESCRIPTION
## Description

In `tool/internal/instrument/apply_raw.go`, `insertRaw()` parses and applies raw instrumentation rules to target functions. When a raw rule specifies a statement-matching regex pattern (`r.Pattern`), `insertRaw()` compiled the regular expression using `regexp.MustCompile(r.Pattern)`. If an invalid regex pattern was provided, this caused a panic rather than returning an error.

This PR replaces `regexp.MustCompile(r.Pattern)` with `regexp.Compile(r.Pattern)` and returns a wrapped error if compilation fails. Unit tests have also been added in `apply_raw_test.go` to verify this error handling.

Fixes #1166

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
