### PR TITLE
refactor(tool): drop redundant intermediate error wraps

### DIFF
--- a/tool/internal/imports/importcfg.go
+++ b/tool/internal/imports/importcfg.go
@@ -29,7 +29,7 @@ type ImportConfig struct {
 func ParseImportCfg(filename string) (ImportConfig, error) {
 	file, err := os.Open(filename)
 	if err != nil {
-		return ImportConfig{}, err
+		return ImportConfig{}, ex.Wrapf(err, "opening importcfg file %s", filename)
 	}
 	defer file.Close()
 

--- a/tool/internal/imports/importcfg_test.go
+++ b/tool/internal/imports/importcfg_test.go
@@ -34,6 +34,12 @@ modinfo "abc123"
 	assert.Equal(t, []string{`modinfo "abc123"`}, cfg.Extras)
 }
 
+func TestParseImportCfg_MissingFile(t *testing.T) {
+	_, err := ParseImportCfg(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opening importcfg file")
+}
+
 func TestParseFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	filename := filepath.Join(tmpDir, "importcfg")

--- a/tool/internal/instrument/apply_call.go
+++ b/tool/internal/instrument/apply_call.go
@@ -113,7 +113,7 @@ func (*instrumentPhase) applyCallReplace(
 ) (bool, error) {
 	tmpl, err := newCallTemplate(r.Replace)
 	if err != nil {
-		return false, ex.Wrapf(err, "rule has no compiled replacement template")
+		return false, err
 	}
 
 	// Pass 1: collect matching calls and pre-compute replacements to avoid
@@ -134,7 +134,7 @@ func (*instrumentPhase) applyCallReplace(
 	})
 
 	if wrapError != nil {
-		return false, ex.Wrapf(wrapError, "failed to wrap matched call")
+		return false, wrapError
 	}
 
 	if len(replacements) == 0 {

--- a/tool/internal/instrument/apply_call_test.go
+++ b/tool/internal/instrument/apply_call_test.go
@@ -170,7 +170,7 @@ func TestApplyCallRule_InvalidTemplate(t *testing.T) {
 	err := newTestPhase().applyCallRule(context.Background(), r, file)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "rule has no compiled replacement template")
+	assert.Contains(t, err.Error(), "failed to parse template")
 }
 
 func TestApplyCallRule_AppendArgs(t *testing.T) {
@@ -950,5 +950,5 @@ func TestApplyCallRule_WrapFailureReturnsError(t *testing.T) {
 	err := newTestPhase().applyCallRule(context.Background(), r, file)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to wrap")
+	assert.Contains(t, err.Error(), "failed to parse generated code")
 }

--- a/tool/internal/instrument/apply_decl.go
+++ b/tool/internal/instrument/apply_decl.go
@@ -115,7 +115,7 @@ func wrapDeclValue(spec *dst.ValueSpec, templateStr string, nameIdx int) error {
 
 	tmpl, err := newCallTemplate(templateStr)
 	if err != nil {
-		return ex.Wrapf(err, "failed to compile wrap template")
+		return err
 	}
 
 	// Package-level var/const initializers have no enclosing function.

--- a/tool/internal/instrument/apply_decl_test.go
+++ b/tool/internal/instrument/apply_decl_test.go
@@ -117,6 +117,17 @@ func TestWrapDeclValue_InvalidTemplate(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to wrap expression")
 }
 
+func TestWrapDeclValue_MalformedTemplateSyntax(t *testing.T) {
+	spec := &dst.ValueSpec{
+		Names:  []*dst.Ident{{Name: "X"}},
+		Values: []dst.Expr{&dst.Ident{Name: "x"}},
+	}
+
+	err := wrapDeclValue(spec, "{{ unclosed", 0)
+
+	require.Error(t, err)
+}
+
 // --- applyDeclRule integration tests ---
 
 // makeVarFile builds a minimal *dst.File containing a single var declaration.

--- a/tool/internal/instrument/apply_func_test.go
+++ b/tool/internal/instrument/apply_func_test.go
@@ -11,7 +11,9 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -408,4 +410,52 @@ func TestAPITemplateMatchesHookContext(t *testing.T) {
 		"%s and api.tmpl have drifted; re-sync with `make build` "+
 			"(or `cp %s tool/internal/instrument/api.tmpl`)",
 		hookContextSource, hookContextSource)
+}
+
+func TestParseFileMissingFile(t *testing.T) {
+	ip := &instrumentPhase{}
+	_, err := ip.parseFile("/nonexistent/path/source.go")
+	require.Error(t, err)
+}
+
+func TestInstrumentParseFileError(t *testing.T) {
+	ip := &instrumentPhase{}
+
+	rset := rule.NewInstRuleSet("example.com/pkg")
+	rset.FuncRules["/nonexistent/does-not-exist.go"] = []*rule.InstFuncRule{
+		{
+			InstBaseRule: rule.InstBaseRule{Name: "test-rule"},
+			Func:         "Foo",
+			Before:       "BeforeFoo",
+			Path:         "example.com/hook",
+		},
+	}
+
+	err := ip.instrument(context.Background(), rset)
+	require.Error(t, err)
+}
+
+func TestInstrument_WriteInstrumentedError(t *testing.T) {
+	// A valid source file whose path does not match compileArgs causes writeInstrumented to fail.
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "source.go")
+	require.NoError(t, os.WriteFile(src, []byte("package main\nvar X = 1\n"), 0o644))
+
+	ip := &instrumentPhase{
+		logger:      slog.New(slog.DiscardHandler),
+		workDir:     tmp,
+		compileArgs: []string{"other.go"}, // doesn't match src, causing writeInstrumented to error
+	}
+
+	rset := rule.NewInstRuleSet("main")
+	rset.DeclRules[src] = []*rule.InstDeclRule{
+		{
+			InstBaseRule: rule.InstBaseRule{Name: "test-rule"},
+			Identifier:   "X",
+			Replace:      "2",
+		},
+	}
+
+	err := ip.instrument(context.Background(), rset)
+	require.Error(t, err)
 }

--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -113,7 +113,7 @@ func interceptCompile(ctx context.Context, args []string) ([]string, error) {
 	if importCfgPath != "" {
 		imports, err := imports.ParseImportCfg(importCfgPath)
 		if err != nil {
-			return nil, ex.Wrapf(err, "parsing importcfg")
+			return nil, err
 		}
 		ip.importConfig = imports
 	}
@@ -188,7 +188,7 @@ func (ip *instrumentPhase) updateImportConfig(ctx context.Context, newImports ma
 	}
 
 	if err := ip.importConfig.WriteFile(ip.importConfigPath); err != nil {
-		return ex.Wrapf(err, "writing importcfg")
+		return err
 	}
 
 	ip.Info("Updated importcfg", "path", ip.importConfigPath)
@@ -319,7 +319,7 @@ func interceptLink(ctx context.Context, args []string) ([]string, error) {
 	// Parse the link importcfg
 	linkConfig, err := imports.ParseImportCfg(importCfgPath)
 	if err != nil {
-		return nil, ex.Wrapf(err, "parsing link importcfg")
+		return nil, err
 	}
 
 	if linkConfig.PackageFile == nil {
@@ -341,7 +341,7 @@ func interceptLink(ctx context.Context, args []string) ([]string, error) {
 	}
 
 	if err = linkConfig.WriteFile(importCfgPath); err != nil {
-		return nil, ex.Wrapf(err, "writing link importcfg")
+		return nil, err
 	}
 
 	logger.InfoContext(ctx, "Updated link importcfg", "path", importCfgPath, "added", len(addedImports))

--- a/tool/internal/instrument/toolexec_test.go
+++ b/tool/internal/instrument/toolexec_test.go
@@ -479,7 +479,7 @@ func TestInterceptCompileImportCfgParseError(t *testing.T) {
 	}
 	_, err := interceptCompile(ctx, args)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "parsing importcfg")
+	assert.Contains(t, err.Error(), "importcfg")
 }
 
 func TestUpdateImportConfigAddsResolvedImport(t *testing.T) {
@@ -539,7 +539,7 @@ func TestUpdateImportConfigWriteError(t *testing.T) {
 	}
 	err := ip.updateImportConfig(t.Context(), map[string]string{"fmt": "fmt"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "writing importcfg")
+	assert.Contains(t, err.Error(), "failed to create file")
 }
 
 func TestUpdateImportConfigTrackError(t *testing.T) {
@@ -638,7 +638,7 @@ func TestInterceptLinkParseError(t *testing.T) {
 	args := []string{"link", "-o", "exe", "-buildid", "id", "-importcfg", filepath.Join(workDir, "missing.link")}
 	_, err := interceptLink(ctx, args)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "parsing link importcfg")
+	assert.Contains(t, err.Error(), "importcfg")
 }
 
 func TestInterceptLinkUpdatesConfig(t *testing.T) {
@@ -697,7 +697,7 @@ func TestInterceptLinkWriteError(t *testing.T) {
 	args := []string{"link", "-o", "exe", "-buildid", "id", "-importcfg", linkCfg}
 	_, err := interceptLink(ctx, args)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "writing link importcfg")
+	assert.Contains(t, err.Error(), "failed to create file")
 }
 
 func TestInterceptToolVersionWriteError(t *testing.T) {

--- a/tool/internal/pkgload/pkgload.go
+++ b/tool/internal/pkgload/pkgload.go
@@ -239,7 +239,7 @@ func FindModuleDirs(ctx context.Context, pkgs []*packages.Package) (map[string]b
 		} else {
 			modDir, err := resolveModuleDir(ctx, pkgDir)
 			if err != nil {
-				return nil, ex.Wrapf(err, "finding module dir for package %s", pkg.PkgPath)
+				return nil, err
 			}
 
 			moduleDir = modDir

--- a/tool/internal/setup/pin.go
+++ b/tool/internal/setup/pin.go
@@ -411,12 +411,12 @@ func updateToolFile(ctx context.Context, toolFile string, prunedImports map[stri
 
 	f, parseErr := p.Parse(toolFile, parser.ParseComments)
 	if parseErr != nil {
-		return ex.Wrapf(parseErr, "parsing tool file %s", toolFile)
+		return parseErr
 	}
 
 	if len(prunedImports) > 0 {
 		if removeErr := removeImports(f, prunedImports); removeErr != nil {
-			return ex.Wrapf(removeErr, "removing imports from %s", toolFile)
+			return removeErr
 		}
 	}
 
@@ -428,14 +428,10 @@ func updateToolFile(ctx context.Context, toolFile string, prunedImports map[stri
 
 	_, ensureErr := ensureOtelcRequire(filepath.Dir(toolFile), util.Version)
 	if ensureErr != nil {
-		return ex.Wrapf(ensureErr, "ensuring otelc require in go.mod in %s", filepath.Dir(toolFile))
+		return ensureErr
 	}
 
-	if tidyErr := runModTidy(ctx, filepath.Dir(toolFile)); tidyErr != nil {
-		return ex.Wrapf(tidyErr, "running go mod tidy in %s", filepath.Dir(toolFile))
-	}
-
-	return nil
+	return runModTidy(ctx, filepath.Dir(toolFile))
 }
 
 func updatePinnedProjects(
@@ -522,17 +518,17 @@ func generatePinnedProjects(ctx context.Context, moduleDirs map[string]bool, opt
 	// No tool file found? Try generating one.
 	deps, findDepsErr := findDeps(ctx, subcommand, opts.Args)
 	if findDepsErr != nil {
-		return nil, ex.Wrapf(findDepsErr, "finding dependencies")
+		return nil, findDepsErr
 	}
 
 	extractErr := extractOtelcBundle()
 	if extractErr != nil {
-		return nil, ex.Wrapf(extractErr, "extracting otelc package")
+		return nil, extractErr
 	}
 
 	ruleset, err := loadMinimalRules(filepath.Join(util.GetBuildTempDir(), unzippedInstDir))
 	if err != nil {
-		return nil, ex.Wrapf(err, "loading instrumentation rules")
+		return nil, err
 	}
 
 	// We expect every built-in instrumentation module to be importable
@@ -564,11 +560,11 @@ func generatePinnedProjects(ctx context.Context, moduleDirs map[string]bool, opt
 		}
 
 		if _, ensureErr := ensureOtelcRequire(moduleDir, util.Version); ensureErr != nil {
-			return nil, ex.Wrapf(ensureErr, "ensuring otelc require in go.mod in %s", moduleDir)
+			return nil, ensureErr
 		}
 
 		if syncErr := syncDeps(ctx, imports, moduleDir); syncErr != nil {
-			return nil, ex.Wrapf(syncErr, "syncing dependencies in %s", moduleDir)
+			return nil, syncErr
 		}
 
 		keepForDebug(ctx, path)
@@ -640,19 +636,19 @@ func pinLocked(ctx context.Context, opts PinOptions) (*PinResult, error) {
 		// forcing module mode and rewriting vendor/ paths to module mode.
 		args, err := prepareVendoredBuild(ctx, util.LoggerFromContext(ctx), opts.Args)
 		if err != nil {
-			return nil, ex.Wrapf(err, "preparing vendored build")
+			return nil, err
 		}
 		opts.Args = args
 
 		// Use opts.Args to find module directories
 		pkgs, getErr := getBuildPackages(ctx, opts.Args)
 		if getErr != nil {
-			return nil, ex.Wrapf(getErr, "getting build packages")
+			return nil, getErr
 		}
 
 		moduleDirs, err = pkgload.FindModuleDirs(ctx, pkgs)
 		if err != nil {
-			return nil, ex.Wrapf(err, "finding module directories")
+			return nil, err
 		}
 	}
 
@@ -682,10 +678,10 @@ func autoPin(ctx context.Context, moduleDirs map[string]bool, subcommand string,
 
 	backupFiles, getBackupErr := getBackupFiles(ctx, moduleDirs)
 	if getBackupErr != nil {
-		return nil, ex.Wrapf(getBackupErr, "getting backup files")
+		return nil, getBackupErr
 	}
 	if trackErr := stateManager.TrackAll(backupFiles...); trackErr != nil {
-		return nil, ex.Wrapf(trackErr, "tracking backup files")
+		return nil, trackErr
 	}
 
 	pinResult, pinErr := Pin(ctx, PinOptions{

--- a/tool/internal/setup/pin_test.go
+++ b/tool/internal/setup/pin_test.go
@@ -1239,3 +1239,177 @@ func TestPrepareVendoredBuild(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, args, got)
 }
+
+func TestPinLocked_GetBuildPackagesError(t *testing.T) {
+	_, err := Pin(t.Context(), PinOptions{
+		Args: []string{"-o"}, // missing required flag value
+	})
+	require.Error(t, err)
+}
+
+func TestAutoPin_TrackAllError(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	modDir := filepath.Join(tmp, "mod")
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+	mustWriteFile(t, filepath.Join(modDir, "go.mod"), "module example.com")
+
+	// Snapshot destination dir as file so TrackAll fails on all platforms (including Windows)
+	require.NoError(t, os.MkdirAll(util.GetBuildTempDir(), 0o755))
+	snapshotDir := util.GetBuildTemp(stateDir)
+	_ = os.RemoveAll(snapshotDir)
+	require.NoError(t, os.WriteFile(snapshotDir, []byte("file"), 0o644))
+
+	sm := newStateManager()
+	ctx := contextWithStateManager(t.Context(), sm)
+
+	_, err := autoPin(ctx, map[string]bool{modDir: true}, "build", []string{"."})
+	require.Error(t, err)
+}
+
+func TestRemoveImports_UnquoteError(t *testing.T) {
+	f := &dst.File{
+		Decls: []dst.Decl{
+			&dst.GenDecl{
+				Tok: token.IMPORT,
+				Specs: []dst.Spec{
+					&dst.ImportSpec{
+						Path: &dst.BasicLit{
+							Kind:  token.STRING,
+							Value: `unquoted"invalid`,
+						},
+					},
+				},
+			},
+		},
+	}
+	err := removeImports(f, map[string]bool{"foo": true})
+	require.Error(t, err)
+}
+
+func TestAutoPin_GetBackupFilesError(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // canceled context causes getBackupFiles to fail
+
+	sm := newStateManager()
+	ctx = contextWithStateManager(ctx, sm)
+
+	_, err := autoPin(ctx, map[string]bool{"/some/dir": true}, "build", []string{"."})
+	require.Error(t, err)
+}
+
+func TestGeneratePinnedProjects_FindDepsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // canceled context causes findDeps to fail
+
+	_, err := generatePinnedProjects(ctx, map[string]bool{"/some/dir": true}, PinOptions{})
+	require.Error(t, err)
+}
+
+func TestPinLocked_FindModuleDirsError(t *testing.T) {
+	// A standalone .go file outside any Go module causes FindModuleDirs in pinLocked to fail on line 651
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	t.Setenv(util.EnvOtelcWorkDir, tmp)
+
+	mainFile := filepath.Join(tmp, "main.go")
+	mustWriteFile(t, mainFile, "package main\nfunc main() {}\n")
+
+	_, err := Pin(t.Context(), PinOptions{Args: []string{mainFile}})
+	require.Error(t, err)
+}
+
+func TestGeneratePinnedProjects_LoadMinimalRulesError(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, tempDir)
+
+	// Create a corrupted go.mod in rules root to fail loadMinimalRules (pin.go:531)
+	instDir := filepath.Join(util.GetBuildTempDir(), unzippedInstDir, "badmod")
+	require.NoError(t, os.MkdirAll(instDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(instDir, "go.mod"), []byte("invalid go.mod"), 0o644))
+
+	_, err := generatePinnedProjects(t.Context(), map[string]bool{tempDir: true}, PinOptions{})
+	require.Error(t, err)
+}
+
+func TestGeneratePinnedProjects_SyncDepsError(t *testing.T) {
+	goMod := `module example.com/test
+
+go 1.21
+
+require (
+	go.opentelemetry.io/otelc v0.0.0
+	nonexistent.invalid/pkg v1.0.0
+)
+`
+	tempDir, _, _ := setupSyncDepsTest(t, goMod, []string{"net/http/client"})
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(tempDir, "main.go"),
+			[]byte("package main\nimport _ \"net/http\"\nfunc main() {}\n"),
+			0o644,
+		),
+	)
+	ruleFile := filepath.Join(util.GetBuildTempDir(), unzippedInstDir, "net", "http", "client", "rules.yaml")
+	require.NoError(t, os.WriteFile(ruleFile, []byte("rule1:\n  target: net/http\n  func: Get\n"), 0o644))
+
+	_, err := generatePinnedProjects(t.Context(), map[string]bool{tempDir: true}, PinOptions{
+		Args: []string{"."},
+	})
+	require.Error(t, err)
+}
+
+func TestGeneratePinnedProjects_EnsureOtelcRequireError(t *testing.T) {
+	goMod := `module example.com/test
+
+go 1.21
+`
+	tempDir, _, _ := setupSyncDepsTest(t, goMod, []string{"net/http/client"})
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(tempDir, "main.go"),
+			[]byte("package main\nimport _ \"net/http\"\nfunc main() {}\n"),
+			0o644,
+		),
+	)
+	ruleFile := filepath.Join(util.GetBuildTempDir(), unzippedInstDir, "net", "http", "client", "rules.yaml")
+	require.NoError(t, os.WriteFile(ruleFile, []byte("rule1:\n  target: net/http\n  func: Get\n"), 0o644))
+
+	// Corrupt go.mod so ensureOtelcRequire fails in generatePinnedProjects (line 563)
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte("invalid go.mod {"), 0o644))
+
+	_, err := generatePinnedProjects(t.Context(), map[string]bool{tempDir: true}, PinOptions{})
+	require.Error(t, err)
+}
+
+func TestGeneratePinnedProjects_ExtractBundleError(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv(util.EnvOtelcWorkDir, tempDir)
+	require.NoError(
+		t,
+		os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte("module example.com/test\n\ngo 1.21\n"), 0o644),
+	)
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644))
+
+	buildTemp := util.GetBuildTempDir()
+	require.NoError(t, os.MkdirAll(buildTemp, 0o755))
+	pkgPath := filepath.Join(buildTemp, unzippedPkgDir)
+	require.NoError(t, os.WriteFile(pkgPath, []byte("file"), 0o644))
+
+	_, err := generatePinnedProjects(t.Context(), map[string]bool{tempDir: true}, PinOptions{
+		Args: []string{"."},
+	})
+	require.Error(t, err)
+}
+
+func TestUpdateToolFile_RemoveImportsError(t *testing.T) {
+	tempDir := t.TempDir()
+	toolFile := filepath.Join(tempDir, "otel.instrumentation.go")
+	content := "package main\n\nimport _ `pkg\nnewline`\n"
+	require.NoError(t, os.WriteFile(toolFile, []byte(content), 0o644))
+
+	err := updateToolFile(t.Context(), toolFile, map[string]bool{"foo": true}, PinOptions{})
+	require.Error(t, err)
+}

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -150,7 +150,7 @@ func getBuildPackages(ctx context.Context, args []string) ([]*packages.Package, 
 
 	pkgTargets, fileTargets, err := splitBuildTargets(args)
 	if err != nil {
-		return nil, ex.Wrapf(err, "splitting build targets")
+		return nil, err
 	}
 	buildFlags := extractBuildFlags(args)
 
@@ -162,7 +162,7 @@ func getBuildPackages(ctx context.Context, args []string) ([]*packages.Package, 
 	case len(fileTargets) > 0:
 		pkgs, loadErr = pkgload.LoadPackages(ctx, mode, buildFlags, fileTargets...)
 		if loadErr != nil {
-			return nil, ex.Wrapf(loadErr, "failed to load packages for files %v", fileTargets)
+			return nil, loadErr
 		}
 
 		if len(pkgs) > 1 {
@@ -171,12 +171,12 @@ func getBuildPackages(ctx context.Context, args []string) ([]*packages.Package, 
 	case len(pkgTargets) > 0:
 		pkgs, loadErr = pkgload.LoadPackages(ctx, mode, buildFlags, pkgTargets...)
 		if loadErr != nil {
-			return nil, ex.Wrapf(loadErr, "failed to load packages for patterns %v", pkgTargets)
+			return nil, loadErr
 		}
 	default:
 		pkgs, loadErr = pkgload.LoadPackages(ctx, mode, buildFlags, ".")
 		if loadErr != nil {
-			return nil, ex.Wrapf(loadErr, "failed to load packages for pattern .")
+			return nil, loadErr
 		}
 	}
 
@@ -274,7 +274,7 @@ func rootModulePaths(ctx context.Context, pkgs []*packages.Package) ([]string, e
 		}
 		mod, err := pkgload.ResolveModule(ctx, pkgDir)
 		if err != nil {
-			return nil, ex.Wrapf(err, "finding module dir for package %s", pkg.PkgPath)
+			return nil, err
 		}
 		if mod.Path != "" {
 			roots[mod.Path] = true
@@ -374,7 +374,7 @@ func setupLocked(ctx context.Context, cmd *cli.Command) error {
 	// Find the module directories for the build packages
 	moduleDirs, findModErr := pkgload.FindModuleDirs(ctx, pkgs)
 	if findModErr != nil {
-		return ex.Wrapf(findModErr, "finding module directories for build packages")
+		return findModErr
 	}
 
 	// Ensure a state manager is available in the context
@@ -389,7 +389,7 @@ func setupLocked(ctx context.Context, cmd *cli.Command) error {
 	if sp.ruleConfig == "" && os.Getenv(util.EnvOtelcRules) == "" {
 		pinResult, pinErr := autoPin(ctx, moduleDirs, subcommand, args)
 		if pinErr != nil {
-			return ex.Wrapf(pinErr, "auto-pinning dependencies")
+			return pinErr
 		}
 		deps = pinResult.AllDeps
 	}
@@ -398,7 +398,7 @@ func setupLocked(ctx context.Context, cmd *cli.Command) error {
 		// Find all dependencies of the project being build
 		deps, err = findDeps(ctx, subcommand, args)
 		if err != nil {
-			return ex.Wrapf(err, "finding dependencies")
+			return err
 		}
 	}
 

--- a/tool/internal/setup/setup_test.go
+++ b/tool/internal/setup/setup_test.go
@@ -622,3 +622,120 @@ func TestGenerateRuntimePerPackageSkipsPackagesWithoutFiles(t *testing.T) {
 	err := sp.generateRuntimePerPackage(context.Background(), pkgs, []*rule.InstRuleSet{})
 	require.NoError(t, err)
 }
+
+func TestGetBuildPackages_LoadErrors(t *testing.T) {
+	ctx := t.Context()
+	nonExistentDir := filepath.Join(t.TempDir(), "nonexistent")
+
+	// File targets with non-existent -C flag
+	_, err := getBuildPackages(ctx, []string{"-C", nonExistentDir, "main.go"})
+	require.Error(t, err)
+
+	// Package targets with non-existent -C flag
+	_, err = getBuildPackages(ctx, []string{"-C", nonExistentDir, "./pkg"})
+	require.Error(t, err)
+
+	// Default targets with non-existent -C flag
+	_, err = getBuildPackages(ctx, []string{"-C", nonExistentDir})
+	require.Error(t, err)
+}
+
+func TestRootModulePaths_ResolveError(t *testing.T) {
+	ctx := t.Context()
+	pkgs := []*packages.Package{
+		{
+			PkgPath: "example.com/foo",
+			GoFiles: []string{filepath.Join(t.TempDir(), "nonexistent", "foo.go")},
+		},
+	}
+	_, err := rootModulePaths(ctx, pkgs)
+	require.Error(t, err)
+}
+
+func TestGenerateRuntimePerPackage_AddDepsError(t *testing.T) {
+	sp := newTestSetupPhase()
+	nonExistentDir := filepath.Join(t.TempDir(), "nonexistent")
+
+	pkgs := []*packages.Package{
+		{
+			PkgPath: "example.com/foo",
+			Name:    "foo",
+			GoFiles: []string{filepath.Join(nonExistentDir, "foo.go")},
+		},
+	}
+	rset := rule.NewInstRuleSet("example.com/foo")
+	rset.FuncRules["foo.go"] = []*rule.InstFuncRule{
+		{
+			InstBaseRule: rule.InstBaseRule{Name: "test-rule"},
+			Func:         "Foo",
+			Before:       "BeforeFoo",
+			Path:         "example.com/hook",
+		},
+	}
+	err := sp.generateRuntimePerPackage(context.Background(), pkgs, []*rule.InstRuleSet{rset})
+	require.Error(t, err)
+}
+
+func TestSetup_AutoPinError(t *testing.T) {
+	setupTestModule(t, []string{"cmd"})
+
+	// Make stateDir a regular file so autoPin fails in setupLocked on all platforms (line 392)
+	require.NoError(t, os.MkdirAll(util.GetBuildTempDir(), 0o755))
+	snapshotDir := util.GetBuildTemp(stateDir)
+	_ = os.RemoveAll(snapshotDir)
+	require.NoError(t, os.WriteFile(snapshotDir, []byte("file"), 0o644))
+
+	cmd := &cli.Command{
+		Name:   "setup",
+		Action: Setup,
+	}
+	err := cmd.Run(t.Context(), []string{"setup", "."})
+	require.Error(t, err)
+}
+
+func TestSetup_FindDepsErrorWithRules(t *testing.T) {
+	setupTestModule(t, []string{"cmd"})
+	t.Setenv(util.EnvOtelcRules, "some-rule-config")
+
+	// Ensure build temp dir is a regular file so listBuildPlan in findDeps fails (line 401)
+	_ = os.RemoveAll(util.GetBuildTempDir())
+	require.NoError(t, os.WriteFile(util.GetBuildTempDir(), []byte("file"), 0o644))
+
+	cmd := &cli.Command{
+		Name:   "setup",
+		Action: Setup,
+	}
+	err := cmd.Run(t.Context(), []string{"setup", "."})
+	require.Error(t, err)
+}
+
+func TestSetup_MatchDepsError(t *testing.T) {
+	setupTestModule(t, []string{"cmd"})
+	t.Setenv(util.EnvOtelcRules, "/nonexistent/rules.yaml")
+	_ = os.RemoveAll(util.GetBuildTempDir())
+	require.NoError(t, os.MkdirAll(util.GetBuildTempDir(), 0o755))
+
+	cmd := &cli.Command{
+		Name:   "setup",
+		Action: Setup,
+	}
+	err := cmd.Run(t.Context(), []string{"setup", "."})
+	require.Error(t, err)
+}
+
+func TestSetupLocked_FindModuleDirsError(t *testing.T) {
+	// A standalone .go file outside any Go module causes FindModuleDirs to fail in setupLocked (line 377)
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	t.Setenv(util.EnvOtelcWorkDir, tmp)
+
+	mainFile := filepath.Join(tmp, "main.go")
+	mustWriteFile(t, mainFile, "package main\nfunc main() {}\n")
+
+	cmd := &cli.Command{
+		Name:   "setup",
+		Action: Setup,
+	}
+	err := cmd.Run(t.Context(), []string{"setup", mainFile})
+	require.Error(t, err)
+}

--- a/tool/internal/setup/state.go
+++ b/tool/internal/setup/state.go
@@ -184,7 +184,7 @@ func (s *stateManager) Track(path string) error {
 	// If the file exists, snapshot it
 	dst := filepath.Join(util.GetBuildTemp(stateDir), stateSnapshotPath(abs))
 	if err = util.CopyFile(abs, dst); err != nil {
-		return ex.Wrapf(err, "failed to snapshot %s", abs)
+		return err
 	}
 
 	s.files[abs] = true
@@ -225,11 +225,7 @@ func (s *stateManager) Commit() error {
 		return ex.Wrapf(err, "failed to create build temp directory")
 	}
 
-	if err = util.WriteFileAtomic(f, bs); err != nil {
-		return ex.Wrapf(err, "failed to write state file %s", f)
-	}
-
-	return nil
+	return util.WriteFileAtomic(f, bs)
 }
 
 // Discard removes the persisted manifest and snapshots. Call it only after a

--- a/tool/internal/setup/state_test.go
+++ b/tool/internal/setup/state_test.go
@@ -512,3 +512,21 @@ func TestStateManagerDiscardEmpty(t *testing.T) {
 	// Discarding an empty state manager is a no-op.
 	require.NoError(t, newStateManager().Discard())
 }
+
+func TestStateManagerTrack_CopyFails(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	src := filepath.Join(tmp, "go.mod")
+	mustWriteFile(t, src, "module example.com")
+
+	// Make stateDir a regular file so CopyFile fails on all platforms (including Windows)
+	require.NoError(t, os.MkdirAll(util.GetBuildTempDir(), 0o755))
+	snapshotDir := util.GetBuildTemp(stateDir)
+	_ = os.RemoveAll(snapshotDir)
+	require.NoError(t, os.WriteFile(snapshotDir, []byte("file"), 0o644))
+
+	sm := newStateManager()
+	err := sm.Track(src)
+	require.Error(t, err)
+}

--- a/tool/internal/setup/sync.go
+++ b/tool/internal/setup/sync.go
@@ -39,11 +39,7 @@ func writeGoMod(gomod string, modfile *modfile.File) error {
 		return ex.Wrapf(err, "failed to format go.mod file")
 	}
 	const perm = 0o644
-	err = util.WriteFileAtomic(gomod, data, perm)
-	if err != nil {
-		return ex.Wrapf(err, "failed to write go.mod file")
-	}
-	return nil
+	return util.WriteFileAtomic(gomod, data, perm)
 }
 
 func runModTidy(ctx context.Context, moduleDir string) error {

--- a/tool/internal/setup/sync_test.go
+++ b/tool/internal/setup/sync_test.go
@@ -672,3 +672,14 @@ go 1.21
 		replacedPaths,
 	)
 }
+
+func TestSyncDeps_ModTidyFails(t *testing.T) {
+	// A go.mod with an invalid go toolchain/version causes runModTidy to fail in syncDeps.
+	goMod := `module example.com/test
+
+go 999.0.0
+`
+	tempDir, _, _ := setupSyncDepsTest(t, goMod, []string{"net/http/client"})
+	err := syncDeps(t.Context(), map[string]bool{util.OtelcInstRoot + "/net/http/client": true}, tempDir)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Description

This PR drops redundant intermediate `ex.Wrap` and `ex.Wrapf` calls across the internal tool packages (`tool/internal/setup`, `tool/internal/instrument`, `tool/internal/pkgload`, and `tool/internal/imports`). Intermediate internal functions now return errors directly (`return err`), while preserving wrapping at error origins (like stdlib/OS calls) and at locations providing unique contextual information. Error assertions in affected tests have been updated accordingly.

## Motivation

Errors in `otelc` are stackful (`ex.New`, `ex.Wrap`, `ex.Wrapf` capture full stack traces). Wrapping errors on intermediate internal call returns where the wrapper only restates the function's action adds redundant message frames without new context. Propagating the error directly avoids cluttering the error message while preserving full stack traces and origin context.

Fixes #1231

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
