### PR TITLE
fix(tool): reject separated flags without values

### DIFF
--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -219,6 +219,9 @@ func splitBuildTargets(args []string) ([]string, []string, error) {
 
 		if strings.HasPrefix(arg, "-") {
 			if !strings.Contains(arg, "=") && (flagsWithPathValues[arg] || testFlagsWithValues[arg]) {
+				if i+1 >= len(args) {
+					return nil, nil, ex.Newf("flag %q requires a value", arg)
+				}
 				i++ // skip this flag's separate value
 			}
 			continue

--- a/tool/internal/setup/setup_test.go
+++ b/tool/internal/setup/setup_test.go
@@ -156,6 +156,7 @@ func TestSplitBuildTargets(t *testing.T) {
 		fileTargets   []string
 		notPkgTargets []string // must NOT be parsed as packages (e.g. flag values)
 		expectError   bool
+		wantErr       string
 	}{
 		{
 			name:        "all package targets",
@@ -247,6 +248,24 @@ func TestSplitBuildTargets(t *testing.T) {
 			notPkgTargets: []string{"sudo"},
 			expectError:   false,
 		},
+		{
+			name:        "go test -run flag requires a value",
+			targets:     []string{"-run"},
+			expectError: true,
+			wantErr:     `flag "-run" requires a value`,
+		},
+		{
+			name:        "go test -exec flag requires a value",
+			targets:     []string{"./pkg", "-exec"},
+			expectError: true,
+			wantErr:     `flag "-exec" requires a value`,
+		},
+		{
+			name:        "go build -o flag requires a value",
+			targets:     []string{"./pkg", "-o"},
+			expectError: true,
+			wantErr:     `flag "-o" requires a value`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -254,6 +273,9 @@ func TestSplitBuildTargets(t *testing.T) {
 			pkgTargets, fileTargets, err := splitBuildTargets(tt.targets)
 			if tt.expectError {
 				require.Error(t, err)
+				if tt.wantErr != "" {
+					require.ErrorContains(t, err, tt.wantErr)
+				}
 				assert.Nil(t, pkgTargets)
 				assert.Nil(t, fileTargets)
 			} else {


### PR DESCRIPTION
## Description

Reject recognized separated-value flags when no value follows them during build-target parsing.

Focused table-driven cases cover trailing `-exec`, `-run`, and `-o` flags.

## Motivation

Malformed commands such as `otelc go test ./pkg -exec` previously passed setup argument parsing. Setup could perform package-loading and instrumentation work before the Go command eventually reported the missing value.

Fixes #1235

---

## Testing

- `go test -count=1 ./tool/internal/setup -run TestSplitBuildTargets`
- `go test -count=1 ./tool/internal/setup`
- `go test -shuffle=on -count=1 ./tool/...`
- `make verify-manifest`
- `make lint/license-header`
- `./.bin/golangci-lint run --config .tools/golangci.yml ./tool/internal/setup` (reports existing findings on unchanged lines only)
- `git diff --check`

