### PR TITLE
fix(instrumentation): detect SSE content types case-insensitively

### DIFF
--- a/instrumentation/github.com/anthropics/anthropic-sdk-go/middleware.go
+++ b/instrumentation/github.com/anthropics/anthropic-sdk-go/middleware.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
 	"time"
@@ -158,7 +159,7 @@ func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, e
 		// still answers with SSE, end the span without response attributes
 		// rather than hold it open on a body we do not accumulate yet.
 		contentType := resp.Header.Get("Content-Type")
-		if strings.HasPrefix(contentType, "text/event-stream") {
+		if isSSEContentType(contentType) {
 			span.SetAttributes(semconv.GenAIRequestIsStream(true))
 			span.End()
 			return resp, nil
@@ -168,6 +169,18 @@ func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, e
 
 		return resp, nil
 	}
+}
+
+// isSSEContentType reports whether a Content-Type header names the SSE media
+// type. HTTP media types are case-insensitive and may carry parameters, so the
+// raw prefix check used previously misclassified headers like
+// "Text/Event-Stream; charset=utf-8".
+func isSSEContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(mediaType, "text/event-stream")
 }
 
 func handleNonStreamingResponse(resp *http.Response, span trace.Span) {

--- a/instrumentation/github.com/anthropics/anthropic-sdk-go/middleware_test.go
+++ b/instrumentation/github.com/anthropics/anthropic-sdk-go/middleware_test.go
@@ -653,3 +653,24 @@ func assertBoolAttribute(t *testing.T, attrs []attribute.KeyValue, key string, e
 	require.True(t, ok, "attribute %s not found", key)
 	assert.Equal(t, expected, val.AsBool(), "attribute %s", key)
 }
+
+func TestIsSSEContentType(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		{"lowercase", "text/event-stream", true},
+		{"mixed case", "Text/Event-Stream", true},
+		{"uppercase with parameter", "TEXT/EVENT-STREAM; charset=utf-8", true},
+		{"json", "application/json", false},
+		{"empty", "", false},
+		{"prefix only", "text/event-streamx", false},
+		{"malformed parameter", "text/event-stream; ::", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSSEContentType(tt.contentType))
+		})
+	}
+}

--- a/instrumentation/github.com/openai/openai-go/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/middleware.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -187,7 +188,7 @@ func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, e
 		}
 
 		contentType := resp.Header.Get("Content-Type")
-		isStreaming := strings.HasPrefix(contentType, "text/event-stream")
+		isStreaming := isSSEContentType(contentType)
 
 		if isStreaming {
 			span.SetAttributes(semconv.GenAIRequestIsStream(true))
@@ -198,6 +199,18 @@ func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, e
 
 		return resp, nil
 	}
+}
+
+// isSSEContentType reports whether a Content-Type header names the SSE media
+// type. HTTP media types are case-insensitive and may carry parameters, so the
+// raw prefix check used previously misclassified headers like
+// "Text/Event-Stream; charset=utf-8".
+func isSSEContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(mediaType, "text/event-stream")
 }
 
 func handleNonStreamingResponse(

--- a/instrumentation/github.com/openai/openai-go/middleware_integration_test.go
+++ b/instrumentation/github.com/openai/openai-go/middleware_integration_test.go
@@ -512,6 +512,45 @@ func TestOtelMiddleware_StreamingResponse(t *testing.T) {
 	assertInt64Attribute(t, attrs, "gen_ai.usage.total_tokens", 7)
 }
 
+func TestOtelMiddleware_StreamingResponse_MixedCaseContentType(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	middleware := OtelMiddleware()
+
+	reqBody := `{"model":"gpt-4","stream":true}`
+	req, _ := http.NewRequest(
+		"POST",
+		"http://api.openai.com/v1/chat/completions",
+		io.NopCloser(bytes.NewReader([]byte(reqBody))),
+	)
+
+	// HTTP media types are case-insensitive (RFC 9110 §8.3.1); some
+	// OpenAI-compatible servers send "Text/Event-Stream".
+	streamData := "data: {\"id\":\"chatcmpl-stream\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"finish_reason\":null}]}\n\ndata: [DONE]\n\n"
+	next := func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"Text/Event-Stream; charset=utf-8"}},
+			Body:       io.NopCloser(bytes.NewReader([]byte(streamData))),
+		}, nil
+	}
+
+	resp, err := middleware(req, next)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Hi")
+	resp.Body.Close()
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+
+	assertAttribute(t, spans[0].Attributes(), "gen_ai.request.is_stream", "true")
+	assertAttribute(t, spans[0].Attributes(), "gen_ai.response.id", "chatcmpl-stream")
+}
+
 func TestOtelMiddleware_AzurePath(t *testing.T) {
 	sr := setupTestTracer(t)
 

--- a/instrumentation/github.com/openai/openai-go/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/middleware_test.go
@@ -128,3 +128,24 @@ func TestParseChatResponse_Valid(t *testing.T) {
 	assert.Equal(t, int64(20), resp.Usage.CompletionTokens)
 	assert.Equal(t, "stop", resp.Choices[0].FinishReason)
 }
+
+func TestIsSSEContentType(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		{"lowercase", "text/event-stream", true},
+		{"mixed case", "Text/Event-Stream", true},
+		{"uppercase with parameter", "TEXT/EVENT-STREAM; charset=utf-8", true},
+		{"json", "application/json", false},
+		{"empty", "", false},
+		{"prefix only", "text/event-streamx", false},
+		{"malformed parameter", "text/event-stream; ::", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSSEContentType(tt.contentType))
+		})
+	}
+}

--- a/instrumentation/github.com/openai/openai-go/v2/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/v2/middleware.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -187,7 +188,7 @@ func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, e
 		}
 
 		contentType := resp.Header.Get("Content-Type")
-		isStreaming := strings.HasPrefix(contentType, "text/event-stream")
+		isStreaming := isSSEContentType(contentType)
 
 		if isStreaming {
 			span.SetAttributes(semconv.GenAIRequestIsStream(true))
@@ -198,6 +199,18 @@ func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, e
 
 		return resp, nil
 	}
+}
+
+// isSSEContentType reports whether a Content-Type header names the SSE media
+// type. HTTP media types are case-insensitive and may carry parameters, so the
+// raw prefix check used previously misclassified headers like
+// "Text/Event-Stream; charset=utf-8".
+func isSSEContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(mediaType, "text/event-stream")
 }
 
 func handleNonStreamingResponse(

--- a/instrumentation/github.com/openai/openai-go/v2/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/v2/middleware_test.go
@@ -128,3 +128,24 @@ func TestParseChatResponse_Valid(t *testing.T) {
 	assert.Equal(t, int64(20), resp.Usage.CompletionTokens)
 	assert.Equal(t, "stop", resp.Choices[0].FinishReason)
 }
+
+func TestIsSSEContentType(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		{"lowercase", "text/event-stream", true},
+		{"mixed case", "Text/Event-Stream", true},
+		{"uppercase with parameter", "TEXT/EVENT-STREAM; charset=utf-8", true},
+		{"json", "application/json", false},
+		{"empty", "", false},
+		{"prefix only", "text/event-streamx", false},
+		{"malformed parameter", "text/event-stream; ::", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSSEContentType(tt.contentType))
+		})
+	}
+}

--- a/instrumentation/github.com/openai/openai-go/v3/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/v3/middleware.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -187,7 +188,7 @@ func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, e
 		}
 
 		contentType := resp.Header.Get("Content-Type")
-		isStreaming := strings.HasPrefix(contentType, "text/event-stream")
+		isStreaming := isSSEContentType(contentType)
 
 		if isStreaming {
 			span.SetAttributes(semconv.GenAIRequestIsStream(true))
@@ -198,6 +199,18 @@ func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, e
 
 		return resp, nil
 	}
+}
+
+// isSSEContentType reports whether a Content-Type header names the SSE media
+// type. HTTP media types are case-insensitive and may carry parameters, so the
+// raw prefix check used previously misclassified headers like
+// "Text/Event-Stream; charset=utf-8".
+func isSSEContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(mediaType, "text/event-stream")
 }
 
 func handleNonStreamingResponse(

--- a/instrumentation/github.com/openai/openai-go/v3/middleware_test.go
+++ b/instrumentation/github.com/openai/openai-go/v3/middleware_test.go
@@ -128,3 +128,24 @@ func TestParseChatResponse_Valid(t *testing.T) {
 	assert.Equal(t, int64(20), resp.Usage.CompletionTokens)
 	assert.Equal(t, "stop", resp.Choices[0].FinishReason)
 }
+
+func TestIsSSEContentType(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		{"lowercase", "text/event-stream", true},
+		{"mixed case", "Text/Event-Stream", true},
+		{"uppercase with parameter", "TEXT/EVENT-STREAM; charset=utf-8", true},
+		{"json", "application/json", false},
+		{"empty", "", false},
+		{"prefix only", "text/event-streamx", false},
+		{"malformed parameter", "text/event-stream; ::", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSSEContentType(tt.contentType))
+		})
+	}
+}


### PR DESCRIPTION
## Description

The OpenAI (v1/v2/v3) and Anthropic middlewares decided whether a response was an SSE stream with a case-sensitive prefix check:

```go
strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream")
```

HTTP media types are case-insensitive (RFC 9110 §8.3.1), and servers behind OpenAI-compatible gateways do send e.g. `Text/Event-Stream; charset=utf-8`. Such responses fell into the non-streaming path: `gen_ai.request.is_stream` was never set and the body was buffered instead of being finalized incrementally by the streaming reader.

## Fix

Parse the header with `mime.ParseMediaType` (which also strips parameters) and compare the resulting media type with `strings.EqualFold`. Applied consistently in:

- `instrumentation/github.com/openai/openai-go` (v1)
- `instrumentation/github.com/openai/openai-go/v2`
- `instrumentation/github.com/openai/openai-go/v3`
- `instrumentation/github.com/anthropics/anthropic-sdk-go`

## Testing

- New integration test in the v1 package sends `Content-Type: Text/Event-Stream; charset=utf-8` and asserts `gen_ai.request.is_stream=true` plus the streamed response attributes — fails on the old prefix check, passes with the fix.
- Table-driven `TestIsSSEContentType` unit tests in all four packages cover mixed case, parameters, `text/event-streamx`, empty, and malformed-parameter headers.
- `go test ./...` passes in all four module directories.

Fixes #1212
