### PR TITLE
docs(tool): document HookContext accessor panics for generic targets

### DIFF
--- a/docs/instrument-guide.md
+++ b/docs/instrument-guide.md
@@ -154,7 +154,24 @@ When implementing hooks, we must adhere to certain limitations:
 
    Importing other third-party libraries is not allowed.
 
-2. **Generic Functions**: If the target function is generic, we cannot use `HookContext` APIs to modify parameters or return values (e.g., `SetParam`, `SetReturnVal`).
+2. **Generic Functions**: If the target function or method receiver is generic, we cannot use the `HookContext` parameter and return value APIs.
+
+   `GetParam`, `SetParam`, `GetReturnVal`, and `SetReturnVal` are each replaced with a body
+   that panics, so reading panics just as writing does. Instead, we read the values from the
+   hook's own parameters, which already receive them positionally:
+
+   ```go
+   // Target: func GenericFunc[T any](p1 T, p2 int) (T, error)
+
+   // We read p1 and p2 from the hook's parameters, never through ictx.GetParam.
+   func GenericFuncBefore(ictx hook.HookContext, p1 interface{}, p2 int) {}
+
+   // The after hook likewise reads the return values from its own parameters.
+   func GenericFuncAfter(ictx hook.HookContext, r1 interface{}, r2 error) {}
+   ```
+
+   Nothing catches this at build time: a hook that calls one of these four methods on a
+   generic target compiles cleanly, and only panics once the instrumented function runs.
 
 ### GLS Operation for OTel SDK Instrumentation
 

--- a/tool/internal/instrument/testdata/golden/generic-functions/hook.go
+++ b/tool/internal/instrument/testdata/golden/generic-functions/hook.go
@@ -9,6 +9,10 @@ import (
 	"go.opentelemetry.io/otelc/pkg/hook"
 )
 
+// These hooks read their values from their own parameters rather than through
+// ctx.GetParam/GetReturnVal: those methods panic for generic targets, so the
+// positional parameters below are the only way to reach the values.
+
 func GenericFuncBefore(ctx hook.HookContext, p1 interface{}, p2 int) {}
 
 func GenericFuncAfter(ctx hook.HookContext, r1 interface{}, r2 error) {}


### PR DESCRIPTION
## Summary

Fixes #1174.

The Generic Functions limitation in the hook-authoring guide said we cannot use `HookContext` to *modify* parameters or return values, naming `SetParam` and `SetReturnVal`. Reading is equally unavailable: for a generic target `GetParam` and `GetReturnVal` are replaced with panicking bodies too, so a hook that only reads still panics at runtime. Nothing flags it at build time, which is what makes it hard to discover.

Docs-only, per y1yang0's confirmation on the issue that this should be documented:

- `docs/instrument-guide.md`: expands the limitation to name all four methods, notes that the failure only surfaces when the instrumented function actually runs, and shows reading the values from the hook's own parameters instead.
- `tool/internal/instrument/testdata/golden/generic-functions/hook.go`: short comment on why those example hooks read positionally, so the omission reads as deliberate rather than incidental. The issue suggested this.

No code changes. The panic generation itself (`rewriteHookContextMethods` / `makeMethodPanic` in `trampoline.go`) is already covered by the existing `generic-functions` golden test, so there is nothing to add there.

## Test plan

- [x] `npx markdownlint-cli -c .tools/markdownlint.yaml docs/instrument-guide.md` clean
- [x] `gofmt -l` clean on the touched fixture
- [x] `.github/scripts/license-check.sh` passes
- [x] Confirmed the fixture is consumed as a helper package (built by `buildTestcaseHelpers`, referenced from the rule YAML's `path:`) rather than copied into the instrumented source that golden output is compared against, so the added comment cannot shift the golden diff