### PR TITLE
fix(tool/internal/instrument): resolve cross-file generic receiver constraints 

### DIFF
--- a/tool/internal/imports/imports.go
+++ b/tool/internal/imports/imports.go
@@ -106,6 +106,19 @@ func FindNew(ctx context.Context, root *dst.File, ruleImports map[string]string,
 	return result
 }
 
+// ResolveAlias reports the import path alias refers to within root's own
+// import declarations, using the same alias resolution parseFile already
+// performs (explicit aliases, or pkgload.ResolvePackageName for implicit
+// ones). This is used to look up what a package-qualifier in an expression
+// copied out of root (e.g. "constraints" in constraints.Ordered) refers to,
+// when that expression is about to be written into a different file that may
+// not share the same alias for that import path.
+func ResolveAlias(ctx context.Context, root *dst.File, alias string, buildFlags ...string) (string, bool) {
+	m := parseFile(ctx, root, buildFlags...)
+	path, ok := m.AliasToPath[alias]
+	return path, ok
+}
+
 // getExisting returns a map of alias -> path for all imports in the file.
 // For imports without explicit aliases, the package name is used as the key.
 func getExisting(ctx context.Context, root *dst.File, buildFlags ...string) map[string]string {

--- a/tool/internal/imports/imports_test.go
+++ b/tool/internal/imports/imports_test.go
@@ -116,6 +116,67 @@ func TestGetExisting(t *testing.T) {
 	}
 }
 
+func TestResolveAlias(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     *dst.File
+		alias    string
+		wantPath string
+		wantOK   bool
+	}{
+		{
+			name: "explicit alias",
+			root: &dst.File{
+				Decls: []dst.Decl{
+					&dst.GenDecl{
+						Tok: token.IMPORT,
+						Specs: []dst.Spec{
+							&dst.ImportSpec{
+								Name: dst.NewIdent("ctx"),
+								Path: &dst.BasicLit{Value: `"context"`},
+							},
+						},
+					},
+				},
+			},
+			alias:    "ctx",
+			wantPath: "context",
+			wantOK:   true,
+		},
+		{
+			name: "implicit alias resolved from package name",
+			root: &dst.File{
+				Decls: []dst.Decl{
+					&dst.GenDecl{
+						Tok: token.IMPORT,
+						Specs: []dst.Spec{
+							&dst.ImportSpec{Path: &dst.BasicLit{Value: `"net/http"`}},
+						},
+					},
+				},
+			},
+			alias:    "http",
+			wantPath: "net/http",
+			wantOK:   true,
+		},
+		{
+			name:     "alias not found",
+			root:     &dst.File{},
+			alias:    "constraints",
+			wantPath: "",
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, ok := ResolveAlias(t.Context(), tt.root, tt.alias)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantPath, path)
+		})
+	}
+}
+
 func TestCreateSpec(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/tool/internal/instrument/apply_func.go
+++ b/tool/internal/instrument/apply_func.go
@@ -243,7 +243,7 @@ func (ip *instrumentPhase) insertToFunc(funcDecl *dst.FuncDecl, tjump *dst.IfStm
 	}
 }
 
-func (ip *instrumentPhase) insertTJump(t *rule.InstFuncRule, funcDecl *dst.FuncDecl) error {
+func (ip *instrumentPhase) insertTJump(ctx context.Context, t *rule.InstFuncRule, funcDecl *dst.FuncDecl) error {
 	util.Assert(funcDecl.Name.Name == t.Func, "sanity check")
 
 	// Record the target function for the whole trampoline creation process
@@ -297,7 +297,7 @@ func (ip *instrumentPhase) insertTJump(t *rule.InstFuncRule, funcDecl *dst.FuncD
 	// hook context for the real hook code. Once all preparations are done, it
 	// jumps to the real hook code. Note that each trampoline has its own hook
 	// context implementation, which is generated dynamically.
-	return ip.createTrampoline(t)
+	return ip.createTrampoline(ctx, t)
 }
 
 func (ip *instrumentPhase) addCompileArg(newArg string) {
@@ -374,6 +374,11 @@ func (ip *instrumentPhase) parseFile(file string) (*dst.File, error) {
 		return nil, ex.Wrapf(err, "parsing source file %s", file)
 	}
 	ip.target = root
+	abs, err := filepath.Abs(file)
+	if err != nil {
+		return nil, ex.Wrap(err)
+	}
+	ip.targetPath = abs
 	// Every time we parse a file, we need to reset the trampoline jumps
 	// because they are associated with one certain file
 	ip.tjumps = make([]*tJump, 0)
@@ -407,7 +412,7 @@ func (ip *instrumentPhase) applyFuncRule(ctx context.Context, rule *rule.InstFun
 		return nil
 	}
 
-	if err = ip.insertTJump(rule, funcDecl); err != nil {
+	if err = ip.insertTJump(ctx, rule, funcDecl); err != nil {
 		return err
 	}
 	if ip.appliedFuncIdentities == nil {

--- a/tool/internal/instrument/imports.go
+++ b/tool/internal/instrument/imports.go
@@ -10,6 +10,7 @@ import (
 
 	"go.opentelemetry.io/otelc/tool/ex"
 	"go.opentelemetry.io/otelc/tool/internal/imports"
+	"go.opentelemetry.io/otelc/tool/util"
 )
 
 // updateImportConfigForFile ensures all imports in the given file's AST are present in the importcfg.
@@ -27,6 +28,52 @@ func (ip *instrumentPhase) updateImportConfigForFile(ctx context.Context, root *
 	}
 
 	return nil
+}
+
+// injectConstraintImports ensures ip.target has whatever imports fields'
+// constraint expressions reference, when those constraints were recovered from
+// a different file (declFile) than the one they're being written into.
+//
+// The same-file constraint recovery this builds on (see extractReceiverTypeParams)
+// could originally assume any import a constraint needed was already present in
+// the receiver's own file, since that file wouldn't otherwise compile. That
+// assumption breaks once a constraint is recovered from a sibling file: the
+// package qualifier it uses (e.g. "constraints" in constraints.Ordered) may not
+// be imported, or may be imported under a different alias, in ip.target. This
+// resolves each qualifier against declFile and adds whatever's missing to
+// ip.target via the existing addRuleImports machinery, which already handles
+// alias-conflict detection and the importcfg update.
+func (ip *instrumentPhase) injectConstraintImports(
+	ctx context.Context,
+	declFile *dst.File,
+	fields *dst.FieldList,
+) error {
+	if declFile == nil || declFile == ip.target || fields == nil {
+		return nil
+	}
+
+	buildFlags := util.GetBuildFlags()
+	needed := make(map[string]string)
+	for _, field := range fields.List {
+		dst.Inspect(field.Type, func(n dst.Node) bool {
+			sel, ok := n.(*dst.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*dst.Ident)
+			if !ok {
+				return true
+			}
+			if path, found := imports.ResolveAlias(ctx, declFile, ident.Name, buildFlags...); found {
+				needed[ident.Name] = path
+			}
+			return true
+		})
+	}
+	if len(needed) == 0 {
+		return nil
+	}
+	return ip.addRuleImports(ctx, ip.target, needed, "generic-receiver-constraint")
 }
 
 // addRuleImports processes imports for a rule and updates the import config.

--- a/tool/internal/instrument/imports_test.go
+++ b/tool/internal/instrument/imports_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/dave/dst"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otelc/tool/internal/ast"
 )
 
 func TestHandleRuleImports_AliasMismatch(t *testing.T) {
@@ -225,6 +227,191 @@ func TestHandleRuleImports_AliasMismatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fileWithImport builds a minimal *dst.File declaring a single import, with
+// an explicit alias if given, or an implicit one (resolved from path) if not.
+func fileWithImport(alias, path string) *dst.File {
+	spec := &dst.ImportSpec{Path: &dst.BasicLit{Value: `"` + path + `"`}}
+	if alias != "" {
+		spec.Name = dst.NewIdent(alias)
+	}
+	return &dst.File{
+		Decls: []dst.Decl{
+			&dst.GenDecl{Tok: token.IMPORT, Specs: []dst.Spec{spec}},
+		},
+	}
+}
+
+func TestInjectConstraintImports_SameFileNoOp(t *testing.T) {
+	ip := newTestPhase()
+	ip.target = fileWithImport("", "example.com/constraints")
+	fields := &dst.FieldList{List: []*dst.Field{{
+		Names: []*dst.Ident{ast.Ident("T")},
+		Type:  &dst.SelectorExpr{X: ast.Ident("constraints"), Sel: ast.Ident("Ordered")},
+	}}}
+
+	err := ip.injectConstraintImports(t.Context(), ip.target, fields)
+	require.NoError(t, err)
+	// declFile == ip.target must short-circuit before touching imports at all.
+	assert.Len(t, ip.target.Decls, 1, "same-file case must not add a second import decl")
+}
+
+func TestInjectConstraintImports_AddsMissingImport(t *testing.T) {
+	ip := newTestPhase()
+	ip.target = &dst.File{} // no imports yet
+	declFile := fileWithImport("", "fmt")
+	fields := &dst.FieldList{List: []*dst.Field{{
+		Names: []*dst.Ident{ast.Ident("T")},
+		Type:  &dst.SelectorExpr{X: ast.Ident("fmt"), Sel: ast.Ident("Stringer")},
+	}}}
+
+	err := ip.injectConstraintImports(t.Context(), declFile, fields)
+	require.NoError(t, err)
+
+	genDecl, ok := ip.target.Decls[0].(*dst.GenDecl)
+	require.True(t, ok)
+	require.Len(t, genDecl.Specs, 1)
+	spec, ok := genDecl.Specs[0].(*dst.ImportSpec)
+	require.True(t, ok)
+	assert.Equal(t, `"fmt"`, spec.Path.Value)
+}
+
+func TestInjectConstraintImports_CompositeConstraint(t *testing.T) {
+	ip := newTestPhase()
+	ip.target = &dst.File{}
+	declFile := fileWithImport("", "fmt")
+	// A constraint nested inside a slice type: []fmt.Stringer. The qualifier
+	// must still be found by walking the field's type, not just type-asserting
+	// it directly to *dst.SelectorExpr.
+	fields := &dst.FieldList{List: []*dst.Field{{
+		Names: []*dst.Ident{ast.Ident("T")},
+		Type: &dst.ArrayType{
+			Elt: &dst.SelectorExpr{X: ast.Ident("fmt"), Sel: ast.Ident("Stringer")},
+		},
+	}}}
+
+	err := ip.injectConstraintImports(t.Context(), declFile, fields)
+	require.NoError(t, err)
+
+	genDecl, ok := ip.target.Decls[0].(*dst.GenDecl)
+	require.True(t, ok)
+	require.Len(t, genDecl.Specs, 1)
+}
+
+func TestInjectConstraintImports_UnionConstraint(t *testing.T) {
+	ip := newTestPhase()
+	ip.target = &dst.File{}
+	declFile := fileWithImport("", "fmt")
+	// A union constraint referencing a qualified type on one side: T
+	// fmt.Stringer | int. The walk must find the selector inside a
+	// *dst.BinaryExpr, not just inside array/slice element types.
+	fields := &dst.FieldList{List: []*dst.Field{{
+		Names: []*dst.Ident{ast.Ident("T")},
+		Type: &dst.BinaryExpr{
+			X:  &dst.SelectorExpr{X: ast.Ident("fmt"), Sel: ast.Ident("Stringer")},
+			Op: token.OR,
+			Y:  ast.Ident("int"),
+		},
+	}}}
+
+	err := ip.injectConstraintImports(t.Context(), declFile, fields)
+	require.NoError(t, err)
+
+	genDecl, ok := ip.target.Decls[0].(*dst.GenDecl)
+	require.True(t, ok)
+	require.Len(t, genDecl.Specs, 1)
+	spec, ok := genDecl.Specs[0].(*dst.ImportSpec)
+	require.True(t, ok)
+	assert.Equal(t, `"fmt"`, spec.Path.Value)
+}
+
+func TestInjectConstraintImports_MultipleFieldsBatchIntoOneCall(t *testing.T) {
+	ip := newTestPhase()
+	ip.target = &dst.File{}
+	// Both paths are stdlib on purpose: AddToFile's createSpec calls
+	// pkgload.ResolvePackageName to decide whether an alias needs to be
+	// spelled out explicitly, which shells out to the real build system and
+	// fatals the whole process on an unresolvable path (as opposed to
+	// returning an error) -- so a fake or non-stdlib path could crash this
+	// test rather than fail it cleanly, depending on what else the module
+	// graph happens to pull in.
+	declFile := &dst.File{
+		Decls: []dst.Decl{
+			&dst.GenDecl{Tok: token.IMPORT, Specs: []dst.Spec{
+				&dst.ImportSpec{Path: &dst.BasicLit{Value: `"fmt"`}},
+				&dst.ImportSpec{Path: &dst.BasicLit{Value: `"os"`}},
+			}},
+		},
+	}
+	// Two type parameters, each needing a different import, resolved in one
+	// extractReceiverTypeParams-style call -- both should land in ip.target
+	// from a single injectConstraintImports invocation.
+	fields := &dst.FieldList{List: []*dst.Field{
+		{
+			Names: []*dst.Ident{ast.Ident("T")},
+			Type:  &dst.SelectorExpr{X: ast.Ident("fmt"), Sel: ast.Ident("Stringer")},
+		},
+		{
+			Names: []*dst.Ident{ast.Ident("U")},
+			Type:  &dst.SelectorExpr{X: ast.Ident("os"), Sel: ast.Ident("File")},
+		},
+	}}
+
+	err := ip.injectConstraintImports(t.Context(), declFile, fields)
+	require.NoError(t, err)
+
+	genDecl, ok := ip.target.Decls[0].(*dst.GenDecl)
+	require.True(t, ok)
+	require.Len(t, genDecl.Specs, 2, "both needed imports should be added")
+
+	gotPaths := make(map[string]bool)
+	for _, spec := range genDecl.Specs {
+		importSpec, isImportSpec := spec.(*dst.ImportSpec)
+		require.True(t, isImportSpec)
+		gotPaths[importSpec.Path.Value] = true
+	}
+	assert.True(t, gotPaths[`"fmt"`])
+	assert.True(t, gotPaths[`"os"`])
+}
+
+func TestInjectConstraintImports_NoQualifiedConstraint(t *testing.T) {
+	ip := newTestPhase()
+	ip.target = &dst.File{}
+	declFile := fileWithImport("", "golang.org/x/exp/constraints")
+	// A plain built-in constraint, e.g. "comparable" -- no package qualifier
+	// anywhere in it, so nothing should be added.
+	fields := &dst.FieldList{List: []*dst.Field{{
+		Names: []*dst.Ident{ast.Ident("T")},
+		Type:  ast.Ident("comparable"),
+	}}}
+
+	err := ip.injectConstraintImports(t.Context(), declFile, fields)
+	require.NoError(t, err)
+	assert.Empty(t, ip.target.Decls, "no import should be added when the constraint has no package qualifier")
+}
+
+func TestInjectConstraintImports_AliasConflict(t *testing.T) {
+	ip := newTestPhase()
+	// ip.target already imports a different path under the alias "fmt".
+	ip.target = fileWithImport("fmt", "some/other/package")
+	declFile := fileWithImport("", "fmt")
+	fields := &dst.FieldList{List: []*dst.Field{{
+		Names: []*dst.Ident{ast.Ident("T")},
+		Type:  &dst.SelectorExpr{X: ast.Ident("fmt"), Sel: ast.Ident("Stringer")},
+	}}}
+
+	err := ip.injectConstraintImports(t.Context(), declFile, fields)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "import conflict")
+}
+
+func TestInjectConstraintImports_NilOrEmptyGuards(t *testing.T) {
+	ip := newTestPhase()
+	ip.target = &dst.File{}
+
+	require.NoError(t, ip.injectConstraintImports(t.Context(), nil, &dst.FieldList{}))
+	require.NoError(t, ip.injectConstraintImports(t.Context(), fileWithImport("", "fmt"), nil))
 }
 
 func TestUpdateImportConfigForFile(t *testing.T) {

--- a/tool/internal/instrument/package_files.go
+++ b/tool/internal/instrument/package_files.go
@@ -1,0 +1,78 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package instrument
+
+import (
+	"path/filepath"
+
+	"github.com/dave/dst"
+
+	"go.opentelemetry.io/otelc/tool/internal/ast"
+	"go.opentelemetry.io/otelc/tool/util"
+)
+
+// packageGoFiles returns the absolute paths of every .go source file in the
+// current package compile, derived from ip.compileArgs. A single toolexec
+// invocation corresponds to one `go tool compile` call for one package, which
+// receives every source file of that package as a positional argument, so
+// this is the current package's complete file set -- no setup-phase plumbing
+// needed.
+//
+// CGO-processed files are not resolved here: unlike the setup phase's
+// findGoSources, this does not replicate CGO object-dir resolution. A .go arg
+// pointing at a path that doesn't exist on disk (as can happen for
+// CGO-generated intermediates) is silently skipped rather than resolved.
+func (ip *instrumentPhase) packageGoFiles() []string {
+	files := make([]string, 0, len(ip.compileArgs))
+	for _, arg := range ip.compileArgs {
+		if !util.IsGoFile(arg) {
+			continue
+		}
+		abs, err := filepath.Abs(arg)
+		if err != nil {
+			ip.Warn(
+				"failed to resolve absolute path for package file, excluding it from cross-file generic type lookup",
+				"file", arg, "error", err)
+			continue
+		}
+		if !util.PathExists(abs) {
+			continue
+		}
+		files = append(files, abs)
+	}
+	return files
+}
+
+// loadSiblingASTs parses every .go file in the current package (via
+// packageGoFiles) with ast.ParseFileFast and caches the result for the rest
+// of this package's instrumentation. A file that fails to parse is logged and
+// skipped rather than aborting instrumentation -- it simply isn't searched,
+// the same outcome as if the declaration weren't present at all.
+//
+// This deliberately does NOT exclude ip.targetPath: ip.compileArgs holds the
+// package's complete file set from the moment instrumentation for this
+// package begins and is only ever mutated in place (writeInstrumented swaps
+// an already-processed file's path for its instrumented copy, it never
+// removes entries), so packageGoFiles() returns the same file set regardless
+// of which file happens to be "current" when the cache is first built. Since
+// resolveGenericTypeDecl is called once per package and reused via
+// ip.siblingASTs, building the cache once with every file included -- and
+// excluding whichever file is current at LOOKUP time instead -- is what makes
+// the cache correct across the whole package, not just for the file that
+// triggered the first lookup. Excluding ip.targetPath here instead would
+// silently and permanently drop that file from every subsequent file's
+// search once the cache is built.
+func (ip *instrumentPhase) loadSiblingASTs() map[string]*dst.File {
+	siblings := make(map[string]*dst.File)
+	for _, file := range ip.packageGoFiles() {
+		root, err := ast.ParseFileFast(file)
+		if err != nil {
+			ip.Warn("failed to parse package file for cross-file generic type lookup",
+				"file", file, "error", err)
+			continue
+		}
+		siblings[file] = root
+	}
+	return siblings
+}

--- a/tool/internal/instrument/package_files_test.go
+++ b/tool/internal/instrument/package_files_test.go
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package instrument
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageGoFiles(t *testing.T) {
+	dir := t.TempDir()
+	goFile := filepath.Join(dir, "a.go")
+	require.NoError(t, os.WriteFile(goFile, []byte("package pkg\n"), 0o644))
+	missingGoFile := filepath.Join(dir, "nonexistent.go")
+
+	ip := newTestPhase()
+	ip.compileArgs = []string{
+		"-p", "example.com/pkg",
+		"-o", filepath.Join(dir, "pkg.a"),
+		goFile,
+		missingGoFile,
+		filepath.Join(dir, "pkg.a"), // not a .go file, must be excluded
+	}
+
+	files := ip.packageGoFiles()
+
+	abs, err := filepath.Abs(goFile)
+	require.NoError(t, err)
+	assert.Equal(t, []string{abs}, files, "only the existing .go file should be kept")
+}
+
+// TestLoadSiblingASTs_ParsesEveryPackageFile confirms loadSiblingASTs caches
+// the WHOLE package's file set, including ip.targetPath's own file -- it must
+// not pre-exclude anything at build time. Exclusion of the current file
+// happens later, in resolveGenericTypeDecl, at lookup time; see
+// TestResolveGenericTypeDecl_FindsDeclarationInEarlierProcessedFile for why
+// that split matters (excluding at build time made the cache permanently
+// blind to whichever file was "current" when it was first populated).
+func TestLoadSiblingASTs_ParsesEveryPackageFile(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.go")
+	sibling := filepath.Join(dir, "sibling.go")
+	require.NoError(t, os.WriteFile(target, []byte("package pkg\n"), 0o644))
+	require.NoError(t, os.WriteFile(sibling, []byte("package pkg\n\ntype Box[T any] struct{}\n"), 0o644))
+
+	absTarget, err := filepath.Abs(target)
+	require.NoError(t, err)
+	absSibling, err := filepath.Abs(sibling)
+	require.NoError(t, err)
+
+	ip := newTestPhase()
+	ip.compileArgs = []string{target, sibling}
+	ip.targetPath = absTarget
+
+	siblings := ip.loadSiblingASTs()
+
+	_, hasTarget := siblings[absTarget]
+	assert.True(t, hasTarget, "loadSiblingASTs must cache the target's own file too, not just its siblings")
+	_, hasSibling := siblings[absSibling]
+	assert.True(t, hasSibling, "a real sibling file should be parsed and present")
+}
+
+func TestLoadSiblingASTs_SkipsUnparsableFile(t *testing.T) {
+	dir := t.TempDir()
+	valid := filepath.Join(dir, "valid.go")
+	broken := filepath.Join(dir, "broken.go")
+	require.NoError(t, os.WriteFile(valid, []byte("package pkg\n"), 0o644))
+	require.NoError(t, os.WriteFile(broken, []byte("package pkg\n\nfunc ( {{{ this is not valid go\n"), 0o644))
+
+	absValid, err := filepath.Abs(valid)
+	require.NoError(t, err)
+	absBroken, err := filepath.Abs(broken)
+	require.NoError(t, err)
+
+	ip := newTestPhase()
+	ip.compileArgs = []string{valid, broken}
+	ip.targetPath = "" // neither file is "current" for this test
+
+	siblings := ip.loadSiblingASTs()
+
+	_, hasValid := siblings[absValid]
+	assert.True(t, hasValid, "the valid file should still be parsed and cached")
+	_, hasBroken := siblings[absBroken]
+	assert.False(t, hasBroken, "a file that fails to parse must be skipped, not fail the whole call")
+}

--- a/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/generic_receiver_cross_file.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/generic_receiver_cross_file.main.go.golden
@@ -1,0 +1,126 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	_ "unsafe"
+	"fmt"
+)
+
+func (g *GenStruct[T]) GenericMethod(p1 T) (_unnamedRetVal_4098921025_0 T) {
+	//line <generated>:1
+	if hookContext4098921025, _ := OtelBeforeTrampoline_GenericMethod4098921025(&g, &p1); false {
+	} else {
+		defer OtelAfterTrampoline_GenericMethod4098921025(hookContext4098921025, &_unnamedRetVal_4098921025_0)
+	}
+	//line main.go:7:2
+	return p1
+}
+
+//line <generated>:1
+type HookContextImpl4098921025 struct {
+	params      []interface{}
+	returnVals  []interface{}
+	skipCall    bool
+	data        interface{}
+	funcName    string
+	packageName string
+}
+
+func (c *HookContextImpl4098921025) SetSkipCall(skip bool)    { c.skipCall = skip }
+func (c *HookContextImpl4098921025) IsSkipCall() bool         { return c.skipCall }
+func (c *HookContextImpl4098921025) SetData(data interface{}) { c.data = data }
+func (c *HookContextImpl4098921025) GetData() interface{}     { return c.data }
+func (c *HookContextImpl4098921025) GetKeyData(key string) interface{} {
+	if m, ok := c.data.(map[string]interface{}); ok {
+		return m[key]
+	}
+	return nil
+}
+
+func (c *HookContextImpl4098921025) SetKeyData(key string, val interface{}) {
+	m, ok := c.data.(map[string]interface{})
+	if !ok || m == nil {
+		m = make(map[string]interface{})
+		c.data = m
+	}
+	m[key] = val
+}
+
+func (c *HookContextImpl4098921025) HasKeyData(key string) bool {
+	if m, ok := c.data.(map[string]interface{}); ok {
+		_, ok := m[key]
+		return ok
+	}
+	return false
+}
+
+func (c *HookContextImpl4098921025) GetParam(idx int) interface{} {
+	panic("GetParam is unsupported for generic functions")
+}
+
+func (c *HookContextImpl4098921025) SetParam(idx int, val interface{}) {
+	panic("SetParam is unsupported for generic functions")
+}
+
+func (c *HookContextImpl4098921025) GetReturnVal(idx int) interface{} {
+	panic("GetReturnVal is unsupported for generic functions")
+}
+
+func (c *HookContextImpl4098921025) SetReturnVal(idx int, val interface{}) {
+	panic("SetReturnVal is unsupported for generic functions")
+}
+func (c *HookContextImpl4098921025) GetParamCount() int     { return len(c.params) }
+func (c *HookContextImpl4098921025) GetReturnValCount() int { return len(c.returnVals) }
+func (c *HookContextImpl4098921025) GetFuncName() string    { return c.funcName }
+func (c *HookContextImpl4098921025) GetPackageName() string { return c.packageName }
+
+// Trampoline Template
+func OtelBeforeTrampoline_GenericMethod4098921025[T fmt.Stringer](recv0 **GenStruct[T], param0 *T) (hookContext *HookContextImpl4098921025, skipCall bool) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec Before hook", "GenericMethodBefore")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext = &HookContextImpl4098921025{}
+	hookContext.params = []interface{}{recv0, param0}
+	hookContext.funcName = "GenericMethod"
+	hookContext.packageName = "main"
+	if GenericMethodBefore != nil {
+		GenericMethodBefore(hookContext, *recv0, *param0)
+	}
+	return hookContext, hookContext.skipCall
+}
+
+func OtelAfterTrampoline_GenericMethod4098921025[T fmt.Stringer](hookContext HookContext, arg0 *T) {
+	defer func() {
+		if err := recover(); err != nil {
+			println("failed to exec After hook", "GenericMethodAfter")
+			if e, ok := err.(error); ok {
+				println(e.Error())
+			}
+			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
+			if fetchStack != nil && printStack != nil {
+				printStack(fetchStack())
+			}
+		}
+	}()
+	hookContext.(*HookContextImpl4098921025).returnVals = []interface{}{arg0}
+	if GenericMethodAfter != nil {
+		GenericMethodAfter(hookContext, *arg0)
+	}
+}
+
+//go:linkname GenericMethodBefore testdata/golden/generic-receiver-cross-file.GenericMethodBefore
+func GenericMethodBefore(hookContext HookContext, recv0 interface{}, param0 interface{})
+
+//go:linkname GenericMethodAfter testdata/golden/generic-receiver-cross-file.GenericMethodAfter
+func GenericMethodAfter(hookContext HookContext, arg0 interface{})

--- a/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/generic_receiver_cross_file.otelc.globals.go.golden
+++ b/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/generic_receiver_cross_file.otelc.globals.go.golden
@@ -1,0 +1,48 @@
+package main
+
+// Variable Template
+var (
+	OtelGetStackImpl   func() []byte = nil
+	OtelPrintStackImpl func([]byte)  = nil
+)
+
+// !!! pkg/hook/context.go will auto-sync to tool/internal/instrument/api.tmpl
+type HookContext interface {
+	// Set the skip call flag, can be used to skip the original function call
+	SetSkipCall(bool)
+	// Get the skip call flag, can be used to skip the original function call
+	IsSkipCall() bool
+	// Set the data field, can be used to pass information between Before and After hooks.
+	// SetData and SetKeyData are mutually exclusive views of the same underlying field: calling
+	// SetData replaces whatever SetKeyData had stored, and calling SetKeyData after SetData(val)
+	// discards val and starts a fresh key-value map. The last writer wins.
+	SetData(interface{})
+	// Get the data field, can be used to pass information between Before and After hooks
+	GetData() interface{}
+	// Get a value from the data field by key
+	GetKeyData(key string) interface{}
+	// Set a key-value pair in the data field. See SetData for how this interacts with it.
+	SetKeyData(key string, val interface{})
+	// Check if a key exists in the data field
+	HasKeyData(key string) bool
+	// Number of original function parameters
+	GetParamCount() int
+	// Get the original function parameter at index idx
+	GetParam(idx int) interface{}
+	// Change the original function parameter at index idx. Passing a nil val
+	// stores nil for an interface-typed parameter, and resets a non-nilable
+	// parameter (e.g. int or a struct) to its zero value.
+	SetParam(idx int, val interface{})
+	// Number of original function return values
+	GetReturnValCount() int
+	// Get the original function return value at index idx
+	GetReturnVal(idx int) interface{}
+	// Change the original function return value at index idx. Passing a nil val
+	// stores nil for an interface-typed return value, and resets a non-nilable
+	// return value (e.g. int or a struct) to its zero value.
+	SetReturnVal(idx int, val interface{})
+	// Get the original function name
+	GetFuncName() string
+	// Get the package name of the original function
+	GetPackageName() string
+}

--- a/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/hook.go
+++ b/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/hook.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testdata
+
+import (
+	_ "unsafe"
+
+	"go.opentelemetry.io/otelc/pkg/hook"
+)
+
+func GenericMethodBefore(ctx hook.HookContext, recv interface{}, p1 interface{}) {}
+
+func GenericMethodAfter(ctx hook.HookContext, r1 interface{}) {}

--- a/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/other.go
+++ b/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/other.go
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "fmt"
+
+type GenStruct[T fmt.Stringer] struct {
+	value T
+}

--- a/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/rules.yml
+++ b/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/rules.yml
@@ -1,0 +1,10 @@
+generic_receiver_cross_file_rule:
+  target: main
+  where:
+    func: GenericMethod
+    recv: "*GenStruct"
+  do:
+    - inject_hooks:
+        before: GenericMethodBefore
+        after: GenericMethodAfter
+        path: testdata/golden/generic-receiver-cross-file

--- a/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/source.go
+++ b/tool/internal/instrument/testdata/golden/generic-receiver-cross-file/source.go
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+func (g *GenStruct[T]) GenericMethod(p1 T) T {
+	return p1
+}

--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -37,6 +37,14 @@ type instrumentPhase struct {
 	importConfigPath string
 	// The target file to be instrumented
 	target *dst.File
+	// The absolute path of the file currently held in target. Used to exclude
+	// the target's own file from sibling-file discovery.
+	targetPath string
+	// Lazily populated cache of every other .go file in the current package,
+	// parsed on first cross-file generic type lookup and reused for the rest
+	// of this package's instrumentation. Keyed by absolute path. Nil until
+	// first populated by loadSiblingASTs.
+	siblingASTs map[string]*dst.File
 	// The parser for the target file
 	parser *ast.AstParser
 	// The compiling arguments for the target file

--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -4,9 +4,12 @@
 package instrument
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"go/token"
+	"maps"
+	"slices"
 	"strconv"
 
 	"github.com/dave/dst"
@@ -477,10 +480,16 @@ func findTargetResultType(targetFunc *dst.FuncDecl) *dst.FieldList {
 // func (c *Type1[K]) Target[V any]() V
 // ->
 // [K, V]
-func findTargetGenericType(file *dst.File, targetFunc *dst.FuncDecl) *dst.FieldList {
+func (ip *instrumentPhase) findTargetGenericType(
+	ctx context.Context,
+	targetFunc *dst.FuncDecl,
+) (*dst.FieldList, error) {
 	var trampolineTypeParams *dst.FieldList
 	if ast.HasReceiver(targetFunc) {
-		receiverTypeParams := extractReceiverTypeParams(file, targetFunc.Recv.List[0].Type)
+		receiverTypeParams, err := ip.extractReceiverTypeParams(ctx, targetFunc.Recv.List[0].Type)
+		if err != nil {
+			return nil, err
+		}
 		if receiverTypeParams != nil {
 			trampolineTypeParams = receiverTypeParams
 		}
@@ -500,20 +509,33 @@ func findTargetGenericType(file *dst.File, targetFunc *dst.FuncDecl) *dst.FieldL
 		clone := dst.Clone(trampolineTypeParams)
 		trampolineTypeParams = util.AssertType[*dst.FieldList](clone)
 	}
-	return trampolineTypeParams
+	return trampolineTypeParams, nil
 }
 
-func (ip *instrumentPhase) buildTrampSignature(before bool) {
+// buildTrampSignature assigns the trampoline function's parameter and type-
+// parameter lists. genericTypes is findTargetGenericType's result, resolved
+// once by the caller (createTrampoline) and passed in here rather than
+// re-resolved per call: recovering a cross-file constraint involves a
+// package search and import resolution, and createTrampoline calls this
+// twice (once for Before, once for After) -- re-deriving genericTypes each
+// time would repeat that work for a value that cannot have changed. It is
+// cloned before assignment since each trampoline FuncDecl needs to own an
+// independent copy of the type-parameter AST subtree.
+func (ip *instrumentPhase) buildTrampSignature(genericTypes *dst.FieldList, before bool) {
 	var fields *dst.FieldList
+	var typeParams *dst.FieldList
+	if genericTypes != nil {
+		typeParams = util.AssertType[*dst.FieldList](dst.Clone(genericTypes))
+	}
 	if before {
 		beforeTramp := ip.beforeTrampFunc
 		beforeTramp.Type.Params = findTargetParamType(ip.targetFunc)
-		beforeTramp.Type.TypeParams = findTargetGenericType(ip.target, ip.targetFunc)
+		beforeTramp.Type.TypeParams = typeParams
 		fields = beforeTramp.Type.Params
 	} else {
 		afterTramp := ip.afterTrampFunc
 		afterTramp.Type.Params = findTargetResultType(ip.targetFunc)
-		afterTramp.Type.TypeParams = findTargetGenericType(ip.target, ip.targetFunc)
+		afterTramp.Type.TypeParams = typeParams
 		fields = afterTramp.Type.Params
 	}
 	// All types should be replaced with dereferenced types, so that the trampoline
@@ -530,11 +552,21 @@ func (ip *instrumentPhase) buildTrampSignature(before bool) {
 	}
 }
 
-func (ip *instrumentPhase) buildHookSignature(t *rule.InstFuncRule, before bool) (*dst.FieldList, error) {
+// buildHookSignature builds the linked hook function's expected signature.
+// genericTypes is findTargetGenericType's result, resolved once by the
+// caller and passed in -- see buildTrampSignature's doc comment for why. It
+// is only read here (matched against field names via replaceTypeParamsWithAny)
+// and never assigned into paramTypes, so unlike buildTrampSignature it needs
+// no clone of its own.
+func (ip *instrumentPhase) buildHookSignature(
+	t *rule.InstFuncRule,
+	before bool,
+	genericTypes *dst.FieldList,
+) (*dst.FieldList, error) {
 	// TargetFunc: func A(a int, b string) (ret string)
 	// BeforeHook: func B(ctx *HookContext, a int, b string)
 	// AfterHook:  func C(ctx *HookContext, ret string)
-	var paramTypes, genericTypes *dst.FieldList
+	var paramTypes *dst.FieldList
 	if before {
 		paramTypes = findTargetParamType(ip.targetFunc)
 	} else {
@@ -543,7 +575,6 @@ func (ip *instrumentPhase) buildHookSignature(t *rule.InstFuncRule, before bool)
 	addHookContext(paramTypes)
 
 	// Replace type parameters with interface{}
-	genericTypes = findTargetGenericType(ip.target, ip.targetFunc)
 	for _, field := range paramTypes.List {
 		field.Type = replaceTypeParamsWithAny(field.Type, genericTypes)
 	}
@@ -747,47 +778,90 @@ func setReturnValClause(idx int, t dst.Expr) *dst.CaseClause {
 // extractReceiverTypeParams extracts type parameters from a receiver type expression
 // For example: *GenStruct[T] or GenStruct[T, U] -> FieldList with T and U as type parameters
 //
-// file is the source file the receiver was declared in. When it contains the
-// matching generic type declaration (e.g. type GenStruct[T comparable] struct{...}),
-// each parameter's real constraint is recovered from it instead of being widened to
-// any. Constraints are matched positionally against that declaration's own type
-// parameters, since a method receiver is free to use different names for them
-// (type GenStruct[T comparable] struct{} but func (s GenStruct[U]) M(v U) is valid
-// Go; U is still constrained by comparable). If no matching declaration is found in
-// file, the constraint falls back to any, as before.
-func extractReceiverTypeParams(file *dst.File, recvType dst.Expr) *dst.FieldList {
+// When the receiver's matching generic type declaration (e.g. type
+// GenStruct[T comparable] struct{...}) can be found -- in ip.target or, failing
+// that, anywhere else in the current package, see resolveGenericTypeDecl --
+// each parameter's real constraint is recovered from it instead of being
+// widened to any. Constraints are matched positionally against that
+// declaration's own type parameters, since a method receiver is free to use
+// different names for them (type GenStruct[T comparable] struct{} but func (s
+// GenStruct[U]) M(v U) is valid Go; U is still constrained by comparable). If
+// no matching declaration is found anywhere in the package, the constraint
+// falls back to any, as before.
+func (ip *instrumentPhase) extractReceiverTypeParams(ctx context.Context, recvType dst.Expr) (*dst.FieldList, error) {
 	switch t := recvType.(type) {
 	case *dst.StarExpr:
 		// *GenStruct[T] - recurse into X
-		return extractReceiverTypeParams(file, t.X)
+		return ip.extractReceiverTypeParams(ctx, t.X)
 	case *dst.IndexExpr:
 		// GenStruct[T] - single type parameter
 		if ident, ok := t.Index.(*dst.Ident); ok {
-			original := findGenericTypeDecl(file, receiverBaseTypeName(t.X))
-			return &dst.FieldList{
+			original, declFile := ip.resolveGenericTypeDecl(receiverBaseTypeName(t.X))
+			fields := &dst.FieldList{
 				List: []*dst.Field{{
 					Names: []*dst.Ident{ident},
 					Type:  receiverConstraintAt(original, 0),
 				}},
 			}
+			if err := ip.injectConstraintImports(ctx, declFile, fields); err != nil {
+				return nil, err
+			}
+			return fields, nil
 		}
 	case *dst.IndexListExpr:
 		// GenStruct[T, U, ...] - multiple type parameters
-		original := findGenericTypeDecl(file, receiverBaseTypeName(t.X))
-		fields := make([]*dst.Field, 0, len(t.Indices))
+		original, declFile := ip.resolveGenericTypeDecl(receiverBaseTypeName(t.X))
+		fieldList := make([]*dst.Field, 0, len(t.Indices))
 		for i, idx := range t.Indices {
 			if ident, ok := idx.(*dst.Ident); ok {
-				fields = append(fields, &dst.Field{
+				fieldList = append(fieldList, &dst.Field{
 					Names: []*dst.Ident{ident},
 					Type:  receiverConstraintAt(original, i),
 				})
 			}
 		}
-		if len(fields) > 0 {
-			return &dst.FieldList{List: fields}
+		if len(fieldList) > 0 {
+			fields := &dst.FieldList{List: fieldList}
+			if err := ip.injectConstraintImports(ctx, declFile, fields); err != nil {
+				return nil, err
+			}
+			return fields, nil
 		}
 	}
-	return nil
+	//nolint:nilnil // nil is returned when the receiver is not generic
+	return nil, nil
+}
+
+// resolveGenericTypeDecl looks up typeName's generic type declaration, first in
+// ip.target (the common case, and the fast path), then -- on a miss -- across
+// every other .go file of the current package, lazily parsed and cached on
+// ip.siblingASTs for the rest of this package's instrumentation. Returns the
+// recovered type-parameter list and the *dst.File it was found in (needed by
+// the caller to resolve any imports its constraints reference), or (nil, nil)
+// if typeName isn't declared anywhere in the package.
+func (ip *instrumentPhase) resolveGenericTypeDecl(typeName string) (*dst.FieldList, *dst.File) {
+	if original := findGenericTypeDecl(ip.target, typeName); original != nil {
+		return original, ip.target
+	}
+	if ip.siblingASTs == nil {
+		ip.siblingASTs = ip.loadSiblingASTs()
+	}
+	// Iterate in a deterministic order: only one file can validly declare a
+	// given type name (Go rejects redeclaration), so this can't change which
+	// declaration is found, but it keeps behavior reproducible across runs.
+	for _, path := range slices.Sorted(maps.Keys(ip.siblingASTs)) {
+		if path == ip.targetPath {
+			// Already checked above via ip.target itself -- its entry in the
+			// cache (if present) may even be a stale re-parse of the file as
+			// it looked before in-progress edits to ip.target, so it must be
+			// skipped here rather than consulted.
+			continue
+		}
+		if original := findGenericTypeDecl(ip.siblingASTs[path], typeName); original != nil {
+			return original, ip.siblingASTs[path]
+		}
+	}
+	return nil, nil
 }
 
 // receiverBaseTypeName returns the local identifier naming a receiver's generic
@@ -804,8 +878,8 @@ func receiverBaseTypeName(x dst.Expr) string {
 // findGenericTypeDecl searches file's top-level declarations for a generic type
 // declaration named typeName and returns its type parameter list (with each
 // parameter's real constraint, not any), or nil if no such declaration is found in
-// file. The declaration may live in a different file of the same package; that case
-// is not resolved today, so it falls through to the caller's any fallback.
+// file. This is the single-file search primitive; see resolveGenericTypeDecl for
+// the whole-package search that also checks other files of the same package.
 func findGenericTypeDecl(file *dst.File, typeName string) *dst.FieldList {
 	if file == nil || typeName == "" {
 		return nil
@@ -892,7 +966,12 @@ func rewriteReturnValMethods(targetFunc *dst.FuncDecl, methodSetRetVal, methodGe
 	}
 }
 
-func (ip *instrumentPhase) rewriteHookContextMethods() {
+// rewriteHookContextMethods rewrites the specialized HookContextImpl's
+// GetParam/SetParam/GetReturnVal/SetReturnVal methods. genericTypes is
+// findTargetGenericType's result, resolved once by the caller (see
+// buildTrampSignature's doc comment for why) -- this function only checks it
+// for nil, so it needs no clone of its own.
+func (ip *instrumentPhase) rewriteHookContextMethods(genericTypes *dst.FieldList) {
 	util.Assert(len(ip.hookCtxMethods) > 4, "sanity check")
 	var methodSetParam, methodGetParam, methodGetRetVal, methodSetRetVal *dst.FuncDecl
 	for _, decl := range ip.hookCtxMethods {
@@ -909,7 +988,7 @@ func (ip *instrumentPhase) rewriteHookContextMethods() {
 	}
 
 	// For generic functions, we need to panic the methods that are not supported
-	if findTargetGenericType(ip.target, ip.targetFunc) != nil {
+	if genericTypes != nil {
 		makeMethodPanic(methodGetParam, "GetParam is unsupported for generic functions")
 		makeMethodPanic(methodGetRetVal, "GetReturnVal is unsupported for generic functions")
 		makeMethodPanic(methodSetParam, "SetParam is unsupported for generic functions")
@@ -1049,9 +1128,9 @@ func processFieldList(fields []*dst.Field, typeParams *dst.FieldList) []*dst.Fie
 	return result
 }
 
-func (ip *instrumentPhase) callHookFunc(t *rule.InstFuncRule, before bool) error {
+func (ip *instrumentPhase) callHookFunc(t *rule.InstFuncRule, before bool, genericTypes *dst.FieldList) error {
 	// Build hook function signature and check if it is correct
-	paramTypes, err := ip.buildHookSignature(t, before)
+	paramTypes, err := ip.buildHookSignature(t, before, genericTypes)
 	if err != nil {
 		return err
 	}
@@ -1074,7 +1153,7 @@ func (ip *instrumentPhase) callHookFunc(t *rule.InstFuncRule, before bool) error
 	return nil
 }
 
-func (ip *instrumentPhase) createTrampoline(t *rule.InstFuncRule) error {
+func (ip *instrumentPhase) createTrampoline(ctx context.Context, t *rule.InstFuncRule) error {
 	// Ensure unsafe package is imported since we use //go:linkname directives
 	ip.ensureUnsafeImport()
 	// Materialize various declarations from template file, no one wants to see
@@ -1085,9 +1164,21 @@ func (ip *instrumentPhase) createTrampoline(t *rule.InstFuncRule) error {
 	}
 	// Implement HookContext interface methods dynamically
 	ip.implementHookContext(t)
+
+	// Resolve the target's generic type parameters once, up front. This is
+	// the one place in this function that can trigger a cross-file search and
+	// import resolution (see findTargetGenericType -> extractReceiverTypeParams
+	// -> resolveGenericTypeDecl / injectConstraintImports); every consumer
+	// below is given the resolved value instead of re-deriving it, so that
+	// work happens once per rule rather than once per consumer.
+	genericTypes, err := ip.findTargetGenericType(ctx, ip.targetFunc)
+	if err != nil {
+		return err
+	}
+
 	// Make all HookContext methods type-aware according to the target function
 	// signature.
-	ip.rewriteHookContextMethods()
+	ip.rewriteHookContextMethods(genericTypes)
 	// Rename template function to trampoline function
 	ip.renameTrampFunc(t)
 	// Build types of trampoline functions. The parameters of the Before trampoline
@@ -1095,15 +1186,15 @@ func (ip *instrumentPhase) createTrampoline(t *rule.InstFuncRule) error {
 	// trampoline function are the same as the target function.
 	// Generate calls to real hook functions
 	if t.Before != "" {
-		ip.buildTrampSignature(trampolineBefore)
-		err = ip.callHookFunc(t, trampolineBefore)
+		ip.buildTrampSignature(genericTypes, trampolineBefore)
+		err = ip.callHookFunc(t, trampolineBefore, genericTypes)
 		if err != nil {
 			return err
 		}
 	}
 	if t.After != "" {
-		ip.buildTrampSignature(trampolineAfter)
-		err = ip.callHookFunc(t, trampolineAfter)
+		ip.buildTrampSignature(genericTypes, trampolineAfter)
+		err = ip.callHookFunc(t, trampolineAfter, genericTypes)
 		if err != nil {
 			return err
 		}

--- a/tool/internal/instrument/trampoline_test.go
+++ b/tool/internal/instrument/trampoline_test.go
@@ -5,12 +5,15 @@ package instrument
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/dave/dst"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otelc/tool/internal/ast"
+	"go.opentelemetry.io/otelc/tool/internal/rule"
 )
 
 func TestBaseTypeName(t *testing.T) {
@@ -503,7 +506,10 @@ func TestExtractReceiverTypeParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			file, recvType := parseReceiverType(t, tt.recvSrc)
 
-			params := extractReceiverTypeParams(file, recvType)
+			ip := newTestPhase()
+			ip.target = file
+			params, err := ip.extractReceiverTypeParams(t.Context(), recvType)
+			require.NoError(t, err)
 
 			if tt.expected == nil {
 				assert.Nil(t, params, "a receiver without type parameters should produce no field list")
@@ -523,7 +529,10 @@ func TestExtractReceiverTypeParams(t *testing.T) {
 func TestExtractReceiverTypeParamsConstraint_NoMatchingDecl(t *testing.T) {
 	file, recvType := parseReceiverType(t, "*GenStruct[T, U]")
 
-	params := extractReceiverTypeParams(file, recvType)
+	ip := newTestPhase()
+	ip.target = file
+	params, err := ip.extractReceiverTypeParams(t.Context(), recvType)
+	require.NoError(t, err)
 	require.NotNil(t, params)
 	require.Len(t, params.List, 2)
 
@@ -577,7 +586,10 @@ func TestExtractReceiverTypeParamsConstraint_Recovered(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			file, recvType := parseReceiverTypeWithDecl(t, tt.imports, tt.typeDecl, tt.recvSrc)
 
-			params := extractReceiverTypeParams(file, recvType)
+			ip := newTestPhase()
+			ip.target = file
+			params, err := ip.extractReceiverTypeParams(t.Context(), recvType)
+			require.NoError(t, err)
 			require.NotNil(t, params)
 			require.Len(t, params.List, 1)
 			assert.Equal(t, tt.wantNames, typeParamNames(t, params))
@@ -606,7 +618,10 @@ func TestExtractReceiverTypeParamsConstraint_MultipleParams(t *testing.T) {
 		"type GenStruct[T, U comparable, V any] struct{}",
 		"GenStruct[T, U, V]")
 
-	params := extractReceiverTypeParams(file, recvType)
+	ip := newTestPhase()
+	ip.target = file
+	params, err := ip.extractReceiverTypeParams(t.Context(), recvType)
+	require.NoError(t, err)
 	require.NotNil(t, params)
 	require.Len(t, params.List, 3)
 	assert.Equal(t, []string{"T", "U", "V"}, typeParamNames(t, params))
@@ -616,6 +631,436 @@ func TestExtractReceiverTypeParamsConstraint_MultipleParams(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, want, constraint.Name)
 	}
+}
+
+// TestResolveGenericTypeDecl_CrossFile covers the whole-package fallback: the
+// generic type's declaration lives in a different file of the same package
+// than the method being instrumented, so the same-file lookup misses and the
+// sibling-file search must find it instead.
+func TestResolveGenericTypeDecl_CrossFile(t *testing.T) {
+	methodFile, _ := parseReceiverType(t, "*GenStruct[T]")
+
+	parser := ast.NewAstParser()
+	declFile, err := parser.ParseSource("package main\n\ntype GenStruct[T comparable] struct{}\n")
+	require.NoError(t, err)
+
+	ip := newTestPhase()
+	ip.target = methodFile
+	ip.siblingASTs = map[string]*dst.File{"decl.go": declFile}
+
+	params, found := ip.resolveGenericTypeDecl("GenStruct")
+
+	require.NotNil(t, params)
+	assert.Same(t, declFile, found, "resolveGenericTypeDecl must report which file the declaration came from")
+	require.Len(t, params.List, 1)
+	constraint, ok := params.List[0].Type.(*dst.Ident)
+	require.True(t, ok)
+	assert.Equal(t, "comparable", constraint.Name)
+}
+
+// TestResolveGenericTypeDecl_SameFileFastPathSkipsSiblingLoad confirms the
+// same-file hit never touches sibling discovery at all: ip.siblingASTs stays
+// nil, so a package with many files pays no parsing cost for a method whose
+// generic type is declared right there in the same file (the common case).
+func TestResolveGenericTypeDecl_SameFileFastPathSkipsSiblingLoad(t *testing.T) {
+	file, _ := parseReceiverTypeWithDecl(t, "", "type GenStruct[T comparable] struct{}", "GenStruct[T]")
+
+	ip := newTestPhase()
+	ip.target = file
+	// No compileArgs/targetPath configured, so if loadSiblingASTs were called
+	// it would have nothing to work with anyway -- but the point of this test
+	// is that it must not even be invoked in the first place.
+
+	params, found := ip.resolveGenericTypeDecl("GenStruct")
+
+	require.NotNil(t, params)
+	assert.Same(t, file, found)
+	assert.Nil(t, ip.siblingASTs, "same-file hit must not trigger sibling loading at all")
+}
+
+// TestResolveGenericTypeDecl_CachesSiblingASTsAcrossCalls proves the sibling
+// cache is genuinely reused, not rebuilt on every lookup, by loading it once
+// from real files on disk and then removing the sibling file before the
+// second call: if resolveGenericTypeDecl reloaded from disk instead of
+// reusing ip.siblingASTs, the second call would find nothing and return nil.
+func TestResolveGenericTypeDecl_CachesSiblingASTsAcrossCalls(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.go")
+	sibling := filepath.Join(dir, "sibling.go")
+	require.NoError(t, os.WriteFile(target, []byte("package main\nfunc (g *GenStruct[T]) M() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(sibling, []byte("package main\ntype GenStruct[T comparable] struct{}\n"), 0o644))
+
+	absTarget, err := filepath.Abs(target)
+	require.NoError(t, err)
+
+	targetFile, err := ast.ParseFileFast(target)
+	require.NoError(t, err)
+
+	ip := newTestPhase()
+	ip.target = targetFile
+	ip.targetPath = absTarget
+	ip.compileArgs = []string{target, sibling}
+
+	require.Nil(t, ip.siblingASTs, "precondition: cache must start empty so the first call performs a real load")
+	params1, found1 := ip.resolveGenericTypeDecl("GenStruct")
+	require.NotNil(t, params1)
+	require.NotNil(t, found1)
+	require.NotNil(t, ip.siblingASTs, "first call should have populated the cache")
+
+	// Remove the sibling file. A second call that (incorrectly) reloads from
+	// disk would find nothing; a second call that reuses the cache still
+	// succeeds.
+	require.NoError(t, os.Remove(sibling))
+
+	params2, found2 := ip.resolveGenericTypeDecl("GenStruct")
+	assert.NotNil(t, params2, "second call should still succeed by reusing the cached sibling ASTs")
+	assert.NotNil(t, found2)
+}
+
+// TestResolveGenericTypeDecl_FindsDeclarationInEarlierProcessedFile is a
+// regression test for a real bug: instrument() processes a package's files in
+// one shared *instrumentPhase, calling parseFile (which updates ip.target and
+// ip.targetPath) once per file. If the sibling cache were built excluding
+// whichever file happened to be "current" at the moment of the first
+// cross-file lookup, that exclusion would stick for the rest of the package's
+// instrumentation -- a type declared in an earlier-processed file would
+// become permanently unfindable from every later file, silently degrading to
+// any exactly like the bug this package exists to fix. This reproduces that
+// exact sequence: a lookup miss while processing the file that will later
+// hold the real declaration, followed by a lookup for it from a different
+// file.
+func TestResolveGenericTypeDecl_FindsDeclarationInEarlierProcessedFile(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.go")
+	b := filepath.Join(dir, "b.go")
+	require.NoError(t, os.WriteFile(a,
+		[]byte("package main\ntype Box[T comparable] struct{}\nfunc (o *Other[T]) X() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(b, []byte("package main\nfunc (g *Box[T]) M() {}\n"), 0o644))
+
+	ip := newTestPhase()
+	ip.compileArgs = []string{a, b}
+
+	// Process a.go first, exactly like instrument()'s per-file loop.
+	_, err := ip.parseFile(a)
+	require.NoError(t, err)
+	// A cross-file miss here (looking up a type that doesn't exist anywhere)
+	// is what used to permanently seed the cache without a.go in it.
+	_, found := ip.resolveGenericTypeDecl("Other")
+	assert.Nil(t, found)
+
+	// Now process b.go, whose method's receiver type is declared back in a.go.
+	_, err = ip.parseFile(b)
+	require.NoError(t, err)
+
+	params, declFile := ip.resolveGenericTypeDecl("Box")
+	require.NotNil(t, params, "Box[T comparable], declared in a.go, must still be found while processing b.go")
+	require.NotNil(t, declFile)
+	constraint, ok := params.List[0].Type.(*dst.Ident)
+	require.True(t, ok)
+	assert.Equal(t, "comparable", constraint.Name)
+}
+
+// TestResolveGenericTypeDecl_NotFoundAnywhere locks in the graceful
+// whole-package fallback: when the type isn't declared in ip.target or in any
+// sibling file, resolveGenericTypeDecl must return (nil, nil) rather than an
+// error, so callers fall back to any exactly as they did before cross-file
+// search existed.
+func TestResolveGenericTypeDecl_NotFoundAnywhere(t *testing.T) {
+	methodFile, _ := parseReceiverType(t, "*GenStruct[T]")
+
+	parser := ast.NewAstParser()
+	unrelated, err := parser.ParseSource("package main\n\ntype SomethingElse[T any] struct{}\n")
+	require.NoError(t, err)
+
+	ip := newTestPhase()
+	ip.target = methodFile
+	ip.siblingASTs = map[string]*dst.File{"other.go": unrelated}
+
+	params, found := ip.resolveGenericTypeDecl("GenStruct")
+
+	assert.Nil(t, params)
+	assert.Nil(t, found)
+}
+
+// TestExtractReceiverTypeParamsConstraint_CrossFileRecovered exercises the
+// full extractReceiverTypeParams path (not just resolveGenericTypeDecl
+// directly) against a cross-file declaration, confirming the recovered
+// constraint is the real one, not any.
+func TestExtractReceiverTypeParamsConstraint_CrossFileRecovered(t *testing.T) {
+	methodFile, recvType := parseReceiverType(t, "*GenStruct[T]")
+
+	parser := ast.NewAstParser()
+	declFile, err := parser.ParseSource("package main\n\ntype GenStruct[T comparable] struct{}\n")
+	require.NoError(t, err)
+
+	ip := newTestPhase()
+	ip.target = methodFile
+	ip.siblingASTs = map[string]*dst.File{"decl.go": declFile}
+
+	params, err := ip.extractReceiverTypeParams(t.Context(), recvType)
+	require.NoError(t, err)
+	require.NotNil(t, params)
+	require.Len(t, params.List, 1)
+
+	constraint, ok := params.List[0].Type.(*dst.Ident)
+	require.True(t, ok, "expected the constraint to be a plain identifier")
+	assert.Equal(t, "comparable", constraint.Name)
+}
+
+// funcDeclFromSource parses src and returns its enclosing file plus the first
+// top-level func declaration found in it.
+func funcDeclFromSource(t *testing.T, src string) (*dst.File, *dst.FuncDecl) {
+	t.Helper()
+	parser := ast.NewAstParser()
+	file, err := parser.ParseSource(src)
+	require.NoError(t, err)
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*dst.FuncDecl); ok {
+			return file, fn
+		}
+	}
+	require.Fail(t, "no function declaration found in source")
+	return nil, nil
+}
+
+// TestFindTargetGenericType covers every combination findTargetGenericType
+// assembles a trampoline's type-parameter list from: no generics at all,
+// receiver-only generics, method-own generics with no receiver, and the
+// combined case (a generic receiver whose method also declares its own type
+// parameter, e.g. func (c *Type1[K]) Target[V any]() V) -- the one branch of
+// this function that had no test coverage of any kind before this change.
+func TestFindTargetGenericType(t *testing.T) {
+	t.Run("no receiver, no method type params", func(t *testing.T) {
+		file, fn := funcDeclFromSource(t, "package main\nfunc Plain(a int) {}")
+		ip := newTestPhase()
+		ip.target = file
+
+		params, err := ip.findTargetGenericType(t.Context(), fn)
+		require.NoError(t, err)
+		assert.Nil(t, params)
+	})
+
+	t.Run("receiver-only generics", func(t *testing.T) {
+		file, fn := funcDeclFromSource(t,
+			"package main\ntype GenStruct[T comparable] struct{}\nfunc (g *GenStruct[T]) M() {}")
+		ip := newTestPhase()
+		ip.target = file
+
+		params, err := ip.findTargetGenericType(t.Context(), fn)
+		require.NoError(t, err)
+		require.NotNil(t, params)
+		assert.Equal(t, []string{"T"}, typeParamNames(t, params))
+	})
+
+	t.Run("method-own type params only, no receiver", func(t *testing.T) {
+		file, fn := funcDeclFromSource(t, "package main\nfunc Generic[V any](v V) V { return v }")
+		ip := newTestPhase()
+		ip.target = file
+
+		params, err := ip.findTargetGenericType(t.Context(), fn)
+		require.NoError(t, err)
+		require.NotNil(t, params)
+		assert.Equal(t, []string{"V"}, typeParamNames(t, params))
+	})
+
+	t.Run("combined: receiver generics plus the method's own type params", func(t *testing.T) {
+		file, fn := funcDeclFromSource(t,
+			"package main\n"+
+				"type Type1[K comparable] struct{}\n"+
+				"func (c *Type1[K]) Target(v K) {}")
+		// Give Target its own type parameter in addition to the receiver's,
+		// mirroring func (c *Type1[K]) Target[V any]() V from the doc comment --
+		// built directly since the parser's receiver-vs-method type param
+		// split is what's under test, not the source syntax for declaring both.
+		fn.Type.TypeParams = &dst.FieldList{List: []*dst.Field{{
+			Names: []*dst.Ident{ast.Ident("V")},
+			Type:  ast.Ident("any"),
+		}}}
+		ip := newTestPhase()
+		ip.target = file
+
+		params, err := ip.findTargetGenericType(t.Context(), fn)
+		require.NoError(t, err)
+		require.NotNil(t, params)
+		// Receiver's own type params come first, then the method's, per the
+		// combining logic in findTargetGenericType.
+		require.Len(t, params.List, 2)
+		assert.Equal(t, []string{"K", "V"}, typeParamNames(t, params))
+		kConstraint, ok := params.List[0].Type.(*dst.Ident)
+		require.True(t, ok)
+		assert.Equal(t, "comparable", kConstraint.Name,
+			"receiver constraint must still be recovered in the combined case")
+		vConstraint, ok := params.List[1].Type.(*dst.Ident)
+		require.True(t, ok)
+		assert.Equal(t, "any", vConstraint.Name)
+	})
+
+	t.Run("propagates an error from constraint import injection instead of swallowing it", func(t *testing.T) {
+		methodFile, fn := funcDeclFromSource(t, "package main\nfunc (g *GenStruct[T]) M() {}")
+		declFile, err := ast.NewAstParser().ParseSource(
+			"package main\nimport \"fmt\"\ntype GenStruct[T fmt.Stringer] struct{}")
+		require.NoError(t, err)
+
+		ip := newTestPhase()
+		// The target file already imports a different path under the alias
+		// "fmt", conflicting with what the cross-file constraint needs.
+		ip.target = fileWithImport("fmt", "some/other/package")
+		ip.target.Decls = append(ip.target.Decls, methodFile.Decls...)
+		ip.siblingASTs = map[string]*dst.File{"decl.go": declFile}
+
+		_, err = ip.findTargetGenericType(t.Context(), fn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "import conflict")
+	})
+}
+
+// TestBuildTrampSignature covers the one place findTargetGenericType's result
+// is actually consumed for codegen: the trampoline function's own
+// Type.TypeParams, plus the dereferencing every parameter field goes through
+// regardless of genericity.
+func TestBuildTrampSignature(t *testing.T) {
+	t.Run("generic receiver: type params attached, params dereferenced", func(t *testing.T) {
+		file, fn := funcDeclFromSource(t,
+			"package main\ntype GenStruct[T comparable] struct{}\nfunc (g *GenStruct[T]) M(p1 T) {}")
+		ip := newTestPhase()
+		ip.target = file
+		ip.targetFunc = fn
+		ip.beforeTrampFunc = &dst.FuncDecl{Type: &dst.FuncType{}}
+
+		genericTypes, err := ip.findTargetGenericType(t.Context(), fn)
+		require.NoError(t, err)
+
+		ip.buildTrampSignature(genericTypes, trampolineBefore)
+
+		require.NotNil(t, ip.beforeTrampFunc.Type.TypeParams)
+		assert.Equal(t, []string{"T"}, typeParamNames(t, ip.beforeTrampFunc.Type.TypeParams))
+		constraint, ok := ip.beforeTrampFunc.Type.TypeParams.List[0].Type.(*dst.Ident)
+		require.True(t, ok)
+		assert.Equal(t, "comparable", constraint.Name)
+		// The assigned TypeParams must be an independent clone, not the same
+		// node genericTypes points at -- buildTrampSignature is called once per
+		// trampoline (Before and After), and each needs to own its own AST
+		// subtree rather than share one.
+		assert.NotSame(t, genericTypes, ip.beforeTrampFunc.Type.TypeParams)
+
+		// Every param field (receiver included) must come out pointer-wrapped so
+		// the trampoline can address/modify the target function's own values.
+		for _, field := range ip.beforeTrampFunc.Type.Params.List {
+			_, isPointer := field.Type.(*dst.StarExpr)
+			assert.True(t, isPointer, "field %v should be dereferenced to a pointer type", field.Names)
+		}
+	})
+
+	t.Run("non-generic: no type params attached", func(t *testing.T) {
+		file, fn := funcDeclFromSource(t, "package main\nfunc Plain(a int) {}")
+		ip := newTestPhase()
+		ip.target = file
+		ip.targetFunc = fn
+		ip.afterTrampFunc = &dst.FuncDecl{Type: &dst.FuncType{}}
+
+		genericTypes, err := ip.findTargetGenericType(t.Context(), fn)
+		require.NoError(t, err)
+		require.Nil(t, genericTypes)
+
+		ip.buildTrampSignature(genericTypes, trampolineAfter)
+		assert.Nil(t, ip.afterTrampFunc.Type.TypeParams)
+	})
+}
+
+// TestRewriteHookContextMethods_GenericPanicsAndErrorPropagation covers the
+// generic-vs-non-generic branch directly (rather than only through golden
+// fixtures) and, more importantly, that an error surfaced while resolving the
+// target's generic type (e.g. a conflicting import needed by a cross-file
+// constraint. genericTypes is resolved directly via findTargetGenericType
+// rather than by this function -- see createTrampoline's doc comment for why
+// -- so this only covers the generic-vs-non-generic branch, not error
+// propagation; TestCreateTrampoline_PropagatesGenericTypeResolutionError
+// covers the error path at the level where it actually now surfaces.
+func TestRewriteHookContextMethods_GenericPanics(t *testing.T) {
+	newMaterializedPhase := func(t *testing.T) *instrumentPhase {
+		t.Helper()
+		ip := newTestPhase()
+		ip.target = &dst.File{}
+		require.NoError(t, ip.materializeTemplate())
+		return ip
+	}
+
+	findMethod := func(t *testing.T, ip *instrumentPhase, name string) *dst.FuncDecl {
+		t.Helper()
+		for _, decl := range ip.hookCtxMethods {
+			if decl.Name.Name == name {
+				return decl
+			}
+		}
+		require.Failf(t, "method not found", "%s not present in hookCtxMethods", name)
+		return nil
+	}
+
+	t.Run("generic target: accessor methods become panics", func(t *testing.T) {
+		ip := newMaterializedPhase(t)
+		src, fn := funcDeclFromSource(t,
+			"package main\ntype GenStruct[T comparable] struct{}\nfunc (g *GenStruct[T]) M() {}")
+		ip.targetFunc = fn
+		// The generic-receiver lookup needs its declaration reachable from
+		// ip.target; materializeTemplate already populated ip.target with the
+		// trampoline template's own decls, so append the source's decls too.
+		ip.target.Decls = append(ip.target.Decls, src.Decls...)
+
+		genericTypes, err := ip.findTargetGenericType(t.Context(), fn)
+		require.NoError(t, err)
+		require.NotNil(t, genericTypes)
+
+		ip.rewriteHookContextMethods(genericTypes)
+
+		getParam := findMethod(t, ip, trampolineGetParamName)
+		require.Len(t, getParam.Body.List, 1)
+		_, isPanic := getParam.Body.List[0].(*dst.ExprStmt)
+		assert.True(t, isPanic, "GetParam body should have been replaced with a single panic statement")
+	})
+
+	t.Run("non-generic target: accessor methods keep their real bodies", func(t *testing.T) {
+		ip := newMaterializedPhase(t)
+		_, fn := funcDeclFromSource(t, "package main\nfunc Plain(a int) (int, error) { return a, nil }")
+		ip.targetFunc = fn
+
+		genericTypes, err := ip.findTargetGenericType(t.Context(), fn)
+		require.NoError(t, err)
+		require.Nil(t, genericTypes)
+
+		ip.rewriteHookContextMethods(genericTypes)
+
+		getParam := findMethod(t, ip, trampolineGetParamName)
+		require.Greater(t, len(getParam.Body.List), 1,
+			"a non-generic target must keep GetParam's real switch-based body, not a bare panic")
+	})
+}
+
+// TestCreateTrampoline_PropagatesGenericTypeResolutionError proves the
+// error-propagation contract this whole restructuring depends on: genericTypes
+// is now resolved exactly once, at the top of createTrampoline, and every
+// consumer (rewriteHookContextMethods, buildTrampSignature for both Before and
+// After, buildHookSignature via callHookFunc) is handed the already-resolved
+// value instead of re-deriving it. This confirms a resolution failure (e.g. a
+// cross-file constraint's import conflicting with one already in ip.target)
+// surfaces from createTrampoline itself, before any of those consumers run.
+func TestCreateTrampoline_PropagatesGenericTypeResolutionError(t *testing.T) {
+	ip := newTestPhase()
+	ip.target = &dst.File{}
+	methodFile, fn := funcDeclFromSource(t, "package main\nfunc (g *GenStruct[T]) M() {}")
+	declFile, err := ast.NewAstParser().ParseSource(
+		"package main\nimport \"fmt\"\ntype GenStruct[T fmt.Stringer] struct{}")
+	require.NoError(t, err)
+
+	// ip.target already carries a conflicting "fmt" alias from a prior rule
+	// application on this file.
+	ip.target.Decls = append(ip.target.Decls, fileWithImport("fmt", "some/other/package").Decls...)
+	ip.target.Decls = append(ip.target.Decls, methodFile.Decls...)
+	ip.siblingASTs = map[string]*dst.File{"decl.go": declFile}
+	ip.targetFunc = fn
+
+	err = ip.createTrampoline(t.Context(), &rule.InstFuncRule{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "import conflict")
 }
 
 // TestReceiverBaseTypeName_NonIdent covers the defensive fallback directly: a
@@ -664,7 +1109,10 @@ func TestExtractReceiverTypeParamsNestedPointer(t *testing.T) {
 	file, inner := parseReceiverType(t, "*GenStruct[T]")
 	nested := &dst.StarExpr{X: inner}
 
-	params := extractReceiverTypeParams(file, nested)
+	ip := newTestPhase()
+	ip.target = file
+	params, err := ip.extractReceiverTypeParams(t.Context(), nested)
+	require.NoError(t, err)
 
 	require.NotNil(t, params)
 	assert.Equal(t, []string{"T"}, typeParamNames(t, params))


### PR DESCRIPTION

## Description
When instrumenting a method on a generic struct whose `type` definition is located in a different file of the same package (rather than in the same file as the method), `otelc` previously failed to resolve the type parameter constraints. This caused trampoline generation to either fall back to `any` or fail compilation when constraints referenced imported packages that were not present in the target file.
This PR introduces the following changes:
1. **Package File Discovery & Caching (`tool/internal/instrument/package_files.go`):**
   - Added `packageGoFiles()` to retrieve package `.go` files from `ip.compileArgs`.
   - Added `loadSiblingASTs()` to lazily parse and cache sibling package ASTs with `ast.ParseFileFast`.
   - Ensured deterministic sibling traversal by sorting map keys.
2. **Cross-file Constraint Recovery & Import Injection (`tool/internal/instrument/trampoline.go`, `tool/internal/instrument/imports.go`):**
   - Added `resolveGenericTypeDecl()` to look up generic struct declarations across package sibling files when not found in the target file.
   - Added `injectConstraintImports()` to inspect constraint expressions, resolve their import paths via `imports.ResolveAlias()`, and inject missing imports into the target file AST and `importcfg` via `addRuleImports()`.
   - Refactored `findTargetGenericType()` to run once per rule at the top of `createTrampoline()` and propagate errors cleanly.
3. **Import Alias Helper (`tool/internal/imports/imports.go`):**
   - Added `ResolveAlias()` to look up the import path for a given alias or inferred package name within an AST file.
4. **Testing:**
   - Added unit tests in `package_files_test.go`, `trampoline_test.go`, and `imports_test.go`.
   - Added end-to-end golden test under `tool/internal/instrument/testdata/golden/generic-receiver-cross-file/`.
## Motivation
Fixes #1171
Generic receiver methods whose type declarations reside in sibling files could not recover constraints (e.g. `[T fmt.Stringer]`), leading to missing type parameters in trampoline functions or compilation failures when constraints required package imports in the target file.

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]
[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
