### PR TITLE
docs(schemas): backfill missing coverage rows for aws and linodego

### DIFF
--- a/schemas/otelc/README.md
+++ b/schemas/otelc/README.md
@@ -20,6 +20,7 @@ schemas/otelc/
 │   ├── anthropic.yaml       # anthropics/anthropic-sdk-go GenAI client spans
 │   ├── mongo.yaml           # go.mongodb.org/mongo-driver client spans
 │   ├── gin.yaml             # gin-gonic/gin server-span enrichment
+│   ├── linodego.yaml        # linode/linodego (v2) client spans + operation-duration metric
 │   ├── otel-sdk.yaml        # go.opentelemetry.io/otel* — Go runtime metrics
 │   ├── logs.yaml            # log, log/slog, logrus — no telemetry (correlation only)
 │   └── runtime.yaml         # runtime — no telemetry (GLS context propagation)
@@ -43,6 +44,7 @@ signals an undeclared instrumentation.
 | --------------------------------------------------- | ------------------- | ---------------------------------------------------------------------- |
 | `net/http/client`, `net/http/server`                | `http.yaml`         | HTTP client + server metrics                                           |
 | `google.golang.org/grpc/{client,server}`            | `grpc.yaml`         | RPC client + server metrics and spans                                  |
+| `github.com/aws/aws-sdk-go-v2`                      | `aws.yaml`          | AWS SDK client spans (trace-only)                                      |
 | `database/sql`                                      | `database-sql.yaml` | DB client spans                                                        |
 | `github.com/redis/go-redis/v9`                      | `redis.yaml`        | DB client spans                                                        |
 | `github.com/segmentio/kafka-go/{producer,consumer}` | `kafka.yaml`        | Messaging producer + consumer spans                                    |
@@ -52,6 +54,7 @@ signals an undeclared instrumentation.
 | `go.mongodb.org/mongo-driver/mongo`                 | `mongo.yaml`        | DB client spans                                                        |
 | `go.mongodb.org/mongo-driver/v2/mongo`              | `mongo.yaml`        | DB client spans                                                        |
 | `github.com/gin-gonic/gin`                          | `gin.yaml`          | `http.route` on the enclosing `net/http` server span                   |
+| `github.com/linode/linodego/v2`                     | `linodego.yaml`     | HTTP client spans + operation-duration metric                          |
 | `go.opentelemetry.io/otel/init`                     | `otel-sdk.yaml`     | Go runtime metrics (`go.*`)                                            |
 | `go.opentelemetry.io/otel`                          | `otel-sdk.yaml`     | nothing — guards the global tracer provider                            |
 | `go.opentelemetry.io/otel/sdk/trace`                | `otel-sdk.yaml`     | nothing — maintains the GLS span chain                                 |


### PR DESCRIPTION
`schemas/otelc/README.md` says a missing row in the coverage table means an undeclared instrumentation. `aws.yaml` and `linodego.yaml` both existed with no row, and `linodego.yaml` was missing from the tree diagram too. This adds both, so the table actually matches what's in `schemas/otelc/groups/`.

