### PR TITLE
fix(tool): wrap raw errors with ex to keep stack traces

### DIFF
--- a/tool/internal/manifest/manifest.go
+++ b/tool/internal/manifest/manifest.go
@@ -42,7 +42,7 @@ func Generate(instrumentationRoot string) (Manifest, error) {
 	manifest := make(Manifest, 0)
 	err := filepath.WalkDir(instrumentationRoot, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return ex.Wrap(err)
 		}
 		if d.IsDir() || d.Name() != "go.mod" || filepath.Dir(path) == instrumentationRoot {
 			return nil
@@ -110,7 +110,7 @@ func loadModuleEntries(moduleDir, modulePath string) (Manifest, error) {
 	rootFS := root.FS()
 	err = fs.WalkDir(rootFS, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return ex.Wrap(err)
 		}
 		if d.IsDir() {
 			if path == "." {
@@ -119,7 +119,7 @@ func loadModuleEntries(moduleDir, modulePath string) (Manifest, error) {
 			if _, statErr := fs.Stat(rootFS, path+"/go.mod"); statErr == nil {
 				return fs.SkipDir
 			} else if !errors.Is(statErr, fs.ErrNotExist) {
-				return statErr
+				return ex.Wrapf(statErr, "stat %s/go.mod", path)
 			}
 			return nil
 		}

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -407,7 +407,7 @@ func rulesFromDir(path string, skipSubmodules bool) ([]string, error) {
 	// Recursively traverse to each directories and include the rule files
 	err := filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return ex.Wrap(err)
 		}
 
 		if skipSubmodules && d.IsDir() && p != path && util.PathExists(filepath.Join(p, "go.mod")) {

--- a/tool/internal/setup/pin.go
+++ b/tool/internal/setup/pin.go
@@ -175,7 +175,7 @@ type yamlRule struct {
 func loadModuleRules(moduleDir, module string, loaded map[string][]yamlRule) error {
 	return filepath.WalkDir(moduleDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return ex.Wrap(err)
 		}
 
 		if d.IsDir() {
@@ -215,7 +215,7 @@ func loadMinimalRules(rulesRoot string) (map[string][]yamlRule, error) {
 
 	err := filepath.WalkDir(rulesRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return ex.Wrap(err)
 		}
 		// rulesRoot is instrumentation/
 		// We want to load rules for submodules within instrumentation/
@@ -255,7 +255,7 @@ func ensureOtelcRequireVersion(f *modfile.File, version string) (bool, error) {
 	}
 
 	if err := f.AddRequire(util.OtelcRoot, version); err != nil {
-		return false, err
+		return false, ex.Wrap(err)
 	}
 
 	return true, nil
@@ -265,12 +265,12 @@ func ensureOtelcRequire(moduleDir, version string) (bool, error) {
 	goModPath := filepath.Join(moduleDir, "go.mod")
 	data, err := os.ReadFile(goModPath)
 	if err != nil {
-		return false, err
+		return false, ex.Wrap(err)
 	}
 
 	f, err := modfile.Parse(goModPath, data, nil)
 	if err != nil {
-		return false, err
+		return false, ex.Wrap(err)
 	}
 
 	modified := false
@@ -285,7 +285,7 @@ func ensureOtelcRequire(moduleDir, version string) (bool, error) {
 
 	if !hasTool {
 		if addErr := f.AddTool(util.OtelcToolCmdRoot); addErr != nil {
-			return false, addErr
+			return false, ex.Wrap(addErr)
 		}
 		modified = true
 	}

--- a/tool/internal/setup/sync.go
+++ b/tool/internal/setup/sync.go
@@ -136,7 +136,7 @@ func discoverNestedModuleReplaces(dir string) (map[string]string, error) {
 
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return ex.Wrap(err)
 		}
 		if d.IsDir() {
 			name := d.Name()


### PR DESCRIPTION
A few error origins in the tool were returning stdlib and golang.org/x/mod errors unwrapped, so those errors reached the top level with no stack trace.
This wraps them with ex.Wrap at the point they enter our code, which is the pattern documented in tool/ex/error.go.