### PR TITLE
fix(tool): close the output file via defer in ast and importcfg writeFile

### DIFF
--- a/tool/internal/ast/parser.go
+++ b/tool/internal/ast/parser.go
@@ -102,14 +102,18 @@ func WriteFile(filePath string, root *dst.File) error {
 	return writeFile(file, filePath, root)
 }
 
-func writeFile(w io.WriteCloser, filePath string, root *dst.File) error {
+func writeFile(w io.WriteCloser, filePath string, root *dst.File) (retErr error) {
+	// The deferred close runs on every return path, including a panic during the write.
+	// The deferred close reports an error only when the write succeeds, so the write error takes priority.
+	defer func() {
+		if closeErr := w.Close(); closeErr != nil && retErr == nil {
+			retErr = ex.Wrapf(closeErr, "failed to close file %s", filePath)
+		}
+	}()
+
 	r := decorator.NewRestorer()
 	if err := r.Fprint(w, root); err != nil {
-		_ = w.Close()
 		return ex.Wrapf(err, "failed to write to file %s", filePath)
-	}
-	if err := w.Close(); err != nil {
-		return ex.Wrapf(err, "failed to close file %s", filePath)
 	}
 	return nil
 }

--- a/tool/internal/ast/parser_test.go
+++ b/tool/internal/ast/parser_test.go
@@ -163,11 +163,16 @@ func TestWriteFile_CreateError(t *testing.T) {
 }
 
 type mockWriteCloser struct {
-	writeErr error
-	closeErr error
+	writeErr     error
+	closeErr     error
+	panicOnWrite bool
+	closed       bool
 }
 
 func (m *mockWriteCloser) Write(p []byte) (int, error) {
+	if m.panicOnWrite {
+		panic("simulated write panic")
+	}
 	if m.writeErr != nil {
 		return 0, m.writeErr
 	}
@@ -175,6 +180,7 @@ func (m *mockWriteCloser) Write(p []byte) (int, error) {
 }
 
 func (m *mockWriteCloser) Close() error {
+	m.closed = true
 	return m.closeErr
 }
 
@@ -196,4 +202,13 @@ func TestWriteFile_CloseError(t *testing.T) {
 	err = writeFile(mock, "out.go", f)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to close file")
+}
+
+func TestWriteFile_PanicSafety(t *testing.T) {
+	f, err := ParseFile("parser_test.go")
+	require.NoError(t, err)
+
+	mock := &mockWriteCloser{panicOnWrite: true}
+	require.Panics(t, func() { _ = writeFile(mock, "out.go", f) })
+	assert.True(t, mock.closed, "the file must be closed even when writing panics")
 }

--- a/tool/internal/imports/importcfg.go
+++ b/tool/internal/imports/importcfg.go
@@ -112,13 +112,17 @@ func (r *ImportConfig) WriteFile(filename string) error {
 	return r.writeFile(file, filename)
 }
 
-func (r *ImportConfig) writeFile(w io.WriteCloser, filename string) error {
+func (r *ImportConfig) writeFile(w io.WriteCloser, filename string) (retErr error) {
+	// The deferred close runs on every return path, including a panic during the write.
+	// The deferred close reports an error only when the write succeeds, so the write error takes priority.
+	defer func() {
+		if closeErr := w.Close(); closeErr != nil && retErr == nil {
+			retErr = ex.Wrapf(closeErr, "failed to close file %s", filename)
+		}
+	}()
+
 	if err := r.write(w); err != nil {
-		_ = w.Close()
 		return ex.Wrapf(err, "failed to write to file %s", filename)
-	}
-	if err := w.Close(); err != nil {
-		return ex.Wrapf(err, "failed to close file %s", filename)
 	}
 	return nil
 }

--- a/tool/internal/imports/importcfg_test.go
+++ b/tool/internal/imports/importcfg_test.go
@@ -106,11 +106,16 @@ func TestWriteFile_CreateError(t *testing.T) {
 }
 
 type mockWriteCloser struct {
-	writeErr error
-	closeErr error
+	writeErr     error
+	closeErr     error
+	panicOnWrite bool
+	closed       bool
 }
 
 func (m *mockWriteCloser) Write(p []byte) (int, error) {
+	if m.panicOnWrite {
+		panic("simulated write panic")
+	}
 	if m.writeErr != nil {
 		return 0, m.writeErr
 	}
@@ -118,6 +123,7 @@ func (m *mockWriteCloser) Write(p []byte) (int, error) {
 }
 
 func (m *mockWriteCloser) Close() error {
+	m.closed = true
 	return m.closeErr
 }
 
@@ -269,4 +275,13 @@ func TestWrite_DeterministicOrder(t *testing.T) {
 		"packagefile net/http=/path/to/net/http.a",
 		"packagefile strings=/path/to/strings.a",
 	}, packageFileLines)
+}
+
+func TestWriteFile_PanicSafety(t *testing.T) {
+	cfg := ImportConfig{
+		PackageFile: map[string]string{"fmt": "/path/to/fmt.a"},
+	}
+	mock := &mockWriteCloser{panicOnWrite: true}
+	require.Panics(t, func() { _ = cfg.writeFile(mock, "importcfg") })
+	assert.True(t, mock.closed, "the file must be closed even when writing panics")
 }


### PR DESCRIPTION
## Description

`ast.writeFile` (`tool/internal/ast/parser.go`) and `ImportConfig.writeFile` (`tool/internal/imports/importcfg.go`) called `Close()` only after the write finished:

```go
func writeFile(w writeCloser, ...) error {
    if err := <write>(w, ...); err != nil {
        _ = w.Close()
        return ex.Wrapf(err, "failed to write ...")
    }
    if err := w.Close(); err != nil {
        return ex.Wrapf(err, "failed to close ...")
    }
    return nil
}
```

If the write panics (a malformed injected AST node, an internal formatting failure), execution escapes before either `Close()` runs, leaking the file descriptor until GC.

Both functions now close via `defer` with a named return, so the descriptor is released on a normal return, an error return, or a panic. A close error is reported only when the write itself succeeded, so the original write error is preserved. Behavior is unchanged on the normal, write-error, and close-error paths.

## Tests

Each package gains `TestWriteFile_PanicSafety`, using the existing `mockWriteCloser` extended to panic on `Write` and record whether `Close` ran. The test asserts the file is closed even when writing panics. I verified both fail against current `main` and pass with this change.

This is tool-only; no bundle regeneration is required.

Fixes #1275

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [ ] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable)
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.