### PR TITLE
fix(tool/internal/setup): recognize quoted -mod tokens in GOFLAGS

### DIFF
--- a/tool/internal/setup/vendor.go
+++ b/tool/internal/setup/vendor.go
@@ -67,14 +67,20 @@ func isModToken(tok string) bool {
 // vendoring, so we respect the user's intent). -mod=mod is appended only when
 // no -mod/--mod token is present at all.
 func forceModMod(goflags string) string {
-	fields := strings.Fields(goflags)
+	// SplitGoflags keeps quoted tokens (such as -tags='foo bar') intact, unlike
+	// strings.Fields which would split them on the inner space.
+	fields := util.SplitGoflags(goflags)
 	hasMod := false
 	for i, f := range fields {
-		switch {
-		case isModVendorToken(f):
+		// The go command strips one layer of surrounding quotes from a GOFLAGS
+		// token before interpreting it, so a quoted flag such as '-mod=readonly'
+		// is a -mod flag. Match on the unquoted form, but keep the original
+		// token in the output so an existing -mod choice is preserved verbatim.
+		switch tok := util.UnquoteGoflagsToken(f); {
+		case isModVendorToken(tok):
 			fields[i] = modMod
 			hasMod = true
-		case isModToken(f):
+		case isModToken(tok):
 			hasMod = true
 		}
 	}

--- a/tool/internal/setup/vendor_test.go
+++ b/tool/internal/setup/vendor_test.go
@@ -91,6 +91,10 @@ func TestForceModMod(t *testing.T) {
 		// following -mod flag is still recognized and not clobbered.
 		{"spaced quoted flag before quoted mod", "-tags='foo bar' '-mod=readonly'", "-tags='foo bar' '-mod=readonly'"},
 		{"spaced quoted flag no mod appends once", "-tags='foo bar'", "-tags='foo bar' -mod=mod"},
+		// The go command strips only a surrounding quote pair, so -mod='vendor' keeps
+		// its quoted value and is not a -mod=vendor token. It stays as written and go
+		// rejects the value later.
+		{"value-quoted vendor preserved; go rejects it later", "-mod='vendor'", "-mod='vendor'"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tool/internal/setup/vendor_test.go
+++ b/tool/internal/setup/vendor_test.go
@@ -78,6 +78,19 @@ func TestForceModMod(t *testing.T) {
 		{"double-dash mod left unchanged, no append", "--mod=mod", "--mod=mod"},
 		{"double-dash readonly left unchanged, no append", "--mod=readonly", "--mod=readonly"},
 		{"bare double-dash mod left as is, no append", "--mod", "--mod"},
+		// The go command accepts quoted GOFLAGS tokens. A quoted -mod flag is
+		// still a -mod flag, so it must be recognized and not have -mod=mod
+		// appended after it, which would win by last-value.
+		{"single-quoted readonly left unchanged", "'-mod=readonly'", "'-mod=readonly'"},
+		{"double-quoted readonly left unchanged", `"-mod=readonly"`, `"-mod=readonly"`},
+		{"quoted readonly among flags left unchanged", "-trimpath '-mod=readonly'", "-trimpath '-mod=readonly'"},
+		{"quoted vendor overridden", "'-mod=vendor'", "-mod=mod"},
+		{"quoted double-dash readonly left unchanged", "'--mod=readonly'", "'--mod=readonly'"},
+		{"quoted double-dash vendor overridden", "'--mod=vendor'", "-mod=mod"},
+		// A quoted flag whose value contains a space stays one token, so the
+		// following -mod flag is still recognized and not clobbered.
+		{"spaced quoted flag before quoted mod", "-tags='foo bar' '-mod=readonly'", "-tags='foo bar' '-mod=readonly'"},
+		{"spaced quoted flag no mod appends once", "-tags='foo bar'", "-tags='foo bar' -mod=mod"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tool/util/go.go
+++ b/tool/util/go.go
@@ -92,12 +92,12 @@ func IsCgoCommand(line string) bool {
 		!strings.Contains(line, "-dynimport")
 }
 
-// splitGoflags splits a GOFLAGS value into tokens like the go command does
+// SplitGoflags splits a GOFLAGS value into tokens like the go command does
 // (https://cs.opensource.google/go/go/+/master:src/cmd/internal/quoted/quoted.go)
 //
 // space-separated, but a token starting with a quote runs to the matching close quote.
 // Quotes are kept so tokens re-join verbatim.
-func splitGoflags(goflags string) []string {
+func SplitGoflags(goflags string) []string {
 	isSpace := func(c byte) bool {
 		return c == ' ' || c == '\t' || c == '\n' || c == '\r'
 	}
@@ -135,20 +135,33 @@ func splitGoflags(goflags string) []string {
 // children's toolexec: none for setup discovery, an explicit CLI flag for
 // `otelc go build`, and nested version-only mode during instrumentation.
 func StripToolexecFromGoflags(goflags string) string {
-	tokens := splitGoflags(goflags)
+	tokens := SplitGoflags(goflags)
 	kept := make([]string, 0, len(tokens))
 	for _, token := range tokens {
-		unquoted := token
-		if len(unquoted) >= 2 && (unquoted[0] == '\'' || unquoted[0] == '"') &&
-			unquoted[len(unquoted)-1] == unquoted[0] {
-			unquoted = unquoted[1 : len(unquoted)-1]
-		}
+		unquoted := UnquoteGoflagsToken(token)
 		if unquoted == "-toolexec" || strings.HasPrefix(unquoted, "-toolexec=") {
 			continue
 		}
 		kept = append(kept, token)
 	}
 	return strings.Join(kept, " ")
+}
+
+// quotedTokenMinLen is the shortest GOFLAGS token that can hold a surrounding
+// quote pair: one opening quote and one closing quote.
+const quotedTokenMinLen = 2
+
+// UnquoteGoflagsToken removes one pair of surrounding matching quotes from a
+// GOFLAGS token, mirroring how the go command interprets it before acting on
+// the flag. A token without a matching surrounding quote pair is returned
+// unchanged. The token should already have been produced by SplitGoflags.
+func UnquoteGoflagsToken(token string) string {
+	if len(token) >= quotedTokenMinLen {
+		if q := token[0]; (q == '\'' || q == '"') && token[len(token)-1] == q {
+			return token[1 : len(token)-1]
+		}
+	}
+	return token
 }
 
 // QuoteGoflagsToken quotes a token for inclusion in a GOFLAGS value, following

--- a/tool/util/go_test.go
+++ b/tool/util/go_test.go
@@ -646,6 +646,27 @@ func TestSplitCompileCmds(t *testing.T) {
 	}
 }
 
+func TestUnquoteGoflagsToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{name: "unquoted token unchanged", token: "-mod=mod", want: "-mod=mod"},
+		{name: "single-quoted token stripped", token: "'-mod=readonly'", want: "-mod=readonly"},
+		{name: "double-quoted token stripped", token: `"-mod=readonly"`, want: "-mod=readonly"},
+		{name: "mismatched pair unchanged", token: `'-mod=readonly"`, want: `'-mod=readonly"`},
+		{name: "double layer strips one layer", token: `"'-mod=readonly'"`, want: "'-mod=readonly'"},
+		{name: "one-character token unchanged", token: "'", want: "'"},
+		{name: "empty token unchanged", token: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, UnquoteGoflagsToken(tt.token))
+		})
+	}
+}
+
 func TestQuoteGoflagsToken(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Description

`forceModMod` in `tool/internal/setup/vendor.go` split `GOFLAGS` with `strings.Fields` and matched the raw tokens. The go command accepts quoted `GOFLAGS` tokens such as `'-mod=readonly'`, and the surrounding quotes stayed attached to the token, so `isModToken` did not recognize it as a `-mod` flag.

`forceModMod` then concluded no module-mode flag was present and appended `-mod=mod`, producing:

```text
'-mod=readonly' -mod=mod
```

Because Go applies last-value-wins for a repeated flag, the effective mode flipped from `readonly` to `mod`, overriding the user's choice and defeating the function's own documented intent to preserve `-mod=readonly` (which already disables vendoring).

The fix matches on the unquoted form of each token, via a small `unquoteGoflagsToken` helper that strips one pair of surrounding matching quotes the way the go command does, while keeping the original token in the output. A quoted `-mod` flag is now recognized and preserved verbatim, and a quoted `-mod=vendor` is still rewritten to `-mod=mod`.

## Tests

`TestForceModMod` gains cases for single- and double-quoted `-mod=readonly` (preserved), a quoted `-mod` among other flags (preserved), and a quoted `-mod=vendor` (still overridden). I verified they fail against current `main` and pass with this change. This is tool-only; no bundle regeneration is required.

Fixes #1267

---

## Checklist

- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Code formatted: `make format`
- [x] Linters pass: `make lint`
- [x] Tests pass: `make test`
- [x] Tests added for new functionality
- [ ] Tests follow [testing guidelines](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/testing.md)
- [ ] Documentation updated (if applicable)
- [ ] OpenTelemetry Registry updated (if applicable)
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/AI_POLICY.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.