### PR TITLE
fix(tool): reject invalid manifest version ranges

### DIFF
--- a/tool/internal/manifest/manifest.go
+++ b/tool/internal/manifest/manifest.go
@@ -136,6 +136,9 @@ func loadModuleEntries(moduleDir, modulePath string) (Manifest, error) {
 			if rule.Target == "" {
 				continue
 			}
+			if validateErr := util.ValidateVersionRange(rule.VersionRange); validateErr != nil {
+				return ex.Wrapf(validateErr, "validating version in rule file %s", path)
+			}
 			entries = append(entries, Entry{
 				ModulePath:   modulePath,
 				Target:       rule.Target,

--- a/tool/internal/manifest/manifest.go
+++ b/tool/internal/manifest/manifest.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -132,12 +133,13 @@ func loadModuleEntries(moduleDir, modulePath string) (Manifest, error) {
 		if unmarshalErr := yaml.Unmarshal(content, &rules); unmarshalErr != nil {
 			return ex.Wrapf(unmarshalErr, "parsing rule file %s", path)
 		}
-		for _, rule := range rules {
+		for _, name := range slices.Sorted(maps.Keys(rules)) {
+			rule := rules[name]
+			if validateErr := util.ValidateVersionRange(rule.VersionRange); validateErr != nil {
+				return ex.Wrapf(validateErr, "validating version for rule %q in file %s", name, path)
+			}
 			if rule.Target == "" {
 				continue
-			}
-			if validateErr := util.ValidateVersionRange(rule.VersionRange); validateErr != nil {
-				return ex.Wrapf(validateErr, "validating version in rule file %s", path)
 			}
 			entries = append(entries, Entry{
 				ModulePath:   modulePath,

--- a/tool/internal/manifest/manifest_test.go
+++ b/tool/internal/manifest/manifest_test.go
@@ -5,6 +5,7 @@ package manifest
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -62,20 +63,80 @@ server:
 	}, got)
 }
 
-func TestGenerateRejectsInvalidVersionRange(t *testing.T) {
+func TestGenerateRejectsInvalidVersionRanges(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		version string
+		wantErr string
+	}{
+		{
+			name:    "empty end bound",
+			target:  "example.com/target",
+			version: "v1.0.0,",
+			wantErr: `version "v1.0.0," must use non-empty start and end bounds`,
+		},
+		{
+			name:    "too many commas",
+			target:  "example.com/target",
+			version: "v1.0.0,v2.0.0,v3.0.0",
+			wantErr: `version "v1.0.0,v2.0.0,v3.0.0" must contain at most one comma`,
+		},
+		{
+			name:    "invalid semver",
+			target:  "example.com/target",
+			version: "not-a-version",
+			wantErr: `version "not-a-version" must be a valid semantic version`,
+		},
+		{
+			name:    "inverted bounds",
+			target:  "example.com/target",
+			version: "v2.0.0,v1.0.0",
+			wantErr: `version "v2.0.0,v1.0.0" must have a lower bound below the upper bound`,
+		},
+		{
+			name:    "empty target",
+			version: "v1.0.0,",
+			wantErr: `version "v1.0.0," must use non-empty start and end bounds`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeModule(t, root, "module", "example.com/test")
+			target := ""
+			if test.target != "" {
+				target = "  target: " + test.target + "\n"
+			}
+			writeRuleFile(t, root, "module/otelc.yaml", fmt.Sprintf("invalid:\n%s  version: %s\n", target, test.version))
+
+			_, err := Generate(root)
+			require.ErrorContains(t, err, test.wantErr)
+			require.ErrorContains(t, err, `validating version for rule "invalid" in file otelc.yaml`)
+			require.ErrorContains(t, err, "loading rules for module example.com/test")
+			require.ErrorContains(t, err, "generating manifest from")
+		})
+	}
+}
+
+func TestGenerateReportsInvalidRulesDeterministically(t *testing.T) {
 	root := t.TempDir()
 	writeModule(t, root, "module", "example.com/test")
 	writeRuleFile(t, root, "module/otelc.yaml", `
-invalid:
-  target: example.com/target
+z-invalid:
+  target: example.com/z
+  version: not-a-version
+a-invalid:
+  target: example.com/a
   version: v1.0.0,
 `)
 
-	_, err := Generate(root)
-	require.ErrorContains(t, err, `version "v1.0.0," must use non-empty start and end bounds`)
-	require.ErrorContains(t, err, "validating version in rule file otelc.yaml")
-	require.ErrorContains(t, err, "loading rules for module example.com/test")
-	require.ErrorContains(t, err, "generating manifest from")
+	for range 10 {
+		_, err := Generate(root)
+		require.ErrorContains(t, err, `validating version for rule "a-invalid" in file otelc.yaml`)
+		require.ErrorContains(t, err, `version "v1.0.0," must use non-empty start and end bounds`)
+	}
 }
 
 func TestGenerateErrors(t *testing.T) {

--- a/tool/internal/manifest/manifest_test.go
+++ b/tool/internal/manifest/manifest_test.go
@@ -34,6 +34,11 @@ empty:
 client:
   target: example.com/client
 `)
+	writeRuleFile(t, root, "parent/ranged.otelc.yaml", `
+ranged:
+  target: example.com/ranged
+  version: v1.0.0,v2.0.0
+`)
 	writeRuleFile(t, root, "parent/ignored.yaml", `
 ignored:
   target: example.com/ignored
@@ -51,9 +56,26 @@ server:
 	require.Equal(t, Manifest{
 		{ModulePath: "example.com/nested", Target: "example.com/server", VersionRange: "v1.5.0"},
 		{ModulePath: "example.com/parent", Target: "example.com/client"},
+		{ModulePath: "example.com/parent", Target: "example.com/ranged", VersionRange: "v1.0.0,v2.0.0"},
 		{ModulePath: "example.com/parent", Target: "example.com/target", VersionRange: "v1.0.0"},
 		{ModulePath: "example.com/parent", Target: "example.com/target", VersionRange: "v2.0.0"},
 	}, got)
+}
+
+func TestGenerateRejectsInvalidVersionRange(t *testing.T) {
+	root := t.TempDir()
+	writeModule(t, root, "module", "example.com/test")
+	writeRuleFile(t, root, "module/otelc.yaml", `
+invalid:
+  target: example.com/target
+  version: v1.0.0,
+`)
+
+	_, err := Generate(root)
+	require.ErrorContains(t, err, `version "v1.0.0," must use non-empty start and end bounds`)
+	require.ErrorContains(t, err, "validating version in rule file otelc.yaml")
+	require.ErrorContains(t, err, "loading rules for module example.com/test")
+	require.ErrorContains(t, err, "generating manifest from")
 }
 
 func TestGenerateErrors(t *testing.T) {

--- a/tool/internal/manifest/manifest_test.go
+++ b/tool/internal/manifest/manifest_test.go
@@ -109,7 +109,12 @@ func TestGenerateRejectsInvalidVersionRanges(t *testing.T) {
 			if test.target != "" {
 				target = "  target: " + test.target + "\n"
 			}
-			writeRuleFile(t, root, "module/otelc.yaml", fmt.Sprintf("invalid:\n%s  version: %s\n", target, test.version))
+			writeRuleFile(
+				t,
+				root,
+				"module/otelc.yaml",
+				fmt.Sprintf("invalid:\n%s  version: %s\n", target, test.version),
+			)
 
 			_, err := Generate(root)
 			require.ErrorContains(t, err, test.wantErr)


### PR DESCRIPTION
## Summary

Validate rule version ranges during manifest generation using the same validation applied during normal rule loading.

Malformed ranges now fail with rule-file context instead of being written to `instrumentation-manifest.json`.

Fixes #1184

## Testing

- `go test -count=1 ./tool/internal/manifest ./tool/util ./tool/internal/setup`
- `go test -shuffle=on -count=1 ./tool/...`
- `make verify-manifest`
- `make lint/license-header`
- `git diff --check`