### PR TITLE
refactor(tool/internal/instrument): stop re-parsing hook files and the trampoline template

### DIFF
--- a/tool/internal/instrument/optimize.go
+++ b/tool/internal/instrument/optimize.go
@@ -394,7 +394,7 @@ func (ip *instrumentPhase) optimizeTJumps() error {
 		// This further simplifies the trampoline-jump-if and gives more chances
 		// for optimization passes to kick in.
 		if rule.Before != "" {
-			hookFunc, err := getHookFunc(tjump.rule, true)
+			hookFunc, err := ip.getHookFunc(tjump.rule, true)
 			if err != nil {
 				return err
 			}

--- a/tool/internal/instrument/toolexec.go
+++ b/tool/internal/instrument/toolexec.go
@@ -62,6 +62,11 @@ type instrumentPhase struct {
 	// whole package because HookContext declarations accumulate into one globals
 	// file across all instrumented source files.
 	appliedFuncIdentities map[string]struct{}
+	// Hook files already parsed via parseHookFileCached, keyed by absolute
+	// file path. A hook package directory is typically shared by many func
+	// rules (one file implementing dozens of before/after pairs), so caching
+	// by file avoids re-parsing it once per rule.
+	parsedHookFiles map[string]*dst.File
 }
 
 func (ip *instrumentPhase) Info(msg string, args ...any)  { ip.logger.Info(msg, args...) }

--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -9,6 +9,7 @@ import (
 	"go/token"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/dave/dst"
 
@@ -94,14 +95,23 @@ func (ip *instrumentPhase) ensureUnsafeImport() {
 	ip.target.Decls = append([]dst.Decl{unsafeImport}, ip.target.Decls...)
 }
 
+// parsedTemplateImpl parses the static impl.tmpl source once per process;
+// materializeTemplate runs once per instrumented func rule and clones this
+// prototype instead of re-parsing, since cloning is significantly cheaper.
+//
+//nolint:gochecknoglobals // memoized parse of an embedded constant, not mutable state
+var parsedTemplateImpl = sync.OnceValues(func() (*dst.File, error) {
+	return ast.NewAstParser().ParseSource(templateImpl)
+})
+
 func (ip *instrumentPhase) materializeTemplate() error {
 	// Read trampoline template and materialize before and after function
 	// declarations based on that
-	p := ast.NewAstParser()
-	astRoot, err := p.ParseSource(templateImpl)
+	proto, err := parsedTemplateImpl()
 	if err != nil {
 		return err
 	}
+	astRoot := util.AssertType[*dst.File](dst.Clone(proto))
 
 	ip.varDecls = make([]dst.Decl, 0)
 	ip.hookCtxMethods = make([]*dst.FuncDecl, 0)
@@ -181,42 +191,55 @@ func isHookDefined(root *dst.File, rule *rule.InstFuncRule) bool {
 	return true
 }
 
-func findHookFile(rule *rule.InstFuncRule) (string, error) {
+// parseHookFileCached parses file once per process and reuses the result
+// across every hook lookup that touches it, whether for the same func rule
+// looked up twice (createTrampoline and optimizeTJumps) or a different rule
+// whose hook happens to live in a file already scanned for another rule.
+func (ip *instrumentPhase) parseHookFileCached(file string) (*dst.File, error) {
+	if root, ok := ip.parsedHookFiles[file]; ok {
+		return root, nil
+	}
+	root, err := ast.ParseFile(file)
+	if err != nil {
+		return nil, err
+	}
+	if ip.parsedHookFiles == nil {
+		ip.parsedHookFiles = make(map[string]*dst.File)
+	}
+	ip.parsedHookFiles[file] = root
+	return root, nil
+}
+
+// findHookFile locates the file in rule.ResolvedPath defining rule's hooks
+// and returns it already parsed, since the caller needs both.
+func (ip *instrumentPhase) findHookFile(rule *rule.InstFuncRule) (string, *dst.File, error) {
 	files, err0 := util.ListFiles(rule.ResolvedPath)
 	if err0 != nil {
-		return "", err0
+		return "", nil, err0
 	}
 	for _, file := range files {
 		if !util.IsGoFile(file) {
 			continue
 		}
-		root, err := ast.ParseFileFast(file)
+		root, err := ip.parseHookFileCached(file)
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
 		if isHookDefined(root, rule) {
-			return file, nil
+			return file, root, nil
 		}
 	}
-	return "", ex.Newf("no hook {%s,%s} found for %s from %v",
+	return "", nil, ex.Newf("no hook {%s,%s} found for %s from %v",
 		rule.Before, rule.After, rule.Func, files)
 }
 
-func getHookFunc(t *rule.InstFuncRule, before bool) (*dst.FuncDecl, error) {
-	file, err := findHookFile(t)
+// getHookFunc resolves the Before/After hook function declaration for t.
+func (ip *instrumentPhase) getHookFunc(t *rule.InstFuncRule, before bool) (*dst.FuncDecl, error) {
+	file, root, err := ip.findHookFile(t)
 	if err != nil {
 		return nil, err
 	}
-	root, err := ast.ParseFile(file) // Complete parse
-	if err != nil {
-		return nil, err
-	}
-	var target *dst.FuncDecl
-	if before {
-		target = ast.FindFuncDeclWithoutRecv(root, t.Before)
-	} else {
-		target = ast.FindFuncDeclWithoutRecv(root, t.After)
-	}
+	target := ast.FindFuncDeclWithoutRecv(root, getHookFuncName(t, before))
 	if target == nil {
 		return nil, ex.Newf("hook %s or %s not found from %s",
 			t.Before, t.After, file)
@@ -707,7 +730,7 @@ func (ip *instrumentPhase) buildHookSignature(t *rule.InstFuncRule, before bool)
 		field.Type = replaceTypeParamsWithAny(field.Type, genericTypes)
 	}
 	// Get the hook function declaration
-	hookFunc, err := getHookFunc(t, before)
+	hookFunc, err := ip.getHookFunc(t, before)
 	if err != nil {
 		return nil, err
 	}

--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -199,7 +199,7 @@ func (ip *instrumentPhase) parseHookFileCached(file string) (*dst.File, error) {
 	if root, ok := ip.parsedHookFiles[file]; ok {
 		return root, nil
 	}
-	root, err := ast.ParseFile(file)
+	root, err := ast.ParseFileFast(file)
 	if err != nil {
 		return nil, err
 	}

--- a/tool/internal/instrument/trampoline.go
+++ b/tool/internal/instrument/trampoline.go
@@ -109,6 +109,8 @@ func (ip *instrumentPhase) materializeTemplate() error {
 	// declarations based on that
 	proto, err := parsedTemplateImpl()
 	if err != nil {
+		// Defensive: templateImpl is an embedded constant, so this error branch
+		// is unreachable in practice unless the binary was built broken.
 		return err
 	}
 	astRoot := util.AssertType[*dst.File](dst.Clone(proto))

--- a/tool/internal/instrument/trampoline_test.go
+++ b/tool/internal/instrument/trampoline_test.go
@@ -5,13 +5,76 @@ package instrument
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/dave/dst"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otelc/tool/internal/ast"
+	"go.opentelemetry.io/otelc/tool/internal/rule"
 )
+
+func TestGetHookFuncCachesParsedFile(t *testing.T) {
+	dir := t.TempDir()
+	hookFile := filepath.Join(dir, "hook.go")
+	// Two hook functions in one file, as a real instrumentation package
+	// typically has many rules sharing one hook file.
+	require.NoError(t, os.WriteFile(
+		hookFile,
+		[]byte("package hook\n\nfunc beforeA() {}\nfunc beforeB() {}\n"),
+		0o600,
+	))
+
+	ip := &instrumentPhase{}
+	ruleA := &rule.InstFuncRule{Before: "beforeA", ResolvedPath: dir}
+	first, err := ip.getHookFunc(ruleA, true)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	// Corrupt the file so a real re-parse would fail; a second lookup for a
+	// *different* rule sharing the same file only succeeds if it reuses the
+	// cached parse instead of re-reading and re-parsing hook.go.
+	require.NoError(t, os.WriteFile(hookFile, []byte("not valid go"), 0o600))
+
+	ruleB := &rule.InstFuncRule{Before: "beforeB", ResolvedPath: dir}
+	second, err := ip.getHookFunc(ruleB, true)
+	require.NoError(t, err)
+	assert.Equal(t, "beforeB", second.Name.Name)
+}
+
+func TestGetHookFuncPropagatesParseError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "hook.go"),
+		[]byte("not valid go"),
+		0o600,
+	))
+
+	ip := &instrumentPhase{}
+	r := &rule.InstFuncRule{Before: "beforeA", ResolvedPath: dir}
+	_, err := ip.getHookFunc(r, true)
+	require.Error(t, err)
+}
+
+func TestMaterializeTemplateClonesIndependently(t *testing.T) {
+	ip1 := &instrumentPhase{target: &dst.File{}}
+	require.NoError(t, ip1.materializeTemplate())
+
+	ip2 := &instrumentPhase{target: &dst.File{}}
+	require.NoError(t, ip2.materializeTemplate())
+
+	// Mutate ip1's hook context type name, as implementHookContext does per
+	// instrumented function, and confirm ip2's independently-cloned copy is
+	// unaffected by it.
+	typeSpec1 := ip1.hookCtxDecl.Specs[0].(*dst.TypeSpec) //nolint:forcetypeassert // test
+	originalName := typeSpec1.Name.Name
+	typeSpec1.Name.Name += "Suffix"
+
+	typeSpec2 := ip2.hookCtxDecl.Specs[0].(*dst.TypeSpec) //nolint:forcetypeassert // test
+	assert.Equal(t, originalName, typeSpec2.Name.Name)
+}
 
 func TestBaseTypeName(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Item 3 from #1242.

Two things were getting re-parsed for no reason:

getHookFunc re-scanned and re-parsed the whole hook directory for every rule, with no caching at all. First pass at this cached by {resolved path, hook name}, but that only helped when the exact same rule got looked up twice (it's called once building the trampoline, once in optimizeTJumps). Real instrumentation packages don't work that way, database/sql alone has ~18 rules that all point at the same hook file with different hook names, so that cache barely did anything. Switched to caching the parsed file itself, keyed by path, so any rule sharing a file only pays for the parse once.

materializeTemplate re-parsed the same static impl.tmpl string from scratch on every func rule. Now it's parsed once per process and cloned per use (has to be cloned, not shared directly, since the caller mutates names on the clone to make each trampoline unique). Checked first whether cloning is actually cheaper than reparsing since that wasn't obvious, it is, about 14x (82µs vs 1.18ms in a quick benchmark).

Added a test that corrupts the hook file after the first lookup and confirms a second lookup for a different rule sharing that file still works, which only passes if it's served from the cache.
