### PR TITLE
refactor(tool): fold internal/manifest into cmd/gen-manifest

### DIFF
--- a/.github/workflows/check-consistency.yaml
+++ b/.github/workflows/check-consistency.yaml
@@ -39,7 +39,6 @@ jobs:
               - 'instrumentation/**/otelc.yaml'
               - 'instrumentation/**/*.otelc.yml'
               - 'instrumentation/**/*.otelc.yaml'
-              - 'tool/internal/manifest/**'
               - 'tool/cmd/gen-manifest/**'
               - 'tool/cmd/check-test-names/**'
               - 'tool/data/instrumentation-manifest.json'

--- a/tool/cmd/gen-manifest/main.go
+++ b/tool/cmd/gen-manifest/main.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 
-	"go.opentelemetry.io/otelc/tool/internal/manifest"
 	"go.opentelemetry.io/otelc/tool/util"
 )
 
@@ -24,7 +23,7 @@ func main() {
 // run expects the repository root as its working directory. The manifest
 // source and output paths are both relative to it, as guaranteed by make.
 func run() error {
-	generated, err := manifest.Generate("instrumentation")
+	generated, err := Generate("instrumentation")
 	if err != nil {
 		return fmt.Errorf("generate instrumentation manifest: %w", err)
 	}

--- a/tool/cmd/gen-manifest/main_test.go
+++ b/tool/cmd/gen-manifest/main_test.go
@@ -10,16 +10,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"go.opentelemetry.io/otelc/tool/internal/manifest"
 )
 
 func TestRun(t *testing.T) {
 	root := t.TempDir()
 	t.Chdir(root)
 
-	writeModule(t, "instrumentation/example", "example.com/instrumentation/example")
-	writeFile(t, "instrumentation/example/otelc.yaml", `
+	writeModule(t, root, "instrumentation/example", "example.com/instrumentation/example")
+	writeRuleFile(t, root, "instrumentation/example/otelc.yaml", `
 http:
   target: net/http
   version: v1.0.0
@@ -34,9 +32,9 @@ http:
 	require.Equal(t, byte('\n'), content[len(content)-1])
 	require.True(t, json.Valid(content))
 
-	var got manifest.Manifest
+	var got Manifest
 	require.NoError(t, json.Unmarshal(content, &got))
-	require.Equal(t, manifest.Manifest{{
+	require.Equal(t, Manifest{{
 		ModulePath:   "example.com/instrumentation/example",
 		Target:       "net/http",
 		VersionRange: "v1.0.0",
@@ -54,24 +52,12 @@ func TestRunWriteError(t *testing.T) {
 	root := t.TempDir()
 	t.Chdir(root)
 
-	writeModule(t, "instrumentation/example", "example.com/instrumentation/example")
-	writeFile(t, "instrumentation/example/otelc.yaml", `
+	writeModule(t, root, "instrumentation/example", "example.com/instrumentation/example")
+	writeRuleFile(t, root, "instrumentation/example/otelc.yaml", `
 http:
   target: net/http
 `)
 
 	err := run()
 	require.ErrorContains(t, err, "write instrumentation manifest")
-}
-
-func writeModule(t *testing.T, relative, modulePath string) {
-	t.Helper()
-	writeFile(t, filepath.Join(relative, "go.mod"), "module "+modulePath+"\n")
-}
-
-func writeFile(t *testing.T, relative, content string) {
-	t.Helper()
-	path := filepath.FromSlash(relative)
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 }

--- a/tool/cmd/gen-manifest/manifest.go
+++ b/tool/cmd/gen-manifest/manifest.go
@@ -1,10 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package manifest
+package main
 
 import (
-	"encoding/json"
 	"errors"
 	"io/fs"
 	"maps"
@@ -16,7 +15,6 @@ import (
 	"golang.org/x/mod/modfile"
 	"gopkg.in/yaml.v3"
 
-	"go.opentelemetry.io/otelc/tool/data"
 	"go.opentelemetry.io/otelc/tool/ex"
 	"go.opentelemetry.io/otelc/tool/internal/rule"
 	"go.opentelemetry.io/otelc/tool/util"
@@ -73,14 +71,6 @@ func Generate(instrumentationRoot string) (Manifest, error) {
 		return strings.Compare(a.VersionRange, b.VersionRange)
 	})
 	manifest = slices.Compact(manifest)
-	return manifest, nil
-}
-
-func load() (Manifest, error) {
-	var manifest Manifest
-	if err := json.Unmarshal(data.GetManifestJSON(), &manifest); err != nil {
-		return nil, ex.Wrapf(err, "loading embedded instrumentation manifest")
-	}
 	return manifest, nil
 }
 

--- a/tool/cmd/gen-manifest/manifest_test.go
+++ b/tool/cmd/gen-manifest/manifest_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package manifest
+package main
 
 import (
 	"encoding/json"
@@ -14,6 +14,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otelc/tool/data"
 )
 
 func TestGenerate(t *testing.T) {
@@ -364,9 +366,12 @@ func TestLoadModuleEntriesRejectsEscapingRuleSymlink(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestLoad(t *testing.T) {
-	got, err := load()
-	require.NoError(t, err)
+// TestEmbeddedManifestMatchesGeneratorContract guards the checked-in artifact
+// this generator produces: it must unmarshal, describe complete entries, and
+// stay sorted and deduplicated the way Generate leaves it.
+func TestEmbeddedManifestMatchesGeneratorContract(t *testing.T) {
+	var got Manifest
+	require.NoError(t, json.Unmarshal(data.GetManifestJSON(), &got))
 	require.NotEmpty(t, got)
 
 	for _, entry := range got {


### PR DESCRIPTION
fold internal/manifest into cmd/gen-manifest, that's the only usage for this package and it's unlikely used elsewhere in the future.