### PR TITLE
fix(tool/ast): handle import alias collisions and enforce strict import matching (#1271)

### DIFF
--- a/tool/internal/ast/typename.go
+++ b/tool/internal/ast/typename.go
@@ -58,8 +58,11 @@ func (t parsedTypeName) matches(node dst.Expr, imports map[string]string) bool {
 			// Populated by a resolving decorator; already the real import path.
 			return t.importPath == ident.Path && t.name == n.Sel.Name
 		}
-		if resolved, importOk := imports[ident.Name]; importOk {
-			return t.importPath == resolved && t.name == n.Sel.Name
+		if imports != nil {
+			if resolved, importOk := imports[ident.Name]; importOk {
+				return t.importPath == resolved && t.name == n.Sel.Name
+			}
+			return false
 		}
 		// No import context at all (imports == nil, e.g. hand-built AST nodes in
 		// tests with no backing *dst.File): compare against importPath's last
@@ -158,6 +161,9 @@ func ImportAliasMap(file *dst.File) map[string]string {
 	}
 
 	aliases := make(map[string]string, len(specs))
+	explicit := make(map[string]bool, len(specs))
+	collided := make(map[string]bool)
+
 	for _, imp := range specs {
 		if imp.Path == nil {
 			continue
@@ -166,8 +172,9 @@ func ImportAliasMap(file *dst.File) map[string]string {
 		if err != nil {
 			continue
 		}
+		isExplicit := imp.Name != nil
 		alias := defaultImportAlias(path)
-		if imp.Name != nil {
+		if isExplicit {
 			alias = imp.Name.Name
 		}
 		// Blank and dot imports don't introduce a qualified identifier that a
@@ -175,8 +182,33 @@ func ImportAliasMap(file *dst.File) map[string]string {
 		if alias == "" || alias == "_" || alias == "." {
 			continue
 		}
-		aliases[alias] = path
+		if existingPath, exists := aliases[alias]; exists {
+			if existingPath != path {
+				if isExplicit && !explicit[alias] {
+					// New explicit alias overrides previous default alias
+					aliases[alias] = path
+					explicit[alias] = true
+					delete(collided, alias)
+				} else if !isExplicit && explicit[alias] {
+					// Previous explicit alias wins over new default alias
+					continue
+				} else {
+					// Collision between two default aliases (or two conflicting explicit aliases)
+					collided[alias] = true
+				}
+			}
+		} else {
+			aliases[alias] = path
+			if isExplicit {
+				explicit[alias] = true
+			}
+		}
 	}
+
+	for c := range collided {
+		delete(aliases, c)
+	}
+
 	return aliases
 }
 

--- a/tool/internal/ast/typename.go
+++ b/tool/internal/ast/typename.go
@@ -59,10 +59,8 @@ func (t parsedTypeName) matches(node dst.Expr, imports map[string]string) bool {
 			return t.importPath == ident.Path && t.name == n.Sel.Name
 		}
 		if imports != nil {
-			if resolved, importOk := imports[ident.Name]; importOk {
-				return t.importPath == resolved && t.name == n.Sel.Name
-			}
-			return false
+			resolved, importOk := imports[ident.Name]
+			return importOk && t.importPath == resolved && t.name == n.Sel.Name
 		}
 		// No import context at all (imports == nil, e.g. hand-built AST nodes in
 		// tests with no backing *dst.File): compare against importPath's last
@@ -139,26 +137,30 @@ func MatchesTypeName(node dst.Expr, typeStr string, imports map[string]string) (
 // The cost is that the default name here is a syntactic guess; see defaultImportAlias.
 //
 // Returns nil when file is nil.
+func collectImportSpecs(file *dst.File) []*dst.ImportSpec {
+	if len(file.Imports) > 0 {
+		return file.Imports
+	}
+	var specs []*dst.ImportSpec
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*dst.GenDecl)
+		if !ok || genDecl.Tok != token.IMPORT {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			if importSpec, isImport := spec.(*dst.ImportSpec); isImport {
+				specs = append(specs, importSpec)
+			}
+		}
+	}
+	return specs
+}
+
 func ImportAliasMap(file *dst.File) map[string]string {
 	if file == nil {
 		return nil
 	}
-	var specs []*dst.ImportSpec
-	if len(file.Imports) > 0 {
-		specs = file.Imports
-	} else {
-		for _, decl := range file.Decls {
-			genDecl, ok := decl.(*dst.GenDecl)
-			if !ok || genDecl.Tok != token.IMPORT {
-				continue
-			}
-			for _, spec := range genDecl.Specs {
-				if importSpec, isImport := spec.(*dst.ImportSpec); isImport {
-					specs = append(specs, importSpec)
-				}
-			}
-		}
-	}
+	specs := collectImportSpecs(file)
 
 	aliases := make(map[string]string, len(specs))
 	explicit := make(map[string]bool, len(specs))
@@ -182,26 +184,32 @@ func ImportAliasMap(file *dst.File) map[string]string {
 		if alias == "" || alias == "_" || alias == "." {
 			continue
 		}
-		if existingPath, exists := aliases[alias]; exists {
-			if existingPath != path {
-				if isExplicit && !explicit[alias] {
-					// New explicit alias overrides previous default alias
-					aliases[alias] = path
-					explicit[alias] = true
-					delete(collided, alias)
-				} else if !isExplicit && explicit[alias] {
-					// Previous explicit alias wins over new default alias
-					continue
-				} else {
-					// Collision between two default aliases (or two conflicting explicit aliases)
-					collided[alias] = true
-				}
-			}
-		} else {
+
+		existingPath, exists := aliases[alias]
+		if !exists {
 			aliases[alias] = path
 			if isExplicit {
 				explicit[alias] = true
 			}
+			continue
+		}
+
+		if existingPath == path {
+			continue
+		}
+
+		switch {
+		case isExplicit && !explicit[alias]:
+			// New explicit alias overrides previous default alias
+			aliases[alias] = path
+			explicit[alias] = true
+			delete(collided, alias)
+		case !isExplicit && explicit[alias]:
+			// Previous explicit alias wins over new default alias
+			continue
+		default:
+			// Collision between two default aliases (or two conflicting explicit aliases)
+			collided[alias] = true
 		}
 	}
 

--- a/tool/internal/ast/typename.go
+++ b/tool/internal/ast/typename.go
@@ -123,21 +123,10 @@ func MatchesTypeName(node dst.Expr, typeStr string, imports map[string]string) (
 	return tn.matches(node, imports), nil
 }
 
-// importAliasMap builds a map from the local identifier used to reference an
-// imported package within file (its explicit alias, or its default package
-// name when unaliased) to that package's real import path. It correctly disambiguates:
-//   - aliased imports (e.g. `import althttp "net/http"`)
-//   - distinct import paths that happen to share a last path segment (e.g.
-//     "text/template" vs "html/template", both conventionally "template")
-//
-// This deliberately duplicates tool/internal/imports.parseFile rather than reusing
-// it: that resolves unaliased imports with pkgload.ResolvePackageName (a
-// go/packages load that ex.Fatalf's on failure), which is too costly and too fatal
-// for the setup/match path, where this runs for every compiled package in the build.
-// The cost is that the default name here is a syntactic guess; see defaultImportAlias.
-//
-// Returns nil when file is nil.
 func collectImportSpecs(file *dst.File) []*dst.ImportSpec {
+	if file == nil {
+		return nil
+	}
 	if len(file.Imports) > 0 {
 		return file.Imports
 	}
@@ -156,6 +145,20 @@ func collectImportSpecs(file *dst.File) []*dst.ImportSpec {
 	return specs
 }
 
+// ImportAliasMap builds a map from the local identifier used to reference an
+// imported package within file (its explicit alias, or its default package
+// name when unaliased) to that package's real import path. It correctly disambiguates:
+//   - aliased imports (e.g. `import althttp "net/http"`)
+//   - distinct import paths that happen to share a last path segment (e.g.
+//     "text/template" vs "html/template", both conventionally "template")
+//
+// This deliberately duplicates tool/internal/imports.parseFile rather than reusing
+// it: that resolves unaliased imports with pkgload.ResolvePackageName (a
+// go/packages load that ex.Fatalf's on failure), which is too costly and too fatal
+// for the setup/match path, where this runs for every compiled package in the build.
+// The cost is that the default name here is a syntactic guess; see defaultImportAlias.
+//
+// Returns nil when file is nil.
 func ImportAliasMap(file *dst.File) map[string]string {
 	if file == nil {
 		return nil

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -261,6 +261,7 @@ func TestTypeNameMatches_ImportAliasResolution(t *testing.T) {
 
 func TestImportAliasMap(t *testing.T) {
 	t.Run("nil file returns nil", func(t *testing.T) {
+		assert.Nil(t, collectImportSpecs(nil))
 		assert.Nil(t, ImportAliasMap(nil))
 	})
 
@@ -559,6 +560,57 @@ func f() {}
 		imports := ImportAliasMap(file)
 		assert.Equal(t, "text/template", imports["template"])
 		assert.Equal(t, "html/template", imports["htmltemplate"])
+	})
+
+	t.Run("explicit alias wins over subsequent default alias", func(t *testing.T) {
+		p := NewAstParser()
+		file, err := p.ParseSource(`package main
+
+import (
+	template "text/template"
+	"html/template"
+)
+
+func f() {}
+`)
+		require.NoError(t, err)
+
+		imports := ImportAliasMap(file)
+		assert.Equal(t, "text/template", imports["template"])
+	})
+
+	t.Run("colliding explicit aliases are excluded", func(t *testing.T) {
+		p := NewAstParser()
+		file, err := p.ParseSource(`package main
+
+import (
+	tpl "text/template"
+	tpl "html/template"
+)
+
+func f() {}
+`)
+		require.NoError(t, err)
+
+		imports := ImportAliasMap(file)
+		assert.NotContains(t, imports, "tpl")
+	})
+
+	t.Run("duplicate identical import path is preserved", func(t *testing.T) {
+		p := NewAstParser()
+		file, err := p.ParseSource(`package main
+
+import (
+	"net/http"
+	"net/http"
+)
+
+func f() {}
+`)
+		require.NoError(t, err)
+
+		imports := ImportAliasMap(file)
+		assert.Equal(t, "net/http", imports["http"])
 	})
 }
 

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -530,8 +530,8 @@ func TestImportAliasMap_CollidingDefaultAliases(t *testing.T) {
 		file, err := p.ParseSource(`package main
 
 import (
-	"text/template"
-	"html/template"
+	"example.com/m/bar"
+	"example.com/m/other/bar"
 	"net/http"
 )
 
@@ -541,7 +541,7 @@ func f() {}
 
 		imports := ImportAliasMap(file)
 		assert.Equal(t, "net/http", imports["http"])
-		assert.NotContains(t, imports, "template")
+		assert.NotContains(t, imports, "bar")
 	})
 
 	t.Run("explicit alias overrides colliding default alias", func(t *testing.T) {
@@ -549,8 +549,8 @@ func f() {}
 		file, err := p.ParseSource(`package main
 
 import (
-	"text/template"
-	htmltemplate "html/template"
+	"example.com/m/bar"
+	otherbar "example.com/m/other/bar"
 )
 
 func f() {}
@@ -558,8 +558,8 @@ func f() {}
 		require.NoError(t, err)
 
 		imports := ImportAliasMap(file)
-		assert.Equal(t, "text/template", imports["template"])
-		assert.Equal(t, "html/template", imports["htmltemplate"])
+		assert.Equal(t, "example.com/m/bar", imports["bar"])
+		assert.Equal(t, "example.com/m/other/bar", imports["otherbar"])
 	})
 
 	t.Run("explicit alias wins over subsequent default alias", func(t *testing.T) {
@@ -567,8 +567,8 @@ func f() {}
 		file, err := p.ParseSource(`package main
 
 import (
-	template "text/template"
-	"html/template"
+	bar "example.com/m/bar"
+	"example.com/m/other/bar"
 )
 
 func f() {}
@@ -576,7 +576,7 @@ func f() {}
 		require.NoError(t, err)
 
 		imports := ImportAliasMap(file)
-		assert.Equal(t, "text/template", imports["template"])
+		assert.Equal(t, "example.com/m/bar", imports["bar"])
 	})
 
 	t.Run("colliding explicit aliases are excluded", func(t *testing.T) {
@@ -584,8 +584,8 @@ func f() {}
 		file, err := p.ParseSource(`package main
 
 import (
-	tpl "text/template"
-	tpl "html/template"
+	tpl "example.com/m/bar"
+	tpl "example.com/m/other/bar"
 )
 
 func f() {}

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -578,4 +578,3 @@ func TestTypeNameMatches_StrictImportContext(t *testing.T) {
 	// Without import context (imports == nil), path-tail matching still works for test AST nodes.
 	assert.True(t, tn.matches(node, nil))
 }
-

--- a/tool/internal/ast/typename_test.go
+++ b/tool/internal/ast/typename_test.go
@@ -522,3 +522,60 @@ func TestMatchesTypeName_UnsupportedNodeDoesNotMatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, matched)
 }
+
+func TestImportAliasMap_CollidingDefaultAliases(t *testing.T) {
+	t.Run("unaliased colliding default aliases are excluded", func(t *testing.T) {
+		p := NewAstParser()
+		file, err := p.ParseSource(`package main
+
+import (
+	"text/template"
+	"html/template"
+	"net/http"
+)
+
+func f() {}
+`)
+		require.NoError(t, err)
+
+		imports := ImportAliasMap(file)
+		assert.Equal(t, "net/http", imports["http"])
+		assert.NotContains(t, imports, "template")
+	})
+
+	t.Run("explicit alias overrides colliding default alias", func(t *testing.T) {
+		p := NewAstParser()
+		file, err := p.ParseSource(`package main
+
+import (
+	"text/template"
+	htmltemplate "html/template"
+)
+
+func f() {}
+`)
+		require.NoError(t, err)
+
+		imports := ImportAliasMap(file)
+		assert.Equal(t, "text/template", imports["template"])
+		assert.Equal(t, "html/template", imports["htmltemplate"])
+	})
+}
+
+func TestTypeNameMatches_StrictImportContext(t *testing.T) {
+	node := &dst.SelectorExpr{
+		X:   &dst.Ident{Name: "req"},
+		Sel: &dst.Ident{Name: "Header"},
+	}
+
+	tn, err := parseTypeName("foo/req.Header")
+	require.NoError(t, err)
+
+	// When imports is provided, an unimported selector "req" must not fall back to path-tail match.
+	imports := map[string]string{"http": "net/http"}
+	assert.False(t, tn.matches(node, imports))
+
+	// Without import context (imports == nil), path-tail matching still works for test AST nodes.
+	assert.True(t, tn.matches(node, nil))
+}
+


### PR DESCRIPTION
## Description

Fixes #1271.

This PR addresses two edge-case issues in `tool/internal/ast/typename.go`:

1. **Import Alias Collisions:** `ImportAliasMap` previously mapped default package aliases to import paths without checking for collisions. When a source file contained multiple unaliased imports sharing a default alias (e.g. `import "text/template"` and `import "html/template"`), `aliases[alias] = path` silently overwrote earlier entries. We now track explicit vs default aliases and exclude ambiguous default aliases from the map so unaliased references do not resolve to an arbitrary import.
2. **Strict Import Context Matching:** In `parsedTypeName.matches` (`*dst.SelectorExpr`), when `imports` context is provided (`imports != nil`), failing to locate `ident.Name` in `imports` now returns `false` immediately instead of falling through to path-tail matching on unimported packages or local variables.

## Verification / Unit Tests

Added unit tests in `tool/internal/ast/typename_test.go`:
- `TestImportAliasMap_CollidingDefaultAliases`
- `TestTypeNameMatches_StrictImportContext`

All tool package tests pass cleanly (`go test ./tool/...`).
