### PR TITLE
fix(ci): propagate change detection failures

### DIFF
--- a/.github/workflows/check-consistency.yaml
+++ b/.github/workflows/check-consistency.yaml
@@ -114,21 +114,36 @@ jobs:
     steps:
       - name: Check result
         run: |
+          changes_result="${{ needs.changes.result }}"
+          code_changed="${{ needs.changes.outputs.code }}"
           api_result="${{ needs.check-api-sync.result }}"
           golden_result="${{ needs.check-golden-files.result }}"
           mod_tidy_result="${{ needs.check-mod-tidy.result }}"
           manifest_result="${{ needs.verify-manifest.result }}"
+          echo "Changes result: $changes_result"
+          echo "Code changed: $code_changed"
           echo "api-sync result: $api_result"
           echo "golden-files result: $golden_result"
           echo "mod-tidy result: $mod_tidy_result"
           echo "manifest result: $manifest_result"
-          if [[ ("$api_result" == "success" || "$api_result" == "skipped") && \
-                ("$golden_result" == "success" || "$golden_result" == "skipped") && \
-                ("$mod_tidy_result" == "success" || "$mod_tidy_result" == "skipped") && \
-                ("$manifest_result" == "success" || "$manifest_result" == "skipped") ]]; then
-            echo "✅ Consistency checks passed or were skipped"
-            exit 0
-          else
-            echo "❌ Consistency checks failed"
+          if [[ "$changes_result" != "success" ]]; then
+            echo "❌ Change detection failed"
             exit 1
           fi
+          if [[ "$code_changed" == "false" ]]; then
+            echo "✅ No relevant code changes; consistency checks skipped"
+            exit 0
+          fi
+          if [[ "$code_changed" != "true" ]]; then
+            echo "❌ Unexpected change detection output: $code_changed"
+            exit 1
+          fi
+          if [[ "$api_result" == "success" && \
+                "$golden_result" == "success" && \
+                "$mod_tidy_result" == "success" && \
+                "$manifest_result" == "success" ]]; then
+            echo "✅ Consistency checks passed"
+            exit 0
+          fi
+          echo "❌ Consistency checks failed"
+          exit 1

--- a/.github/workflows/check-license-headers.yaml
+++ b/.github/workflows/check-license-headers.yaml
@@ -50,12 +50,27 @@ jobs:
     steps:
       - name: Check result
         run: |
-          result="${{ needs.check-license-headers.result }}"
-          echo "Test result: $result"
-          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
-            echo "✅ Tests passed or were skipped"
-            exit 0
-          else
-            echo "❌ Tests failed"
+          changes_result="${{ needs.changes.result }}"
+          code_changed="${{ needs.changes.outputs.code }}"
+          license_result="${{ needs.check-license-headers.result }}"
+          echo "Changes result: $changes_result"
+          echo "Code changed: $code_changed"
+          echo "License result: $license_result"
+          if [[ "$changes_result" != "success" ]]; then
+            echo "❌ Change detection failed"
             exit 1
           fi
+          if [[ "$code_changed" == "false" ]]; then
+            echo "✅ No relevant code changes; license check skipped"
+            exit 0
+          fi
+          if [[ "$code_changed" != "true" ]]; then
+            echo "❌ Unexpected change detection output: $code_changed"
+            exit 1
+          fi
+          if [[ "$license_result" == "success" ]]; then
+            echo "✅ License check passed"
+            exit 0
+          fi
+          echo "❌ License check failed"
+          exit 1

--- a/.github/workflows/lint-golang.yaml
+++ b/.github/workflows/lint-golang.yaml
@@ -59,12 +59,27 @@ jobs:
     steps:
       - name: Check result
         run: |
-          result="${{ needs.golangci-lint.result }}"
-          echo "Test result: $result"
-          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
-            echo "✅ Tests passed or were skipped"
-            exit 0
-          else
-            echo "❌ Tests failed"
+          changes_result="${{ needs.changes.result }}"
+          code_changed="${{ needs.changes.outputs.code }}"
+          lint_result="${{ needs.golangci-lint.result }}"
+          echo "Changes result: $changes_result"
+          echo "Code changed: $code_changed"
+          echo "Lint result: $lint_result"
+          if [[ "$changes_result" != "success" ]]; then
+            echo "❌ Change detection failed"
             exit 1
           fi
+          if [[ "$code_changed" == "false" ]]; then
+            echo "✅ No relevant code changes; lint skipped"
+            exit 0
+          fi
+          if [[ "$code_changed" != "true" ]]; then
+            echo "❌ Unexpected change detection output: $code_changed"
+            exit 1
+          fi
+          if [[ "$lint_result" == "success" ]]; then
+            echo "✅ Lint passed"
+            exit 0
+          fi
+          echo "❌ Lint failed"
+          exit 1

--- a/.github/workflows/test-latestlibbuild.yaml
+++ b/.github/workflows/test-latestlibbuild.yaml
@@ -76,12 +76,27 @@ jobs:
     steps:
       - name: Check result
         run: |
-          result="${{ needs.test-latestlibbuild.result }}"
-          echo "Test result: $result"
-          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
-            echo "✅ Tests passed or were skipped"
-            exit 0
-          else
-            echo "❌ Tests failed"
+          changes_result="${{ needs.changes.result }}"
+          code_changed="${{ needs.changes.outputs.code }}"
+          latestlibbuild_result="${{ needs.test-latestlibbuild.result }}"
+          echo "Changes result: $changes_result"
+          echo "Code changed: $code_changed"
+          echo "LatestLibBuild result: $latestlibbuild_result"
+          if [[ "$changes_result" != "success" ]]; then
+            echo "❌ Change detection failed"
             exit 1
           fi
+          if [[ "$code_changed" == "false" ]]; then
+            echo "✅ No relevant code changes; tests skipped"
+            exit 0
+          fi
+          if [[ "$code_changed" != "true" ]]; then
+            echo "❌ Unexpected change detection output: $code_changed"
+            exit 1
+          fi
+          if [[ "$latestlibbuild_result" == "success" ]]; then
+            echo "✅ Tests passed"
+            exit 0
+          fi
+          echo "❌ Tests failed"
+          exit 1

--- a/.github/workflows/verify-bundle.yaml
+++ b/.github/workflows/verify-bundle.yaml
@@ -49,12 +49,27 @@ jobs:
     steps:
       - name: Check result
         run: |
-          result="${{ needs.verify-bundle.result }}"
-          echo "Test result: $result"
-          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
-            echo "✅ Tests passed or were skipped"
-            exit 0
-          else
-            echo "❌ Tests failed"
+          changes_result="${{ needs.changes.result }}"
+          bundle_changed="${{ needs.changes.outputs.bundle }}"
+          bundle_result="${{ needs.verify-bundle.result }}"
+          echo "Changes result: $changes_result"
+          echo "Bundle changed: $bundle_changed"
+          echo "Bundle result: $bundle_result"
+          if [[ "$changes_result" != "success" ]]; then
+            echo "❌ Change detection failed"
             exit 1
           fi
+          if [[ "$bundle_changed" == "false" ]]; then
+            echo "✅ No relevant bundle changes; verification skipped"
+            exit 0
+          fi
+          if [[ "$bundle_changed" != "true" ]]; then
+            echo "❌ Unexpected change detection output: $bundle_changed"
+            exit 1
+          fi
+          if [[ "$bundle_result" == "success" ]]; then
+            echo "✅ Bundle verification passed"
+            exit 0
+          fi
+          echo "❌ Bundle verification failed"
+          exit 1


### PR DESCRIPTION
## Description

Update required workflow aggregate jobs so a failed `Detect Changes` job cannot be mistaken for an intentional path-filter skip.

The affected jobs now:

- fail when change detection fails
- pass when change detection succeeds and reports no relevant changes
- reject missing or unexpected filter outputs
- require downstream jobs to succeed when relevant changes are present

This follows the existing pattern in the Unit, Integration, and E2E workflows.

Fixes #1181

## Verification

- `make format/yaml`
- `make lint/yaml`
- `make lint/action`
- `git diff --check`
