### PR TITLE
doc: correct license header make targets in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,11 +89,11 @@ make help
   - `make lint/action` - Lint GitHub Actions workflows
   - `make lint/makefile` - Lint Makefile
   - `make lint/license-header` - Check license headers (has dedicated CI workflow)
-  - `make lint/license-header/fix` - Apply license headers to Go files
+  - `make lint/license-header/fix` - Apply license headers to Go and shell files
 
 #### License Headers
 
-All Go files must include the proper license header. The license header configuration is defined in `license.yml` which handles exclusions for vendor directories, temporary files, and generated code.
+All Go and shell files must include the proper license header. The required headers and path exclusions are managed in `.github/scripts/license-check.sh`.
 
 To check and fix license headers:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,13 +83,13 @@ make help
 - `make format` - Format all code (Go + YAML + License Headers)
   - `make format/go` - Format Go code only using golangci-lint
   - `make format/yaml` - Format YAML files only using yamlfmt
-  - `make format/license` - Apply license headers to Go files
 - `make lint` - Run all linters (Go, YAML, GitHub Actions, Makefile)
   - `make lint/go` - Run golangci-lint on Go code
   - `make lint/yaml` - Lint YAML formatting
   - `make lint/action` - Lint GitHub Actions workflows
   - `make lint/makefile` - Lint Makefile
-  - `make lint/license` - Check license headers (has dedicated CI workflow)
+  - `make lint/license-header` - Check license headers (has dedicated CI workflow)
+  - `make lint/license-header/fix` - Apply license headers to Go files
 
 #### License Headers
 
@@ -97,8 +97,8 @@ All Go files must include the proper license header. The license header configur
 
 To check and fix license headers:
 
-- **Check license headers**: `make lint/license`
-- **Apply license headers**: `make format/license`
+- **Check license headers**: `make lint/license-header`
+- **Apply license headers**: `make lint/license-header/fix`
 
 The license header checker has a dedicated CI workflow (`check-license-headers.yaml`) that runs automatically on pull requests and pushes when Go files or the license configuration change.
 


### PR DESCRIPTION
<!--
Thank you for contributing to OpenTelemetry Go Compile Instrumentation!

INSTRUCTIONS:
1. Fill in the description and motivation sections below
2. Complete the checklist before submitting
3. Ensure PR title follows conventional commits format (enforced by CI)

PR TITLE FORMAT (required):
  type(scope): description

  Types: chore, doc, docs, feat, fix, release, refactor, test
  Scopes: tool, pkg, demo, test, docs

  Examples:
  - feat(pkg): add gRPC client instrumentation
  - fix(tool): resolve hook signature matching issue
  - docs(api): update instrumenter interface documentation
  - refactor(pkg): simplify attribute extractor composition

BEFORE SUBMITTING:
  make format  # Format Go code and YAML files
  make lint    # Run all linters
  make test    # Run all tests (unit + integration + e2e)

If your PR adds a new user-facing instrumentation, please also submit a corresponding OpenTelemetry Registry PR:
https://opentelemetry.io/ecosystem/registry/adding/

For detailed contribution guidelines, see CONTRIBUTING.md
For available make targets, run: make help
-->

## Description

#### Some of the Make target references in the current **CONTRIBUTING.md** are outdated

Update `CONTRIBUTING.md` to use the current license header Make targets:

- `make lint/license-header` for checking headers
- `make lint/license-header/fix` for applying missing headers

## Motivation

PR [#144](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pull/144) replaced the previous `go-license`-based targets, `lint/license` and `format/license`, with the current script-based targets. It updated the Makefile and license-header workflow, but the corresponding commands in `CONTRIBUTING.md` remained unchanged.

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [ ] Tests added for new functionality
- [ ] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [x] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable, see [registry guide](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/instrument-guide.md#4-register-the-instrumentation))
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
