### PR TITLE
fix(tool): handle generic receiver type parameters

### DIFF
--- a/tool/internal/instrument/apply_func.go
+++ b/tool/internal/instrument/apply_func.go
@@ -165,7 +165,7 @@ func createTrampArgs(names []string) []dst.Expr {
 	return exprs
 }
 
-func createTJumpIf(t *rule.InstFuncRule, funcDecl *dst.FuncDecl,
+func createTJumpIf(file *dst.File, t *rule.InstFuncRule, funcDecl *dst.FuncDecl,
 	args, retVals []string,
 ) *dst.IfStmt {
 	funcSuffix := t.Identity()
@@ -175,8 +175,9 @@ func createTJumpIf(t *rule.InstFuncRule, funcDecl *dst.FuncDecl,
 	argsToAfter = append([]dst.Expr{argHookContext}, argsToAfter...)
 	beforeCallName := makeName(t, funcDecl, true)
 	afterCallName := makeName(t, funcDecl, false)
-	beforeCall := ast.CallTo(beforeCallName, funcDecl.Type.TypeParams, argsToBefore)
-	afterCall := ast.CallTo(afterCallName, funcDecl.Type.TypeParams, argsToAfter)
+	typeParams := findTargetGenericType(file, funcDecl)
+	beforeCall := ast.CallTo(beforeCallName, typeParams, argsToBefore)
+	afterCall := ast.CallTo(afterCallName, typeParams, argsToAfter)
 	tjumpInit := ast.DefineStmts(
 		ast.Exprs(
 			ast.Ident(trampolineHookContextName+funcSuffix),
@@ -271,7 +272,7 @@ func (ip *instrumentPhase) insertTJump(t *rule.InstFuncRule, funcDecl *dst.FuncD
 	// the context, handles exceptions, etc, and ultimately jumps to the real
 	// hook code. By inserting trampoline-jump-if at the target function entry,
 	// we can intercept the original function and execute before/after hooks.
-	tjump := createTJumpIf(t, funcDecl, args, retVals)
+	tjump := createTJumpIf(ip.target, t, funcDecl, args, retVals)
 
 	// Record the trampoline-jump-if as they can be optimized later, they are
 	// performance-critical

--- a/tool/internal/instrument/apply_func_test.go
+++ b/tool/internal/instrument/apply_func_test.go
@@ -459,3 +459,75 @@ func TestInstrument_WriteInstrumentedError(t *testing.T) {
 	err := ip.instrument(context.Background(), rset)
 	require.Error(t, err)
 }
+
+func TestCreateTJumpIfGenericReceiverTypeArgs(t *testing.T) {
+	file, funcDecl := parseFileFunc(t, `package main
+type GenStruct[T any] struct{}
+func (g *GenStruct[T]) Reset() error { return nil }
+`)
+
+	funcRule := &rule.InstFuncRule{
+		InstBaseRule: rule.InstBaseRule{Name: "reset-rule"},
+		Func:         "Reset",
+		Before:       "BeforeReset",
+		After:        "AfterReset",
+		Path:         "example.com/hook",
+	}
+
+	retVals := collectReturnValues(funcDecl, funcRule.Identity())
+	args := collectArguments(funcDecl, funcRule.Identity())
+	tjump := createTJumpIf(file, funcRule, funcDecl, args, retVals)
+	require.NotNil(t, tjump)
+
+	// Verify beforeCall contains type argument [T]
+	assignStmt, ok := tjump.Init.(*dst.AssignStmt)
+	require.True(t, ok)
+	require.Len(t, assignStmt.Rhs, 1)
+	beforeCall, ok := assignStmt.Rhs[0].(*dst.CallExpr)
+	require.True(t, ok)
+	beforeIndex, ok := beforeCall.Fun.(*dst.IndexExpr)
+	require.True(t, ok, "beforeCall should be an IndexExpr with type argument")
+	assert.Equal(t, "T", beforeIndex.Index.(*dst.Ident).Name)
+
+	// Verify afterCall contains type argument [T]
+	elseBlock, ok := tjump.Else.(*dst.BlockStmt)
+	require.True(t, ok)
+	require.Len(t, elseBlock.List, 1)
+	deferStmt, ok := elseBlock.List[0].(*dst.DeferStmt)
+	require.True(t, ok)
+	afterCall := deferStmt.Call
+	afterIndex, ok := afterCall.Fun.(*dst.IndexExpr)
+	require.True(t, ok, "afterCall should be an IndexExpr with type argument")
+	assert.Equal(t, "T", afterIndex.Index.(*dst.Ident).Name)
+}
+
+func TestCreateTJumpIfMultipleGenericReceiverTypeArgs(t *testing.T) {
+	file, funcDecl := parseFileFunc(t, `package main
+type GenStruct[K comparable, V any] struct{}
+func (g *GenStruct[K, V]) Clear() error { return nil }
+`)
+
+	funcRule := &rule.InstFuncRule{
+		InstBaseRule: rule.InstBaseRule{Name: "clear-rule"},
+		Func:         "Clear",
+		Before:       "BeforeClear",
+		After:        "AfterClear",
+		Path:         "example.com/hook",
+	}
+
+	retVals := collectReturnValues(funcDecl, funcRule.Identity())
+	args := collectArguments(funcDecl, funcRule.Identity())
+	tjump := createTJumpIf(file, funcRule, funcDecl, args, retVals)
+	require.NotNil(t, tjump)
+
+	elseBlock, ok := tjump.Else.(*dst.BlockStmt)
+	require.True(t, ok)
+	deferStmt, ok := elseBlock.List[0].(*dst.DeferStmt)
+	require.True(t, ok)
+	afterCall := deferStmt.Call
+	afterIndexList, ok := afterCall.Fun.(*dst.IndexListExpr)
+	require.True(t, ok, "afterCall should be an IndexListExpr with type arguments")
+	require.Len(t, afterIndexList.Indices, 2)
+	assert.Equal(t, "K", afterIndexList.Indices[0].(*dst.Ident).Name)
+	assert.Equal(t, "V", afterIndexList.Indices[1].(*dst.Ident).Name)
+}

--- a/tool/internal/instrument/testdata/golden/generic-functions/generic_functions.main.go.golden
+++ b/tool/internal/instrument/testdata/golden/generic-functions/generic_functions.main.go.golden
@@ -21,9 +21,9 @@ type GenStruct[T any] struct {
 
 func (g *GenStruct[T]) GenericMethod(p1 T, p2 string) (_unnamedRetVal_1139503255_0 T, _unnamedRetVal_1139503255_1 error) {
 	//line <generated>:1
-	if hookContext1139503255, _ := OtelBeforeTrampoline_GenericMethod1139503255(&g, &p1, &p2); false {
+	if hookContext1139503255, _ := OtelBeforeTrampoline_GenericMethod1139503255[T](&g, &p1, &p2); false {
 	} else {
-		defer OtelAfterTrampoline_GenericMethod1139503255(hookContext1139503255, &_unnamedRetVal_1139503255_0, &_unnamedRetVal_1139503255_1)
+		defer OtelAfterTrampoline_GenericMethod1139503255[T](hookContext1139503255, &_unnamedRetVal_1139503255_0, &_unnamedRetVal_1139503255_1)
 	}
 	//line main.go:15:2
 	return p1, nil


### PR DESCRIPTION
## Motivation

Fixes #1218

When instrumenting methods on generic types, the generated trampoline functions correctly include the receiver's type parameters, but the trampoline calls were not passing those type arguments.

This change resolves the generic type parameters from the method receiver and uses them when generating the trampoline calls. It also adds unit test coverage for methods with both single and multiple receiver type parameters.

The existing behavior for regular functions, regular methods, and top level generic functions remains unchanged.

## Checklist

- [x] PR title follows conventional commits format
- [x] Code formatted
- [x] Linters pass
- [x] Tests pass
- [x] Tests added for new functionality
- [x] Tests follow testing guidelines
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable)
- [ ] This PR has content that I did not fully write myself.
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.