### PR TITLE
fix(tool): parse separated -exec flag values correctly

### DIFF
--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -108,6 +108,7 @@ var testFlagsWithValues = map[string]bool{
 	"-coverprofile":         true,
 	"-cpu":                  true,
 	"-cpuprofile":           true,
+	"-exec":                 true,
 	"-fuzz":                 true,
 	"-fuzzminimizetime":     true,
 	"-fuzztime":             true,

--- a/tool/internal/setup/setup_test.go
+++ b/tool/internal/setup/setup_test.go
@@ -233,6 +233,20 @@ func TestSplitBuildTargets(t *testing.T) {
 			notPkgTargets: []string{"off"},
 			expectError:   false,
 		},
+		{
+			name:          "go test -exec value is not a package",
+			targets:       []string{"-exec", "sudo", "./pkg"},
+			pkgTargets:    []string{"./pkg"},
+			notPkgTargets: []string{"sudo"},
+			expectError:   false,
+		},
+		{
+			name:          "go test package before -exec flag",
+			targets:       []string{"./pkg", "-exec", "sudo"},
+			pkgTargets:    []string{"./pkg"},
+			notPkgTargets: []string{"sudo"},
+			expectError:   false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Fixes `otelc go test -exec <program> ./...` setup failures where the program passed to `-exec` is incorrectly loaded as a package target.

  ## Motivation

`splitBuildTargets` skips separated flag values only for flags listed in `flagsWithPathValues` or `testFlagsWithValues`. Since `-exec` was missing from both tables, its value was classified as a package pattern.

  ## Changes

  - Add `-exec` to `testFlagsWithValues`.
  - Add regression coverage for both supported argument orders.

  ## Testing

  - `go test ./tool/internal/setup -count=1` ✅
  - `make all` reached Go lint but failed with 43 golangci-lint findings, including a goconst finding involving this change.

  Fixes #1221

  ---

  ## Checklist

  - [x] PR title follows conventional commits format
  - [ ] Code formatted: `make format`
  - [ ] Linters pass: `make lint`
  - [x] Tests pass for the affected package
  - [x] Tests added for new functionality
  - [x] Tests follow testing guidelines
  - [ ] Documentation updated
  - [ ] OpenTelemetry Registry updated
  - [x] I have read and followed the Generative AI Contribution Policy
  - [x] I have the experience and knowledge necessary to understand, review, and validate this PR