### PR TITLE
chore(ci): welcome first-time contributors on PR open

### DIFF
--- a/.github/workflows/first-time-pr.yaml
+++ b/.github/workflows/first-time-pr.yaml
@@ -1,0 +1,20 @@
+name: First time contributor
+
+on:
+  pull_request_target:  # zizmor: ignore[dangerous-triggers] runs only the trusted shared workflow; never checks out PR code
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  welcome:
+    permissions:
+      pull-requests: write # required by the shared workflow to post the welcome comment
+    uses: open-telemetry/shared-workflows/.github/workflows/first-time-pr.yml@dde3047a8f219c296772c17936b9d02bb7447af5  # v0.12.0
+    with:
+      custom_message: |
+        - Build and test locally before pushing: `make build`, then `make test`. `make all` runs build, format, lint and test in sequence.
+        - Your **PR title** must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and is CI-enforced. Allowed types: `chore`, `doc`/`docs`, `feat`, `fix`, `release`, `refactor`, `test`.
+        - Run `make setup-git` once per clone. `tool/data/otelc-bundle.tgz` is a binary archive that cannot be merged by git and otherwise conflicts on nearly every rebase.
+        - On Windows or WSL, set `git config --global core.autocrlf false` **before** cloning, or generated-code tests will fail against the LF golden files.
+        - Repo-specific questions belong in [#otel-go-compt-instr-sig](https://cloud-native.slack.com/archives/C088D8GSSSF).

--- a/.github/workflows/first-time-pr.yaml
+++ b/.github/workflows/first-time-pr.yaml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   welcome:
     permissions:
-      pull-requests: write # required by the shared workflow to post the welcome comment
+      pull-requests: write  # required by the shared workflow to post the welcome comment
     uses: open-telemetry/shared-workflows/.github/workflows/first-time-pr.yml@dde3047a8f219c296772c17936b9d02bb7447af5  # v0.12.0
     with:
       custom_message: |
@@ -17,4 +17,5 @@ jobs:
         - Your **PR title** must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and is CI-enforced. Allowed types: `chore`, `doc`/`docs`, `feat`, `fix`, `release`, `refactor`, `test`.
         - Run `make setup-git` once per clone. `tool/data/otelc-bundle.tgz` is a binary archive that cannot be merged by git and otherwise conflicts on nearly every rebase.
         - On Windows or WSL, set `git config --global core.autocrlf false` **before** cloning, or generated-code tests will fail against the LF golden files.
+        - Using AI tools is welcome, but you must understand every line you submit — see our [AI Usage Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/AI_POLICY.md).
         - Repo-specific questions belong in [#otel-go-compt-instr-sig](https://cloud-native.slack.com/archives/C088D8GSSSF).


### PR DESCRIPTION
Posts the shared welcome comment when someone with no prior association to the repo opens a PR.

The shared workflow's default text already covers CONTRIBUTING, the CLA and the GenAI policy. `custom_message` adds only the four things that actually cost newcomers time here: the make targets, the CI-enforced conventional-commit title, `make setup-git` for the bundle merge driver, and the `core.autocrlf` trap on Windows.

No `label` input — no suitable label exists in the repo yet.

`pull_request_target` invokes only the pinned shared workflow and never checks out PR code, hence the `dangerous-triggers` suppression. Cannot be tested from a PR; it takes effect on merge to `main`.