### PR TITLE
fix(tool/internal/ast): handle import alias collisions in ImportAliasMap

### DIFF
--- a/tool/internal/ast/parser.go
+++ b/tool/internal/ast/parser.go
@@ -40,7 +40,9 @@ func (ap *AstParser) Parse(filePath string, mode parser.Mode) (*dst.File, error)
 	if err != nil {
 		return nil, ex.Wrapf(err, "failed to open file %s", filePath)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 	astFile, err := parser.ParseFile(ap.fset, name, file, mode)
 	if err != nil {
 		return nil, ex.Wrapf(err, "failed to parse file %s", filePath)

--- a/tool/internal/ast/typename.go
+++ b/tool/internal/ast/typename.go
@@ -158,6 +158,7 @@ func ImportAliasMap(file *dst.File) map[string]string {
 	}
 
 	aliases := make(map[string]string, len(specs))
+	explicit := make(map[string]bool, len(specs))
 	for _, imp := range specs {
 		if imp.Path == nil {
 			continue
@@ -167,15 +168,31 @@ func ImportAliasMap(file *dst.File) map[string]string {
 			continue
 		}
 		alias := defaultImportAlias(path)
+		isExplicit := false
 		if imp.Name != nil {
 			alias = imp.Name.Name
+			isExplicit = true
 		}
 		// Blank and dot imports don't introduce a qualified identifier that a
 		// type reference could use, so they can't participate in matching.
 		if alias == "" || alias == "_" || alias == "." {
 			continue
 		}
-		aliases[alias] = path
+
+		if existing, exists := aliases[alias]; exists && existing != path {
+			if isExplicit {
+				aliases[alias] = path
+				explicit[alias] = true
+			} else if !explicit[alias] {
+				// Disambiguate: two distinct default aliases collide; remove ambiguous key.
+				delete(aliases, alias)
+			}
+		} else {
+			aliases[alias] = path
+			if isExplicit {
+				explicit[alias] = true
+			}
+		}
 	}
 	return aliases
 }

--- a/tool/internal/ast/typename.go
+++ b/tool/internal/ast/typename.go
@@ -159,6 +159,8 @@ func ImportAliasMap(file *dst.File) map[string]string {
 
 	aliases := make(map[string]string, len(specs))
 	explicit := make(map[string]bool, len(specs))
+	ambiguous := make(map[string]bool, len(specs))
+
 	for _, imp := range specs {
 		if imp.Path == nil {
 			continue
@@ -179,18 +181,17 @@ func ImportAliasMap(file *dst.File) map[string]string {
 			continue
 		}
 
-		if existing, exists := aliases[alias]; exists && existing != path {
-			if isExplicit {
-				aliases[alias] = path
-				explicit[alias] = true
-			} else if !explicit[alias] {
-				// Disambiguate: two distinct default aliases collide; remove ambiguous key.
-				delete(aliases, alias)
-			}
-		} else {
+		if isExplicit {
 			aliases[alias] = path
-			if isExplicit {
-				explicit[alias] = true
+			explicit[alias] = true
+			delete(ambiguous, alias)
+		} else if !explicit[alias] {
+			if existing, exists := aliases[alias]; exists && existing != path {
+				// Disambiguate: two or more distinct default aliases collide; remove key and track as ambiguous.
+				delete(aliases, alias)
+				ambiguous[alias] = true
+			} else if !ambiguous[alias] {
+				aliases[alias] = path
 			}
 		}
 	}

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -359,6 +359,57 @@ func f() {}
 		assert.Equal(t, "text/template", imports["txttemplate"])
 	})
 
+	t.Run("explicit alias overrides existing default alias", func(t *testing.T) {
+		p := NewAstParser()
+		file, err := p.ParseSource(`package main
+
+import (
+	"html/template"
+	template "text/template"
+)
+
+func f() {}
+`)
+		require.NoError(t, err)
+
+		imports := ImportAliasMap(file)
+		assert.Equal(t, "text/template", imports["template"])
+	})
+
+	t.Run("explicit alias takes precedence over subsequent default alias", func(t *testing.T) {
+		p := NewAstParser()
+		file, err := p.ParseSource(`package main
+
+import (
+	template "text/template"
+	"html/template"
+)
+
+func f() {}
+`)
+		require.NoError(t, err)
+
+		imports := ImportAliasMap(file)
+		assert.Equal(t, "text/template", imports["template"])
+	})
+
+	t.Run("duplicate identical import path is preserved", func(t *testing.T) {
+		p := NewAstParser()
+		file, err := p.ParseSource(`package main
+
+import (
+	"html/template"
+	"html/template"
+)
+
+func f() {}
+`)
+		require.NoError(t, err)
+
+		imports := ImportAliasMap(file)
+		assert.Equal(t, "html/template", imports["template"])
+	})
+
 	t.Run("package name unrelated to import path is not resolved by convention", func(t *testing.T) {
 		// github.com/redis/go-redis/v9 declares package "redis", not "go-redis".
 		p := NewAstParser()

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -324,6 +324,41 @@ func f(x *foo.T, y *bar.T) {}
 		assert.Equal(t, "github.com/b/bar/v2", imports["bar"])
 	})
 
+	t.Run("unaliased colliding default aliases are removed as ambiguous", func(t *testing.T) {
+		p := NewAstParser()
+		file, err := p.ParseSource(`package main
+
+import (
+	"html/template"
+	"text/template"
+)
+
+func f() {}
+`)
+		require.NoError(t, err)
+
+		imports := ImportAliasMap(file)
+		assert.NotContains(t, imports, "template")
+	})
+
+	t.Run("explicit alias overrides colliding default alias", func(t *testing.T) {
+		p := NewAstParser()
+		file, err := p.ParseSource(`package main
+
+import (
+	"html/template"
+	txttemplate "text/template"
+)
+
+func f() {}
+`)
+		require.NoError(t, err)
+
+		imports := ImportAliasMap(file)
+		assert.Equal(t, "html/template", imports["template"])
+		assert.Equal(t, "text/template", imports["txttemplate"])
+	})
+
 	t.Run("package name unrelated to import path is not resolved by convention", func(t *testing.T) {
 		// github.com/redis/go-redis/v9 declares package "redis", not "go-redis".
 		p := NewAstParser()

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -341,6 +341,24 @@ func f() {}
 		assert.NotContains(t, imports, "template")
 	})
 
+	t.Run("three-way unaliased colliding default aliases remain ambiguous", func(t *testing.T) {
+		p := NewAstParser()
+		file, err := p.ParseSource(`package main
+
+import (
+	"example.com/foo/util"
+	"example.com/bar/util"
+	"example.com/baz/util"
+)
+
+func f() {}
+`)
+		require.NoError(t, err)
+
+		imports := ImportAliasMap(file)
+		assert.NotContains(t, imports, "util")
+	})
+
 	t.Run("explicit alias overrides colliding default alias", func(t *testing.T) {
 		p := NewAstParser()
 		file, err := p.ParseSource(`package main


### PR DESCRIPTION
Fixes #1219

### Description
This PR resolves issue #1219 in `ImportAliasMap` where distinct unaliased imports sharing a last path segment (e.g. `text/template` and `html/template`, both conventionally defaulting to `template`) would silently overwrite existing map entries.

### Changes Made
1. Updated `ImportAliasMap` in `tool/internal/ast/typename.go` to track explicit vs default import aliases.
2. If two unaliased imports produce colliding default package names, the ambiguous alias key is deleted from `aliases` instead of overwriting the previous entry.
3. Explicit aliases (`import txttemplate "text/template"`) continue to take precedence over default package names.
4. Added comprehensive unit test coverage in `tool/internal/ast/typename_test.go`.

### Verification
- All AST package unit tests (`go test -v ./tool/internal/ast/...`) passed cleanly (100%).
