### PR TITLE
fix(tool): remove unused HookContextImpl methods when After hook is absent

### DIFF
--- a/tool/internal/instrument/optimize.go
+++ b/tool/internal/instrument/optimize.go
@@ -198,6 +198,28 @@ func removeAfterTrampolineDecl(targetFile *dst.File, tjump *tJump) error {
 	return ex.Newf("can not remove After trampoline function")
 }
 
+func removeUnusedHookContextImplMethods(targetFile *dst.File, tjump *tJump) error {
+	structName := trampolineHookContextImplType + tjump.rule.Identity()
+	var newDecls []dst.Decl
+	for _, decl := range targetFile.Decls {
+		if funcDecl, ok := decl.(*dst.FuncDecl); ok && ast.HasReceiver(funcDecl) {
+			t := util.AssertType[*dst.StarExpr](funcDecl.Recv.List[0].Type)
+			t2 := util.AssertType[*dst.Ident](t.X)
+			if t2.Name == structName {
+				methodName := funcDecl.Name.Name
+				if methodName == trampolineGetReturnValName ||
+					methodName == trampolineSetReturnValName ||
+					methodName == "GetReturnValCount" {
+					continue
+				}
+			}
+		}
+		newDecls = append(newDecls, decl)
+	}
+	targetFile.Decls = newDecls
+	return nil
+}
+
 // canFlattenTJump checks if the tjump can be safely flattened based on
 // the hook function's usage of HookContext. Returns true if:
 // 1. SetSkipCall is never called (so skip is always false)
@@ -372,6 +394,10 @@ func (ip *instrumentPhase) optimizeTJumps() error {
 				return err
 			}
 			err = removeAfterTrampolineDecl(ip.target, tjump)
+			if err != nil {
+				return err
+			}
+			err = removeUnusedHookContextImplMethods(ip.target, tjump)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION

## Description

This PR extends the `optimizeTJumps()` logic to locate the `HookContextImpl` type declaration associated with a given trampoline and actively remove the AST nodes for `SetReturnVal`, `GetReturnVal`, and `GetReturnValCount` when the rule doesn't define an `After` hook (`rule.After == ""`).

## Motivation

Previously, `HookContextImpl` methods related to return values were generated for every instrumented function, even if the instrumentation lacked an `After` hook. By removing these methods when `rule.After == ""`, we resolve the pending technical debt (as noted in an inline `TODO`), keep the generated hook context leaner, and avoid unnecessary compilation overhead from serializing/compiling unused AST nodes.

Fixes #1264

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]
