### PR TITLE
fix(instrumentation/redis): redact db.query.text argument values by default

### DIFF
--- a/instrumentation/github.com/redis/go-redis/v9/hook.go
+++ b/instrumentation/github.com/redis/go-redis/v9/hook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -148,16 +149,25 @@ func (o *otelRedisHook) DialHook(next redis.DialHook) redis.DialHook {
 	}
 }
 
+// captureFullStatement reports whether db.query.text should include
+// full command argument values. When false (the default), only the
+// command name and key are captured; all subsequent arguments are
+// replaced with "?" to avoid leaking sensitive data into traces.
+func captureFullStatement() bool {
+	return strings.EqualFold(os.Getenv("OTEL_REDIS_CAPTURE_FULL_STATEMENT"), "true")
+}
+
 func getRedisV9Statement(cmd redis.Cmder) string {
 	args := cmd.Args()
-	redactStart, redactEnd := redisV9CredentialRedactRange(cmd.Name(), args)
+	credStart, credEnd := redisV9CredentialRedactRange(cmd.Name(), args)
+	valStart, valEnd := redisV9ValueRedactRange(args)
 
 	b := make([]byte, 0, 64)
 	for i, arg := range args {
 		if i > 0 {
 			b = append(b, ' ')
 		}
-		if i >= redactStart && i < redactEnd {
+		if (i >= credStart && i < credEnd) || (i >= valStart && i < valEnd) {
 			b = append(b, redisQueryTextRedact...)
 			continue
 		}
@@ -187,6 +197,17 @@ func redisV9CredentialRedactRange(name string, args []interface{}) (start, end i
 		}
 	}
 	return 0, 0
+}
+
+// redisV9ValueRedactRange returns a half-open index range [2, len(args)) of
+// arguments that carry data values and should be redacted by default. Returns
+// (0, 0) when OTEL_REDIS_CAPTURE_FULL_STATEMENT is "true" or the command
+// has no value arguments (index <= 1).
+func redisV9ValueRedactRange(args []interface{}) (start, end int) {
+	if len(args) <= 2 || captureFullStatement() {
+		return 0, 0
+	}
+	return 2, len(args)
 }
 
 func redisV9HelloAuthIndex(args []interface{}) int {

--- a/instrumentation/github.com/redis/go-redis/v9/hook_test.go
+++ b/instrumentation/github.com/redis/go-redis/v9/hook_test.go
@@ -36,24 +36,24 @@ func TestGetRedisV9Statement(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "GET command",
+			name:     "GET command with only key",
 			cmd:      redis.NewCmd(context.Background(), "get", "mykey"),
 			expected: "get mykey",
 		},
 		{
-			name:     "SET command with value",
+			name:     "SET command redacts value by default",
 			cmd:      redis.NewCmd(context.Background(), "set", "mykey", "myvalue"),
-			expected: "set mykey myvalue",
+			expected: "set mykey ?",
 		},
 		{
-			name:     "HSET command",
+			name:     "HSET command redacts field values by default",
 			cmd:      redis.NewCmd(context.Background(), "hset", "myhash", "field1", "value1"),
-			expected: "hset myhash field1 value1",
+			expected: "hset myhash ? ?",
 		},
 		{
-			name:     "DEL command",
+			name:     "DEL command redacts second key by default",
 			cmd:      redis.NewCmd(context.Background(), "del", "key1", "key2"),
-			expected: "del key1 key2",
+			expected: "del key1 ?",
 		},
 		{
 			name:     "command with nil arg",
@@ -61,19 +61,52 @@ func TestGetRedisV9Statement(t *testing.T) {
 			expected: "set <nil>",
 		},
 		{
-			name:     "command with int arg",
+			name:     "command with int arg redacted by default",
 			cmd:      redis.NewCmd(context.Background(), "expire", "mykey", 60),
-			expected: "expire mykey 60",
+			expected: "expire mykey ?",
 		},
 		{
-			name:     "command with bool arg true",
+			name:     "command with bool arg true redacted by default",
 			cmd:      redis.NewCmd(context.Background(), "set", "mykey", true),
-			expected: "set mykey true",
+			expected: "set mykey ?",
 		},
 		{
-			name:     "command with bool arg false",
+			name:     "command with bool arg false redacted by default",
 			cmd:      redis.NewCmd(context.Background(), "set", "mykey", false),
-			expected: "set mykey false",
+			expected: "set mykey ?",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getRedisV9Statement(tt.cmd)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetRedisV9Statement_CaptureFull(t *testing.T) {
+	t.Setenv("OTEL_REDIS_CAPTURE_FULL_STATEMENT", "true")
+
+	tests := []struct {
+		name     string
+		cmd      redis.Cmder
+		expected string
+	}{
+		{
+			name:     "SET command captures full value",
+			cmd:      redis.NewCmd(context.Background(), "set", "mykey", "myvalue"),
+			expected: "set mykey myvalue",
+		},
+		{
+			name:     "HSET command captures full values",
+			cmd:      redis.NewCmd(context.Background(), "hset", "myhash", "field1", "value1"),
+			expected: "hset myhash field1 value1",
+		},
+		{
+			name:     "GET command unchanged",
+			cmd:      redis.NewCmd(context.Background(), "get", "mykey"),
+			expected: "get mykey",
 		},
 		{
 			name:     "AUTH password",
@@ -164,12 +197,12 @@ func TestGetRedisV9Statement_RedactsCredentials(t *testing.T) {
 		{
 			name:     "HELLO handshake with AUTH",
 			cmd:      redis.NewCmd(context.Background(), "hello", 3, "auth", "default", "s3cret"),
-			expected: "hello 3 auth ? ?",
+			expected: "hello 3 ? ? ?",
 		},
 		{
-			name:     "HELLO keeps SETNAME visible",
+			name:     "HELLO with SETNAME",
 			cmd:      redis.NewCmd(context.Background(), "hello", 3, "auth", "default", "s3cret", "setname", "myapp"),
-			expected: "hello 3 auth ? ? setname myapp",
+			expected: "hello 3 ? ? ? ? ?",
 		},
 		{
 			name:     "HELLO without AUTH is untouched",
@@ -179,7 +212,7 @@ func TestGetRedisV9Statement_RedactsCredentials(t *testing.T) {
 		{
 			name:     "key literally named auth is not a credential",
 			cmd:      redis.NewCmd(context.Background(), "get", "auth", "token"),
-			expected: "get auth token",
+			expected: "get auth ?",
 		},
 	}
 
@@ -188,6 +221,40 @@ func TestGetRedisV9Statement_RedactsCredentials(t *testing.T) {
 			result := getRedisV9Statement(tt.cmd)
 			assert.Equal(t, tt.expected, result)
 			assert.NotContains(t, result, "s3cret", "the password must never reach db.query.text")
+		})
+	}
+}
+
+func TestGetRedisV9Statement_CredentialsAlwaysRedacted(t *testing.T) {
+	t.Setenv("OTEL_REDIS_CAPTURE_FULL_STATEMENT", "true")
+
+	tests := []struct {
+		name     string
+		cmd      redis.Cmder
+		expected string
+	}{
+		{
+			name:     "AUTH credentials redacted even with full capture",
+			cmd:      redis.NewCmd(context.Background(), "auth", "s3cret"),
+			expected: "auth ?",
+		},
+		{
+			name:     "AUTH with username redacted even with full capture",
+			cmd:      redis.NewCmd(context.Background(), "auth", "default", "s3cret"),
+			expected: "auth ? ?",
+		},
+		{
+			name:     "HELLO AUTH redacted even with full capture",
+			cmd:      redis.NewCmd(context.Background(), "hello", 3, "auth", "default", "s3cret"),
+			expected: "hello 3 auth ? ?",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getRedisV9Statement(tt.cmd)
+			assert.Equal(t, tt.expected, result)
+			assert.NotContains(t, result, "s3cret")
 		})
 	}
 }
@@ -308,7 +375,7 @@ func TestProcessHook_RedactsAuthCredentials(t *testing.T) {
 			name:      "HELLO AUTH",
 			cmd:       redis.NewCmd(context.Background(), "hello", 3, "auth", "default", "s3cret"),
 			spanName:  "hello",
-			wantQuery: "hello 3 auth ? ?",
+			wantQuery: "hello 3 ? ? ?",
 		},
 	}
 
@@ -340,6 +407,63 @@ func TestProcessHook_RedactsAuthCredentials(t *testing.T) {
 			assert.Equal(t, tt.wantQuery, queryText)
 			assert.NotContains(t, queryText, "s3cret")
 		})
+	}
+}
+
+func TestProcessHook_RedactsValues(t *testing.T) {
+	initOnce = *new(sync.Once)
+	t.Setenv("OTEL_GO_ENABLED_INSTRUMENTATIONS", "redis")
+
+	sr := setupTestTracer(t)
+
+	hook := newOtelRedisHook("localhost:6379")
+	processHook := hook.ProcessHook(func(ctx context.Context, cmd redis.Cmder) error {
+		return nil
+	})
+
+	cmd := redis.NewCmd(context.Background(), "set", "session:42", "s3cret-session-token")
+	err := processHook(context.Background(), cmd)
+	assert.NoError(t, err)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+
+	span := spans[0]
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == "db.query.text" {
+			val := attr.Value.AsString()
+			assert.Equal(t, "set session:42 ?", val)
+			assert.NotContains(t, val, "s3cret-session-token",
+				"sensitive value must not appear in db.query.text by default")
+		}
+	}
+}
+
+func TestProcessHook_CaptureFullStatement(t *testing.T) {
+	initOnce = *new(sync.Once)
+	t.Setenv("OTEL_GO_ENABLED_INSTRUMENTATIONS", "redis")
+	t.Setenv("OTEL_REDIS_CAPTURE_FULL_STATEMENT", "true")
+
+	sr := setupTestTracer(t)
+
+	hook := newOtelRedisHook("localhost:6379")
+	processHook := hook.ProcessHook(func(ctx context.Context, cmd redis.Cmder) error {
+		return nil
+	})
+
+	cmd := redis.NewCmd(context.Background(), "set", "session:42", "s3cret-session-token")
+	err := processHook(context.Background(), cmd)
+	assert.NoError(t, err)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+
+	span := spans[0]
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == "db.query.text" {
+			val := attr.Value.AsString()
+			assert.Equal(t, "set session:42 s3cret-session-token", val)
+		}
 	}
 }
 
@@ -447,6 +571,38 @@ func TestProcessPipelineHook_CreatesSpan(t *testing.T) {
 	}
 	assert.Equal(t, "redis", attrMap["db.system.name"])
 	assert.Equal(t, "pipeline", attrMap["db.operation.name"])
+}
+
+func TestProcessPipelineHook_RedactsValues(t *testing.T) {
+	initOnce = *new(sync.Once)
+	t.Setenv("OTEL_GO_ENABLED_INSTRUMENTATIONS", "redis")
+
+	sr := setupTestTracer(t)
+
+	hook := newOtelRedisHook("localhost:6379")
+	pipelineHook := hook.ProcessPipelineHook(func(ctx context.Context, cmds []redis.Cmder) error {
+		return nil
+	})
+
+	cmds := []redis.Cmder{
+		redis.NewCmd(context.Background(), "set", "key1", "secret-value"),
+		redis.NewCmd(context.Background(), "hset", "hash", "field", "sensitive-data"),
+	}
+	err := pipelineHook(context.Background(), cmds)
+	assert.NoError(t, err)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+
+	for _, attr := range spans[0].Attributes() {
+		if string(attr.Key) == "db.query.text" {
+			val := attr.Value.AsString()
+			assert.NotContains(t, val, "secret-value",
+				"sensitive value must not appear in pipeline db.query.text")
+			assert.NotContains(t, val, "sensitive-data",
+				"sensitive value must not appear in pipeline db.query.text")
+		}
+	}
 }
 
 func TestProcessPipelineHook_TruncatesLongPipeline(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to OpenTelemetry Go Compile Instrumentation!

INSTRUCTIONS:
1. Fill in the description and motivation sections below
2. Complete the checklist before submitting
3. Ensure PR title follows conventional commits format (enforced by CI)

PR TITLE FORMAT (required):
  type(scope): description

  Types: chore, doc, docs, feat, fix, release, refactor, test
  Scopes: tool, pkg, demo, test, docs

BEFORE SUBMITTING:
  make format  # Format Go code and YAML files
  make lint    # Run all linters
  make test    # Run all tests (unit + integration + e2e)
-->

## Description

`db.query.text` on Redis client spans currently captures full, unredacted command argument values by default — session tokens, API keys, emails, and arbitrary application data are serialized into every span and shipped to trace backends unconditionally.

This changes `getRedisV9Statement` to redact all arguments at index ≥ 2 (everything after the command name and key) by default, replacing them with `?`. Users who need full argument capture can opt in via `OTEL_REDIS_CAPTURE_FULL_STATEMENT=true`.

Existing `AUTH`/`HELLO` credential redaction (from #1091) continues to work under both modes.

## Motivation

The OTel Redis semantic conventions state that `db.query.text` "SHOULD NOT be collected by default unless there is sanitization that excludes sensitive data." Redis commands don't separate "query" from "parameters" the way SQL does — the arguments to `SET`, `HSET`, `LPUSH`, etc. *are* the data being written. Capturing them verbatim leaks sensitive data into traces by default.

Fixes #1200

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
