### PR TITLE
fix(setup): quote the toolexec executable path so spaces survive go's splitting

### DIFF
--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -542,7 +542,10 @@ func buildWithToolexec(ctx context.Context, cmd *cli.Command, vendored bool) err
 	if err != nil {
 		return ex.Wrapf(err, "failed to get executable path")
 	}
-	insert := "-toolexec=" + execPath + " toolexec"
+	// cmd/go splits the -toolexec value on whitespace (internal/quoted), so
+	// a path containing spaces — "Program Files" being the obvious one —
+	// must be quoted or only the first chunk reaches the tool (#1207).
+	insert := "-toolexec=" + quoteForGo(execPath) + " toolexec"
 	const additionalCount = 2
 	newArgs := make([]string, 0, len(args)+additionalCount) // Avoid in-place modification
 	// Add "go build"
@@ -663,4 +666,14 @@ func runGoBuild(ctx context.Context, cmd *cli.Command) error {
 	}
 	logger.InfoContext(ctx, "Instrumentation completed successfully")
 	return nil
+}
+
+// quoteForGo quotes a value for cmd/go's internal/quoted splitting: the
+// -toolexec flag value is split on whitespace, so paths with spaces must be
+// wrapped in double quotes. cmd/go's splitter does not process backslash
+// escapes (unlike strconv.Quote), so a plain quote wrap is the correct form;
+// like go itself, values containing a literal double quote cannot be
+// represented (#1207).
+func quoteForGo(v string) string {
+	return `"` + v + `"`
 }

--- a/tool/internal/setup/toolexec_quote_test.go
+++ b/tool/internal/setup/toolexec_quote_test.go
@@ -1,0 +1,64 @@
+package setup
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression (#1207): cmd/go splits the -toolexec value on whitespace
+// (internal/quoted), so an otelc executable installed under a path with
+// spaces — "Program Files" being the obvious one — must be quoted or `go`
+// runs only the first chunk. The constructed flag value must therefore
+// contain the whole executable path as a single whitespace-free token after
+// go's unquoting, and the " toolexec" argument must survive as its own token.
+func TestToolexecFlagQuotesPathWithSpaces(t *testing.T) {
+	execPath := filepath.Join("C:", "Program Files", "otelc", "otelc.exe")
+	insert := "-toolexec=" + quoteForGo(execPath) + " toolexec"
+
+	value := strings.TrimPrefix(insert, "-toolexec=")
+
+	// go's internal/quoted split: honor double quotes, split on whitespace.
+	tokens := splitQuoted(value)
+	if len(tokens) != 2 {
+		t.Fatalf("expected [exec arg] tokens after go's split, got %d: %q", len(tokens), tokens)
+	}
+	if tokens[0] != execPath {
+		t.Fatalf("executable token = %q, want the full path %q", tokens[0], execPath)
+	}
+	if tokens[1] != "toolexec" {
+		t.Fatalf("argument token = %q, want %q", tokens[1], "toolexec")
+	}
+
+	// Without quoting the split drops everything after the first space.
+	unquoted := "-toolexec=" + execPath + " toolexec"
+	bare := strings.Fields(strings.TrimPrefix(unquoted, "-toolexec="))
+	if bare[0] != "C:Program" || len(bare) > 3 {
+		t.Fatalf("unquoted construction should break at the space, got %q", bare)
+	}
+}
+
+// splitQuoted mimics cmd/go's internal/quoted splitting closely enough for
+// this test: double-quoted runs count as one token, else split on spaces.
+func splitQuoted(s string) []string {
+	var out []string
+	var cur strings.Builder
+	inQuote := false
+	for _, r := range s {
+		switch {
+		case r == '"':
+			inQuote = !inQuote
+		case r == ' ' && !inQuote:
+			if cur.Len() > 0 {
+				out = append(out, cur.String())
+				cur.Reset()
+			}
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	if cur.Len() > 0 {
+		out = append(out, cur.String())
+	}
+	return out
+}


### PR DESCRIPTION
Fixes #1207.

## Root cause

`buildWithToolexec` builds the flag by plain concatenation:

```go
insert := "-toolexec=" + execPath + " toolexec"
```

`cmd/go` splits the `-toolexec` value on whitespace (`internal/quoted`), so an install path with a space — `C:\Program Files\...` on Windows being the obvious case, any user dir with a space works too — makes `go` run only the first chunk, and the build fails with `executable file not found` for the truncated path (the issue's exact repro).

## Fix

Wrap the path in **plain double quotes** — not `strconv.Quote`: go's splitter does not process backslash escapes, so `strconv.Quote` would corrupt Windows paths by doubling every backslash (verified against the splitter semantics; a first draft using `strconv.Quote` produced doubled-backslash tokens). Like `go` itself, values containing a literal double quote cannot be represented.

## Test

`TestToolexecFlagQuotesPathWithSpaces` splits the constructed flag value the way cmd/go's `internal/quoted` does (double-quoted runs are one token) and asserts the executable token is the **whole** path, the ` toolexec` argument survives as its own token, and the unquoted construction demonstrably breaks at the space (pinning the bug).

Package passes with the fix; differential with `setup.go` reverted fails on the broken-split assertions. `gofmt`/`go vet` clean.
