### PR TITLE
chore(tool): drop redundant comments on rule struct fields

### DIFF
--- a/tool/internal/rule/base.go
+++ b/tool/internal/rule/base.go
@@ -33,41 +33,15 @@ type InstRule interface {
 // support remains intentionally narrow: simple leaf predicates are supported,
 // while qualifier composition is validated but not yet executed.
 type FilterDef struct {
-	// AllOf, OneOf, and Not are the boolean combinators. Each composes nested
-	// FilterDefs so predicates can be combined. A node may use at most one
-	// combinator, and a combinator may not be mixed with sibling leaf predicates
-	// on the same node; both rules are enforced at build time.
-	AllOf []FilterDef `json:"all-of,omitempty" yaml:"all-of,omitempty"` // match when every nested predicate matches
-	OneOf []FilterDef `json:"one-of,omitempty" yaml:"one-of,omitempty"` // match when at least one nested predicate matches
-	Not   *FilterDef  `json:"not,omitempty"    yaml:"not,omitempty"`    // match when the nested predicate does not match
-
-	HasFunc      string `json:"has_func,omitempty"      yaml:"has_func,omitempty"`      // match files that declare this function
-	HasRecv      string `json:"has_recv,omitempty"      yaml:"has_recv,omitempty"`      // narrow has_func to this receiver type; requires has_func
-	HasDirective string `json:"has_directive,omitempty" yaml:"has_directive,omitempty"` // match files carrying this //go: directive (validated, not yet executed)
-
-	// HasStruct matches files declaring this name as a struct type; an interface
-	// or alias of the same name does not. This inverts under not, which selects
-	// files it would otherwise skip when the name is an interface.
-	HasStruct string `json:"has_struct,omitempty" yaml:"has_struct,omitempty"`
-
-	// HasPackage matches source files whose declared package clause equals this
-	// name. The declared name is read from the parsed AST (the `package foo`
-	// line), not the import path (use target for that) and not the build's
-	// test-ness (use is_test for that). Non-test files in a package share one
-	// declared name; an external test file may declare a different name
-	// (e.g. "foo_test").
-	HasPackage string `json:"has_package,omitempty" yaml:"has_package,omitempty"`
-
-	// IsTest is a tri-state boolean predicate that selects or excludes test
-	// builds — compilation units the Go toolchain produces only as part of
-	// `go test` (a package augmented with its _test.go files, the external
-	// xxx_test package, or the generated _testmain.go runner). Test-ness is a
-	// property of the compile's source set, not of the import path.
-	//
-	//   is_test: true  → match only test builds
-	//   is_test: false → match only non-test builds
-	//   absent (nil)   → no filtering; the rule applies to every build
-	IsTest *bool `json:"is_test,omitempty" yaml:"is_test,omitempty"`
+	AllOf        []FilterDef `json:"all-of,omitempty"        yaml:"all-of,omitempty"`
+	OneOf        []FilterDef `json:"one-of,omitempty"        yaml:"one-of,omitempty"`
+	Not          *FilterDef  `json:"not,omitempty"           yaml:"not,omitempty"`
+	HasFunc      string      `json:"has_func,omitempty"      yaml:"has_func,omitempty"`
+	HasRecv      string      `json:"has_recv,omitempty"      yaml:"has_recv,omitempty"`
+	HasDirective string      `json:"has_directive,omitempty" yaml:"has_directive,omitempty"`
+	HasStruct    string      `json:"has_struct,omitempty"    yaml:"has_struct,omitempty"`
+	HasPackage   string      `json:"has_package,omitempty"   yaml:"has_package,omitempty"`
+	IsTest       *bool       `json:"is_test,omitempty"       yaml:"is_test,omitempty"`
 }
 
 // WhereDef carries the structured where clause after package selectors have
@@ -77,20 +51,18 @@ type FilterDef struct {
 // selector and qualifier fields are preserved here so the agreed syntax surface
 // can be normalized now without forcing the broader internal refactor yet.
 type WhereDef struct {
-	File *FilterDef `json:"file,omitempty" yaml:"file,omitempty"`
-
-	AllOf []WhereDef `json:"all-of,omitempty" yaml:"all-of,omitempty"`
-	OneOf []WhereDef `json:"one-of,omitempty" yaml:"one-of,omitempty"`
-	Not   *WhereDef  `json:"not,omitempty"    yaml:"not,omitempty"`
-
-	Func          string `json:"func,omitempty"           yaml:"func,omitempty"`
-	Recv          string `json:"recv,omitempty"           yaml:"recv,omitempty"`
-	Struct        string `json:"struct,omitempty"         yaml:"struct,omitempty"`
-	StructLiteral string `json:"struct_literal,omitempty" yaml:"struct_literal,omitempty"`
-	FunctionCall  string `json:"function_call,omitempty"  yaml:"function_call,omitempty"`
-	Directive     string `json:"directive,omitempty"      yaml:"directive,omitempty"`
-	Kind          string `json:"kind,omitempty"           yaml:"kind,omitempty"`
-	Identifier    string `json:"identifier,omitempty"     yaml:"identifier,omitempty"`
+	File          *FilterDef `json:"file,omitempty"           yaml:"file,omitempty"`
+	AllOf         []WhereDef `json:"all-of,omitempty"         yaml:"all-of,omitempty"`
+	OneOf         []WhereDef `json:"one-of,omitempty"         yaml:"one-of,omitempty"`
+	Not           *WhereDef  `json:"not,omitempty"            yaml:"not,omitempty"`
+	Func          string     `json:"func,omitempty"           yaml:"func,omitempty"`
+	Recv          string     `json:"recv,omitempty"           yaml:"recv,omitempty"`
+	Struct        string     `json:"struct,omitempty"         yaml:"struct,omitempty"`
+	StructLiteral string     `json:"struct_literal,omitempty" yaml:"struct_literal,omitempty"`
+	FunctionCall  string     `json:"function_call,omitempty"  yaml:"function_call,omitempty"`
+	Directive     string     `json:"directive,omitempty"      yaml:"directive,omitempty"`
+	Kind          string     `json:"kind,omitempty"           yaml:"kind,omitempty"`
+	Identifier    string     `json:"identifier,omitempty"     yaml:"identifier,omitempty"`
 }
 
 // InstBaseRule is the base rule for all instrumentation rules.
@@ -98,7 +70,7 @@ type InstBaseRule struct {
 	Name    string            `json:"name,omitempty"    yaml:"name,omitempty"`
 	Target  string            `json:"target"            yaml:"target"`
 	Version string            `json:"version,omitempty" yaml:"version,omitempty"`
-	Imports map[string]string `json:"imports,omitempty" yaml:"imports,omitempty"` // map[alias]path
+	Imports map[string]string `json:"imports,omitempty" yaml:"imports,omitempty"`
 	Where   *WhereDef         `json:"where,omitempty"   yaml:"where,omitempty"`
 }
 

--- a/tool/internal/rule/call_rule.go
+++ b/tool/internal/rule/call_rule.go
@@ -34,6 +34,7 @@ import (
 // Into: tracedGet(http.Get("url"))
 type InstCallRule struct {
 	InstBaseRule `yaml:",inline"`
+
 	FunctionCall string   `json:"function_call" yaml:"function_call"`
 	ImportPath   string   `json:"import-path"   yaml:"-"` // "net/http", parsed from FunctionCall
 	FuncName     string   `json:"func-name"     yaml:"-"` // "Get", parsed from FunctionCall

--- a/tool/internal/rule/call_rule.go
+++ b/tool/internal/rule/call_rule.go
@@ -34,38 +34,12 @@ import (
 // Into: tracedGet(http.Get("url"))
 type InstCallRule struct {
 	InstBaseRule `yaml:",inline"`
-
-	// FunctionCall is the qualified function name from YAML (e.g., "net/http.Get")
-	// This field is parsed into ImportPath and FuncName during rule creation.
-	FunctionCall string `json:"function_call" yaml:"function_call"`
-
-	// ImportPath is the parsed package import path (e.g., "net/http")
-	// This field is populated during rule creation from FunctionCall.
-	ImportPath string `json:"import-path" yaml:"-"`
-
-	// FuncName is the parsed function name (e.g., "Get")
-	// This field is populated during rule creation from FunctionCall.
-	FuncName string `json:"func-name" yaml:"-"`
-
-	// Replace is the wrapper code with {{ . }} as placeholder for the original call.
-	// The replacement must be a valid Go expression. The output may be any
-	// expression type; it is not required to be a call expression.
-	//
-	// Examples:
-	//   - "wrapper({{ . }})" wraps the call with wrapper()
-	//   - "(func() { return {{ . }} })()" uses an IIFE
-	//   - "otelhttp.NewTransport({{ . }})" replaces a transport value
-	Replace string `json:"replace" yaml:"replace"`
-
-	// AppendArgs is a list of Go expression strings appended as additional
-	// arguments to the matched call. See docs/rules.md for full semantics.
-	AppendArgs []string `json:"append_args" yaml:"append_args"`
-
-	// VariadicType is the element type of the variadic parameter (e.g. "grpc.DialOption").
-	// Required only when the matched call uses an ellipsis spread (f(a, opts...)).
-	// When set and the call is ellipsis, an IIFE wrapper is generated.
-	// When unset and the call is ellipsis, the call is skipped with a warning.
-	VariadicType string `json:"variadic_type" yaml:"variadic_type"`
+	FunctionCall string   `json:"function_call" yaml:"function_call"`
+	ImportPath   string   `json:"import-path"   yaml:"-"` // "net/http", parsed from FunctionCall
+	FuncName     string   `json:"func-name"     yaml:"-"` // "Get", parsed from FunctionCall
+	Replace      string   `json:"replace"       yaml:"replace"`
+	AppendArgs   []string `json:"append_args"   yaml:"append_args"`
+	VariadicType string   `json:"variadic_type" yaml:"variadic_type"`
 }
 
 // funcNamePattern matches qualified function names like "net/http.Get".

--- a/tool/internal/rule/decl_rule.go
+++ b/tool/internal/rule/decl_rule.go
@@ -37,10 +37,11 @@ import (
 //	    otelhttp: "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 type InstDeclRule struct {
 	InstBaseRule `yaml:",inline"`
-	Kind         string `json:"kind"           yaml:"kind"`
-	Identifier   string `json:"identifier"     yaml:"identifier"`
-	Replace      string `json:"replace"        yaml:"replace"`
-	Wrap         string `json:"wrap,omitempty" yaml:"wrap,omitempty"`
+
+	Kind       string `json:"kind"           yaml:"kind"`
+	Identifier string `json:"identifier"     yaml:"identifier"`
+	Replace    string `json:"replace"        yaml:"replace"`
+	Wrap       string `json:"wrap,omitempty" yaml:"wrap,omitempty"`
 }
 
 // NewInstDeclRule loads and validates an InstDeclRule from YAML data.

--- a/tool/internal/rule/decl_rule.go
+++ b/tool/internal/rule/decl_rule.go
@@ -37,23 +37,10 @@ import (
 //	    otelhttp: "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 type InstDeclRule struct {
 	InstBaseRule `yaml:",inline"`
-
-	// Kind optionally constrains the kind of declaration to match.
-	// Valid values: "func", "var", "const", "type", or "" (match any).
-	Kind string `json:"kind" yaml:"kind"` // empty = matches any kind
-
-	// Identifier is the name of the top-level declaration to match.
-	Identifier string `json:"identifier" yaml:"identifier"`
-
-	// Replace is a Go expression to assign as the value of the matched var or
-	// const declaration. Mutually exclusive with Wrap.
-	Replace string `json:"replace" yaml:"replace"`
-
-	// Wrap wraps the existing initializer of the matched var or const
-	// declaration using a template. {{ . }} is substituted with the original
-	// expression. Mutually exclusive with Replace. An error is returned at
-	// instrumentation time if the declaration has no initializer.
-	Wrap string `json:"wrap,omitempty" yaml:"wrap,omitempty"`
+	Kind         string `json:"kind"           yaml:"kind"`
+	Identifier   string `json:"identifier"     yaml:"identifier"`
+	Replace      string `json:"replace"        yaml:"replace"`
+	Wrap         string `json:"wrap,omitempty" yaml:"wrap,omitempty"`
 }
 
 // NewInstDeclRule loads and validates an InstDeclRule from YAML data.

--- a/tool/internal/rule/directive_rule.go
+++ b/tool/internal/rule/directive_rule.go
@@ -17,8 +17,9 @@ import (
 // their bodies. The template supports {{.FuncName}} as a placeholder.
 type InstDirectiveRule struct {
 	InstBaseRule `yaml:",inline"`
-	Directive    string `json:"directive" yaml:"directive"`
-	Template     string `json:"template"  yaml:"template"`
+
+	Directive string `json:"directive" yaml:"directive"`
+	Template  string `json:"template"  yaml:"template"`
 }
 
 // NewInstDirectiveRule loads and validates an InstDirectiveRule from YAML data.

--- a/tool/internal/rule/directive_rule.go
+++ b/tool/internal/rule/directive_rule.go
@@ -17,9 +17,8 @@ import (
 // their bodies. The template supports {{.FuncName}} as a placeholder.
 type InstDirectiveRule struct {
 	InstBaseRule `yaml:",inline"`
-
-	Directive string `json:"directive" yaml:"directive"` // The directive name to match (without //)
-	Template  string `json:"template"  yaml:"template"`  // Go text/template rendered into code prepended to matching functions
+	Directive    string `json:"directive" yaml:"directive"`
+	Template     string `json:"template"  yaml:"template"`
 }
 
 // NewInstDirectiveRule loads and validates an InstDirectiveRule from YAML data.

--- a/tool/internal/rule/file_rule.go
+++ b/tool/internal/rule/file_rule.go
@@ -21,6 +21,7 @@ import (
 //		path: "github.com/foo/bar/newfile"
 type InstFileRule struct {
 	InstBaseRule `yaml:",inline"`
+
 	File         string `json:"file"          yaml:"file"`
 	Path         string `json:"path"          yaml:"path"`
 	ResolvedPath string `json:"resolved_path" yaml:"-"` // local dir Path resolves to

--- a/tool/internal/rule/file_rule.go
+++ b/tool/internal/rule/file_rule.go
@@ -21,11 +21,9 @@ import (
 //		path: "github.com/foo/bar/newfile"
 type InstFileRule struct {
 	InstBaseRule `yaml:",inline"`
-
-	File string `json:"file" yaml:"file"` // The name of the file to be added to the target package
-	Path string `json:"path" yaml:"path"` // The import path where the file is located
-
-	ResolvedPath string `json:"resolved_path" yaml:"-"` // The local path of the package directory resolved from import path
+	File         string `json:"file"          yaml:"file"`
+	Path         string `json:"path"          yaml:"path"`
+	ResolvedPath string `json:"resolved_path" yaml:"-"` // local dir Path resolves to
 }
 
 // NewInstFileRule loads and validates an InstFileRule from YAML data.

--- a/tool/internal/rule/func_rule.go
+++ b/tool/internal/rule/func_rule.go
@@ -47,18 +47,13 @@ type FuncSignature struct {
 //	last_result: error
 //	param: context.Context
 type InstFuncRule struct {
-	InstBaseRule `yaml:",inline"`
-
-	Func   string `json:"func"   yaml:"func"`   // The name of the target func to be instrumented
-	Recv   string `json:"recv"   yaml:"recv"`   // The name of the receiver type
-	Before string `json:"before" yaml:"before"` // The function we inject at the target function entry
-	After  string `json:"after"  yaml:"after"`  // The function we inject at the target function exit
-	Path   string `json:"path"   yaml:"path"`   // The import path where hook code is located
-
-	ResolvedPath string `json:"resolved_path" yaml:"-"` // The local path of the package directory resolved from import path
-
-	// Optional signature sub-filters (all non-empty filters must match; combined
-	// with AND logic so any combination is allowed).
+	InstBaseRule      `yaml:",inline"`
+	Func              string         `json:"func"                         yaml:"func"`
+	Recv              string         `json:"recv"                         yaml:"recv"`
+	Before            string         `json:"before"                       yaml:"before"`
+	After             string         `json:"after"                        yaml:"after"`
+	Path              string         `json:"path"                         yaml:"path"`
+	ResolvedPath      string         `json:"resolved_path"                yaml:"-"` // local dir Path resolves to
 	Signature         *FuncSignature `json:"signature,omitempty"          yaml:"signature"`
 	SignatureContains *FuncSignature `json:"signature_contains,omitempty" yaml:"signature_contains"`
 	Result            string         `json:"result,omitempty"             yaml:"result"`

--- a/tool/internal/rule/func_rule.go
+++ b/tool/internal/rule/func_rule.go
@@ -47,7 +47,8 @@ type FuncSignature struct {
 //	last_result: error
 //	param: context.Context
 type InstFuncRule struct {
-	InstBaseRule      `yaml:",inline"`
+	InstBaseRule `yaml:",inline"`
+
 	Func              string         `json:"func"                         yaml:"func"`
 	Recv              string         `json:"recv"                         yaml:"recv"`
 	Before            string         `json:"before"                       yaml:"before"`

--- a/tool/internal/rule/lit_rule.go
+++ b/tool/internal/rule/lit_rule.go
@@ -18,17 +18,9 @@ import (
 // exclusive replace/wrap, both may be set together, because whether a field is
 // present varies from one literal to the next.
 type InstLitField struct {
-	// Name is the field name to set.
-	Name string `json:"name" yaml:"name"`
-
-	// Value is a Go expression assigned to the field. When Wrap is also set,
-	// it applies only to literals that omit the field.
+	Name  string `json:"name"            yaml:"name"`
 	Value string `json:"value,omitempty" yaml:"value,omitempty"`
-
-	// Wrap is a Go expression template applied to the value the literal already
-	// assigns to this field. {{ . }} is substituted with that expression. It has
-	// no effect on a literal that omits the field; set Value for that case.
-	Wrap string `json:"wrap,omitempty" yaml:"wrap,omitempty"`
+	Wrap  string `json:"wrap,omitempty"  yaml:"wrap,omitempty"`
 }
 
 // InstLitRule represents a rule that sets fields on composite literals of a
@@ -50,23 +42,11 @@ type InstLitField struct {
 // This transforms: &http.Transport{MaxIdleConns: 100}
 // Into: &http.Transport{Internal: true, MaxIdleConns: 100}
 type InstLitRule struct {
-	InstBaseRule `yaml:",inline"`
-
-	// StructLiteral is the qualified type name from YAML (e.g. "net/http.Transport").
-	// This field is parsed into ImportPath and TypeName during rule creation.
-	StructLiteral string `json:"struct_literal" yaml:"struct_literal"`
-
-	// ImportPath is the parsed package import path (e.g. "net/http").
-	// This field is populated during rule creation from StructLiteral.
-	ImportPath string `json:"import-path" yaml:"-"`
-
-	// TypeName is the parsed type name (e.g. "Transport").
-	// This field is populated during rule creation from StructLiteral.
-	TypeName string `json:"type-name" yaml:"-"`
-
-	// Field lists the fields to set on each matched literal. A field already
-	// present in the literal is overridden; the remaining elements are kept.
-	Field []*InstLitField `json:"field" yaml:"field"`
+	InstBaseRule  `yaml:",inline"`
+	StructLiteral string          `json:"struct_literal" yaml:"struct_literal"`
+	ImportPath    string          `json:"import-path"    yaml:"-"` // "net/http", parsed from StructLiteral
+	TypeName      string          `json:"type-name"      yaml:"-"` // "Transport", parsed from StructLiteral
+	Field         []*InstLitField `json:"field"          yaml:"field"`
 }
 
 // typeNamePattern matches qualified type names like "net/http.Transport",

--- a/tool/internal/rule/lit_rule.go
+++ b/tool/internal/rule/lit_rule.go
@@ -42,7 +42,8 @@ type InstLitField struct {
 // This transforms: &http.Transport{MaxIdleConns: 100}
 // Into: &http.Transport{Internal: true, MaxIdleConns: 100}
 type InstLitRule struct {
-	InstBaseRule  `yaml:",inline"`
+	InstBaseRule `yaml:",inline"`
+
 	StructLiteral string          `json:"struct_literal" yaml:"struct_literal"`
 	ImportPath    string          `json:"import-path"    yaml:"-"` // "net/http", parsed from StructLiteral
 	TypeName      string          `json:"type-name"      yaml:"-"` // "Transport", parsed from StructLiteral

--- a/tool/internal/rule/raw_rule.go
+++ b/tool/internal/rule/raw_rule.go
@@ -27,12 +27,11 @@ import (
 //		placement: before|after
 type InstRawRule struct {
 	InstBaseRule `yaml:",inline"`
-
-	Func      string `json:"func"                yaml:"func"`                // The name of the target func to be instrumented
-	Recv      string `json:"recv"                yaml:"recv"`                // The name of the receiver type
-	Raw       string `json:"raw"                 yaml:"raw"`                 // The raw code to be injected
-	Pattern   string `json:"pattern,omitempty"   yaml:"pattern,omitempty"`   // The position to inject the raw code. Must be a regex pattern
-	Placement string `json:"placement,omitempty" yaml:"placement,omitempty"` // The placement of the raw code. Can be "before" or "after". Default is "before".
+	Func         string `json:"func"                yaml:"func"`
+	Recv         string `json:"recv"                yaml:"recv"`
+	Raw          string `json:"raw"                 yaml:"raw"`
+	Pattern      string `json:"pattern,omitempty"   yaml:"pattern,omitempty"`
+	Placement    string `json:"placement,omitempty" yaml:"placement,omitempty"`
 }
 
 // NewInstRawRule loads and validates an InstRawRule from YAML data.

--- a/tool/internal/rule/raw_rule.go
+++ b/tool/internal/rule/raw_rule.go
@@ -27,11 +27,12 @@ import (
 //		placement: before|after
 type InstRawRule struct {
 	InstBaseRule `yaml:",inline"`
-	Func         string `json:"func"                yaml:"func"`
-	Recv         string `json:"recv"                yaml:"recv"`
-	Raw          string `json:"raw"                 yaml:"raw"`
-	Pattern      string `json:"pattern,omitempty"   yaml:"pattern,omitempty"`
-	Placement    string `json:"placement,omitempty" yaml:"placement,omitempty"`
+
+	Func      string `json:"func"                yaml:"func"`
+	Recv      string `json:"recv"                yaml:"recv"`
+	Raw       string `json:"raw"                 yaml:"raw"`
+	Pattern   string `json:"pattern,omitempty"   yaml:"pattern,omitempty"`
+	Placement string `json:"placement,omitempty" yaml:"placement,omitempty"`
 }
 
 // NewInstRawRule loads and validates an InstRawRule from YAML data.

--- a/tool/internal/rule/struct_rule.go
+++ b/tool/internal/rule/struct_rule.go
@@ -12,8 +12,8 @@ import (
 
 // InstStructField represents a single field to be added to a struct.
 type InstStructField struct {
-	Name string `json:"name" yaml:"name"` // The name of the field to be added
-	Type string `json:"type" yaml:"type"` // The type of the field to be added
+	Name string `json:"name" yaml:"name"`
+	Type string `json:"type" yaml:"type"`
 }
 
 // InstStructRule represents a rule that adds new fields to a target struct.
@@ -27,9 +27,8 @@ type InstStructField struct {
 //	      type: string
 type InstStructRule struct {
 	InstBaseRule `yaml:",inline"`
-
-	Struct   string             `json:"struct"    yaml:"struct"`    // The type name of the struct to be instrumented
-	NewField []*InstStructField `json:"new_field" yaml:"new_field"` // The new fields to be added
+	Struct       string             `json:"struct"    yaml:"struct"`
+	NewField     []*InstStructField `json:"new_field" yaml:"new_field"`
 }
 
 // NewInstStructRule loads and validates an InstStructRule from YAML data.

--- a/tool/internal/rule/struct_rule.go
+++ b/tool/internal/rule/struct_rule.go
@@ -27,8 +27,9 @@ type InstStructField struct {
 //	      type: string
 type InstStructRule struct {
 	InstBaseRule `yaml:",inline"`
-	Struct       string             `json:"struct"    yaml:"struct"`
-	NewField     []*InstStructField `json:"new_field" yaml:"new_field"`
+
+	Struct   string             `json:"struct"    yaml:"struct"`
+	NewField []*InstStructField `json:"new_field" yaml:"new_field"`
 }
 
 // NewInstStructRule loads and validates an InstStructRule from YAML data.


### PR DESCRIPTION
Closes #1290

rules.md already spells out what every rule field means, so the per-field comments on the InstXxxRule structs were just repeating it, plus some had gone stale (the has_directive comment claimed it wasn't executed yet, but it is).

Dropped those comments and the blank lines that were only there to separate them, so the structs read as compact tables. The struct-level doc comments with the YAML examples are untouched, those still earn their keep.

A few fields (ImportPath, FuncName, ResolvedPath, TypeName) are derived internally rather than part of the YAML schema, so rules.md doesn't cover them. Kept a short trailing note on those instead of dropping them silently.