### PR TITLE
fix(tool): quote otelc path in -toolexec so spaced paths work

### DIFF
--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"maps"
 	"os"
@@ -474,9 +473,22 @@ func EnableNestedToolexec() error {
 	if err != nil {
 		return ex.Wrapf(err, "resolving otelc executable path")
 	}
-	toolexecFlag, err := util.QuoteGoflagsToken(fmt.Sprintf("-toolexec=%s toolexec", execPath))
+	// Quoted twice on purpose: the inner quote keeps a spaced path intact when
+	// cmd/go splits the -toolexec value, the outer one keeps the whole flag a
+	// single token when cmd/go splits GOFLAGS.
+	innerFlag, err := util.BuildToolexecFlag(execPath)
 	if err != nil {
-		return ex.Wrapf(err, "quoting nested toolexec GOFLAGS entry")
+		return ex.Wrapf(err, "building nested -toolexec flag for %q", execPath)
+	}
+	toolexecFlag, err := util.QuoteGoflagsToken(innerFlag)
+	if err != nil {
+		// Only reachable when execPath contains a single quote: the inner
+		// quoting then has to use double quotes, leaving both kinds in the
+		// token. GOFLAGS is split by cmd/internal/quoted.Split, which has no
+		// escape syntax, so such a token simply cannot be represented there.
+		return ex.Wrapf(err, "otelc's own path %q contains a single quote, "+
+			"which cannot be passed to nested go commands through GOFLAGS; "+
+			"reinstall otelc under a path without one", execPath)
 	}
 	goflags := strings.TrimSpace(os.Getenv("GOFLAGS") + " " + toolexecFlag)
 	if err = os.Setenv("GOFLAGS", goflags); err != nil {

--- a/tool/internal/instrument/toolexec_test.go
+++ b/tool/internal/instrument/toolexec_test.go
@@ -706,6 +706,13 @@ func TestEnableNestedToolexec(t *testing.T) {
 	exe, err := os.Executable()
 	require.NoError(t, err)
 
+	// Built rather than hardcoded: the quoting depends on whether the test
+	// binary's own path contains a space, which varies by machine.
+	innerFlag, err := util.BuildToolexecFlag(exe)
+	require.NoError(t, err)
+	wantToken, err := util.QuoteGoflagsToken(innerFlag)
+	require.NoError(t, err)
+
 	t.Run("appends to existing GOFLAGS and sets the nested marker", func(t *testing.T) {
 		t.Setenv("GOFLAGS", "-mod=mod")
 		t.Setenv(util.EnvOtelcNestedToolexec, "")
@@ -714,7 +721,7 @@ func TestEnableNestedToolexec(t *testing.T) {
 
 		goflags := os.Getenv("GOFLAGS")
 		assert.Contains(t, goflags, "-mod=mod", "existing flags are preserved")
-		assert.Contains(t, goflags, "'-toolexec="+exe+" toolexec'", "otelc is added as the toolexec")
+		assert.Contains(t, goflags, wantToken, "otelc is added as the toolexec")
 		assert.Equal(t, "1", os.Getenv(util.EnvOtelcNestedToolexec))
 	})
 
@@ -724,8 +731,83 @@ func TestEnableNestedToolexec(t *testing.T) {
 
 		require.NoError(t, EnableNestedToolexec())
 
-		assert.Equal(t, "'-toolexec="+exe+" toolexec'", os.Getenv("GOFLAGS"))
+		assert.Equal(t, wantToken, os.Getenv("GOFLAGS"))
 	})
+
+	t.Run("GOFLAGS survives both splits cmd/go performs", func(t *testing.T) {
+		t.Setenv("GOFLAGS", "")
+		t.Setenv(util.EnvOtelcNestedToolexec, "")
+
+		require.NoError(t, EnableNestedToolexec())
+
+		assert.Equal(t, []string{exe, "toolexec"}, parseToolexecFromGoflags(t, os.Getenv("GOFLAGS")))
+	})
+
+	t.Run("a spaced executable path survives both splits", func(t *testing.T) {
+		// EnableNestedToolexec resolves its own path, so the spaced case is
+		// exercised by composing GOFLAGS the same way and parsing it back.
+		spaced := filepath.Join(string(filepath.Separator)+"opt", "my tools", "otelc")
+		inner, buildErr := util.BuildToolexecFlag(spaced)
+		require.NoError(t, buildErr)
+		token, quoteErr := util.QuoteGoflagsToken(inner)
+		require.NoError(t, quoteErr)
+
+		assert.Equal(t, []string{spaced, "toolexec"}, parseToolexecFromGoflags(t, token))
+	})
+
+	t.Run("a path containing a single quote is rejected with an actionable error", func(t *testing.T) {
+		// Both quote kinds end up in the token, which GOFLAGS cannot encode.
+		inner, buildErr := util.BuildToolexecFlag("/home/it's me/otelc")
+		require.NoError(t, buildErr, "the inner flag itself is representable")
+
+		_, quoteErr := util.QuoteGoflagsToken(inner)
+		require.Error(t, quoteErr, "but it cannot be nested inside GOFLAGS")
+	})
+}
+
+// splitQuoted mirrors cmd/internal/quoted.Split, which is what cmd/go uses for
+// both GOFLAGS and the -toolexec value: whitespace-separated, with `'` or `"`
+// grouping, and no unescaping inside a quoted run. Reimplemented here rather
+// than reusing the production helpers so the tests below check the round trip
+// against the real format instead of against otelc's own encoder.
+func splitQuoted(t *testing.T, s string) []string {
+	t.Helper()
+	isSpace := func(c byte) bool { return c == ' ' || c == '\t' || c == '\n' || c == '\r' }
+	var out []string
+	for len(s) > 0 {
+		for len(s) > 0 && isSpace(s[0]) {
+			s = s[1:]
+		}
+		if len(s) == 0 {
+			break
+		}
+		if q := s[0]; q == '"' || q == '\'' {
+			s = s[1:]
+			end := strings.IndexByte(s, q)
+			require.GreaterOrEqual(t, end, 0, "unterminated %c-quoted run in %q", q, s)
+			out = append(out, s[:end])
+			s = s[end+1:]
+			continue
+		}
+		end := 0
+		for end < len(s) && !isSpace(s[end]) {
+			end++
+		}
+		out = append(out, s[:end])
+		s = s[end:]
+	}
+	return out
+}
+
+// parseToolexecFromGoflags walks the same two split layers cmd/go does and
+// returns the argv it would end up executing for -toolexec.
+func parseToolexecFromGoflags(t *testing.T, goflags string) []string {
+	t.Helper()
+	flags := splitQuoted(t, goflags)
+	require.Len(t, flags, 1, "expected a lone -toolexec flag in %q", goflags)
+	value, ok := strings.CutPrefix(flags[0], "-toolexec=")
+	require.True(t, ok, "flag %q is not a -toolexec entry", flags[0])
+	return splitQuoted(t, value)
 }
 
 // versionMarkerPattern documents the exact tool-ID shape the go build cache

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -542,7 +542,10 @@ func buildWithToolexec(ctx context.Context, cmd *cli.Command, vendored bool) err
 	if err != nil {
 		return ex.Wrapf(err, "failed to get executable path")
 	}
-	insert := "-toolexec=" + execPath + " toolexec"
+	insert, err := util.BuildToolexecFlag(execPath)
+	if err != nil {
+		return ex.Wrapf(err, "building -toolexec flag for %q", execPath)
+	}
 	const additionalCount = 2
 	newArgs := make([]string, 0, len(args)+additionalCount) // Avoid in-place modification
 	// Add "go build"

--- a/tool/util/go.go
+++ b/tool/util/go.go
@@ -171,6 +171,18 @@ func QuoteGoflagsToken(token string) (string, error) {
 	}
 }
 
+// BuildToolexecFlag returns the -toolexec flag that points the go command at
+// the given executable in toolexec mode. execPath is quoted because cmd/go
+// splits the flag's value with cmd/internal/quoted.Split, so an unquoted path
+// containing a space would be read as a path plus extra arguments.
+func BuildToolexecFlag(execPath string) (string, error) {
+	quotedPath, err := QuoteGoflagsToken(execPath)
+	if err != nil {
+		return "", ex.Wrapf(err, "quoting otelc executable path for -toolexec")
+	}
+	return "-toolexec=" + quotedPath + " toolexec", nil
+}
+
 // FindFlagValue finds the value of a flag in the command line.
 func FindFlagValue(cmd []string, flag string) string {
 	flagWithValue := flag + "="

--- a/tool/util/go_test.go
+++ b/tool/util/go_test.go
@@ -673,6 +673,60 @@ func TestQuoteGoflagsToken(t *testing.T) {
 	}
 }
 
+func TestBuildToolexecFlag(t *testing.T) {
+	tests := []struct {
+		name     string
+		execPath string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "path without spaces stays unquoted",
+			execPath: "/usr/local/bin/otelc",
+			want:     "-toolexec=/usr/local/bin/otelc toolexec",
+		},
+		{
+			name:     "path with spaces is single quoted",
+			execPath: `C:\Program Files\otelc\otelc.exe`,
+			want:     `-toolexec='C:\Program Files\otelc\otelc.exe' toolexec`,
+		},
+		{
+			name:     "path with a single quote falls back to double quotes",
+			execPath: "/home/it's me/otelc",
+			want:     `-toolexec="/home/it's me/otelc" toolexec`,
+		},
+		{
+			name:     "path with both quote characters errors",
+			execPath: `/home/it's "me"/otelc`,
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildToolexecFlag(tt.execPath)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// A -toolexec entry built by BuildToolexecFlag carries its own inner quotes
+// once the executable path has a space, so stripping has to see past them.
+func TestStripToolexecFromGoflagsWithNestedQuotes(t *testing.T) {
+	inner, err := BuildToolexecFlag(`C:\Program Files\otelc\otelc.exe`)
+	require.NoError(t, err)
+	token, err := QuoteGoflagsToken(inner)
+	require.NoError(t, err)
+
+	assert.Empty(t, StripToolexecFromGoflags(token))
+	assert.Equal(t, "-mod=mod", StripToolexecFromGoflags("-mod=mod "+token))
+	assert.Equal(t, "-mod=mod", StripToolexecFromGoflags(token+" -mod=mod"))
+}
+
 func TestNewFileScanner(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "lines.txt")
 	require.NoError(t, os.WriteFile(path, []byte("line1\nline2\nline3\n"), 0o644))


### PR DESCRIPTION
## Description

`buildWithToolexec` built the `-toolexec` flag by concatenating otelc's own path in unquoted. `cmd/go` parses the `-toolexec` value with `cmd/internal/quoted.Split`, so an unquoted executable path containing a space was read as a path plus extra arguments. A build run from `C:\Program Files\otelc\otelc.exe` failed with `exec: "C:\Program": executable file not found in %PATH%`.

Added `util.BuildToolexecFlag`, which quotes `execPath` with the existing `QuoteGoflagsToken`, and used it at both construction sites. The nested `GOFLAGS` entry now quotes twice on purpose: the inner quote survives the `-toolexec` value split, the outer one survives the `GOFLAGS` split.

A path containing a single quote leaves both quote kinds in the nested token, which `GOFLAGS` cannot encode since `quoted.Split` has no escape syntax. That case now fails with an error naming the path as the cause rather than silently producing a flag the go command misparses.

## Motivation

Any otelc install path with a space in it hits this, `Program Files` on Windows being the obvious one, but any user directory with a space works too. Build just breaks with a confusing error pointing at a truncated path.

Fixes #1207

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

