### PR TITLE
test: add context to HTTP request in vendor_test.go

### DIFF
--- a/test/integration/vendor_test.go
+++ b/test/integration/vendor_test.go
@@ -77,7 +77,9 @@ func TestVendoredBuild(t *testing.T) {
 
 	testutil.WaitForTCP(t, fmt.Sprintf("127.0.0.1:%d", port))
 
-	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/hello/OpenTelemetry", port)) //nolint:noctx
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/hello/OpenTelemetry", port), nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, http.StatusOK, resp.StatusCode)


### PR DESCRIPTION
<!--
Thank you for contributing to OpenTelemetry Go Compile Instrumentation!

INSTRUCTIONS:
1. Fill in the description and motivation sections below
2. Complete the checklist before submitting
3. Ensure PR title follows conventional commits format (enforced by CI)

PR TITLE FORMAT (required):
  type(scope): description

  Types: chore, doc, docs, feat, fix, release, refactor, test
  Scopes: tool, pkg, demo, test, docs

  Examples:
  - feat(pkg): add gRPC client instrumentation
  - fix(tool): resolve hook signature matching issue
  - docs(api): update instrumenter interface documentation
  - refactor(pkg): simplify attribute extractor composition

BEFORE SUBMITTING:
  make format  # Format Go code and YAML files
  make lint    # Run all linters
  make test    # Run all tests (unit + integration + e2e)

If your PR adds a new user-facing instrumentation, please also submit a corresponding OpenTelemetry Registry PR:
https://opentelemetry.io/ecosystem/registry/adding/

For detailed contribution guidelines, see CONTRIBUTING.md
For available make targets, run: make help
-->

## Description

This PR replaces `http.Get` with `http.NewRequestWithContext` in `test/integration/vendor_test.go` to use the test context (`t.Context()`) for the HTTP request instead of ignoring the missing context.

## Motivation

This change is needed to ensure proper context propagation during HTTP requests in tests. It prevents potential test hangs and complies with best practices.



---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
