### PR TITLE
fix(instrumentation/openai): stop silently dropping telemetry on oversized bodies

### DIFF
--- a/instrumentation/github.com/openai/openai-go/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/middleware.go
@@ -108,6 +108,28 @@ func operationName(op operationType) string {
 	}
 }
 
+// readBounded reads up to limit bytes from body for attribute parsing while
+// preserving the full stream for downstream consumers (the SDK or the HTTP
+// caller). truncated reports whether body held more than limit bytes, in
+// which case bodyBytes is a cut-off prefix and must not be treated as
+// complete JSON.
+func readBounded(body io.ReadCloser, limit int64) (bodyBytes []byte, truncated bool, reassembled io.ReadCloser, err error) {
+	var buf bytes.Buffer
+	tee := io.TeeReader(body, &buf)
+	// Read one byte past the limit so a full body can be told apart from one
+	// that was cut short. That extra byte is still captured by the tee, so
+	// reassembled below reproduces the stream in full either way.
+	read, err := io.ReadAll(io.LimitReader(tee, limit+1))
+	reassembled = struct {
+		io.Reader
+		io.Closer
+	}{io.MultiReader(&buf, body), body}
+	if int64(len(read)) > limit {
+		return read[:limit], true, reassembled, err
+	}
+	return read, false, reassembled, err
+}
+
 // OtelMiddleware returns an HTTP middleware that creates spans for OpenAI API
 // calls following GenAI semantic conventions.
 func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, error)) (*http.Response, error) {
@@ -126,15 +148,14 @@ func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, e
 		opName := operationName(op)
 
 		// Read a bounded copy for attribute parsing, but preserve the full body for the SDK.
-		var buf bytes.Buffer
-		tee := io.TeeReader(req.Body, &buf)
-		bodyBytes, err := io.ReadAll(io.LimitReader(tee, maxRequestBodySize))
-		// Reassemble: buffered bytes + remaining unread body.
-		req.Body = struct {
-			io.Reader
-			io.Closer
-		}{io.MultiReader(&buf, req.Body), req.Body}
+		bodyBytes, truncated, reassembledBody, err := readBounded(req.Body, maxRequestBodySize)
+		req.Body = reassembledBody
 		if err != nil {
+			return next(req)
+		}
+		if truncated {
+			logger.Warn("openai request body exceeded size cap, skipping request attributes",
+				"operation", opName, "cap_bytes", maxRequestBodySize)
 			return next(req)
 		}
 
@@ -238,15 +259,14 @@ func handleNonStreamingResponse(
 	defer span.End()
 
 	// Read a bounded preview for parsing, but reassemble the full body for callers.
-	var buf bytes.Buffer
-	tee := io.TeeReader(resp.Body, &buf)
-	bodyBytes, err := io.ReadAll(io.LimitReader(tee, maxResponseBodySize))
-	// Reassemble: preview bytes + remaining unread body.
-	resp.Body = struct {
-		io.Reader
-		io.Closer
-	}{io.MultiReader(&buf, resp.Body), resp.Body}
+	bodyBytes, truncated, reassembledBody, err := readBounded(resp.Body, maxResponseBodySize)
+	resp.Body = reassembledBody
 	if err != nil {
+		return
+	}
+	if truncated {
+		logger.Warn("openai response body exceeded size cap, skipping response attributes",
+			"operation", operationName(op), "cap_bytes", maxResponseBodySize)
 		return
 	}
 

--- a/instrumentation/github.com/openai/openai-go/middleware_integration_test.go
+++ b/instrumentation/github.com/openai/openai-go/middleware_integration_test.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -510,6 +512,110 @@ func TestOtelMiddleware_StreamingResponse(t *testing.T) {
 	assertInt64Attribute(t, attrs, "gen_ai.usage.input_tokens", 5)
 	assertInt64Attribute(t, attrs, "gen_ai.usage.output_tokens", 2)
 	assertInt64Attribute(t, attrs, "gen_ai.usage.total_tokens", 7)
+}
+
+// TestOtelMiddleware_ResponseBodyTruncated covers Issue #1309: a response
+// larger than maxResponseBodySize (e.g. a large batch embeddings call) must
+// not produce a span that silently looks fully successful. The span should
+// still carry request-side attributes, the caller must still see the
+// complete, untruncated body, and the drop should be logged rather than
+// silent.
+func TestOtelMiddleware_ResponseBodyTruncated(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	var logBuf bytes.Buffer
+	origLogger := logger
+	t.Cleanup(func() { logger = origLogger })
+	logger = slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	middleware := OtelMiddleware()
+
+	reqBody := `{"model":"gpt-4"}`
+	req, _ := http.NewRequest(
+		"POST",
+		"http://api.openai.com/v1/chat/completions",
+		io.NopCloser(bytes.NewReader([]byte(reqBody))),
+	)
+
+	// A response whose JSON would otherwise be valid, but padded past
+	// maxResponseBodySize the way a large batch response would be.
+	padding := strings.Repeat("x", maxResponseBodySize)
+	oversized := `{"id":"chatcmpl-big","model":"gpt-4","choices":[{"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2},"padding":"` + padding + `"}`
+	next := func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(oversized)),
+		}, nil
+	}
+
+	resp, err := middleware(req, next)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// The full, untruncated body must still reach the caller - only the
+	// telemetry parse is bounded, not what the SDK receives.
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, oversized, string(body))
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+
+	attrs := spans[0].Attributes()
+	assertAttribute(t, attrs, "gen_ai.request.model", "gpt-4")
+	assertNoAttribute(t, attrs, "gen_ai.response.model")
+	assertNoAttribute(t, attrs, "gen_ai.response.id")
+	assertNoAttribute(t, attrs, "gen_ai.usage.total_tokens")
+
+	assert.Contains(t, logBuf.String(), "response body exceeded size cap",
+		"a truncated response must be logged instead of silently dropped")
+}
+
+// TestOtelMiddleware_RequestBodyTruncated covers Issue #1314: a request
+// larger than maxRequestBodySize must not silently vanish from telemetry
+// without at least a log line, and the SDK must still receive the complete
+// body.
+func TestOtelMiddleware_RequestBodyTruncated(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	var logBuf bytes.Buffer
+	origLogger := logger
+	t.Cleanup(func() { logger = origLogger })
+	logger = slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	middleware := OtelMiddleware()
+
+	padding := strings.Repeat("x", maxRequestBodySize)
+	oversized := `{"model":"gpt-4","padding":"` + padding + `"}`
+	req, _ := http.NewRequest(
+		"POST",
+		"http://api.openai.com/v1/chat/completions",
+		io.NopCloser(strings.NewReader(oversized)),
+	)
+
+	called := false
+	next := func(r *http.Request) (*http.Response, error) {
+		called = true
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, oversized, string(body), "the SDK must still see the full, untruncated request body")
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
+		}, nil
+	}
+
+	resp, err := middleware(req, next)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, called)
+
+	assert.Empty(t, sr.Ended(), "an oversized request should pass through uninstrumented, like any other unparsable body")
+	assert.Contains(t, logBuf.String(), "request body exceeded size cap",
+		"a truncated request must be logged instead of silently dropped")
 }
 
 func TestOtelMiddleware_AzurePath(t *testing.T) {

--- a/instrumentation/github.com/openai/openai-go/testhelpers_test.go
+++ b/instrumentation/github.com/openai/openai-go/testhelpers_test.go
@@ -66,3 +66,13 @@ func assertSliceAttribute(t *testing.T, attrs []attribute.KeyValue, key string, 
 	}
 	t.Errorf("attribute %q not found", key)
 }
+
+func assertNoAttribute(t *testing.T, attrs []attribute.KeyValue, key string) {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			t.Errorf("attribute %q should not be present, got %v", key, attr.Value.Emit())
+			return
+		}
+	}
+}

--- a/instrumentation/github.com/openai/openai-go/v2/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/v2/middleware.go
@@ -108,6 +108,28 @@ func operationName(op operationType) string {
 	}
 }
 
+// readBounded reads up to limit bytes from body for attribute parsing while
+// preserving the full stream for downstream consumers (the SDK or the HTTP
+// caller). truncated reports whether body held more than limit bytes, in
+// which case bodyBytes is a cut-off prefix and must not be treated as
+// complete JSON.
+func readBounded(body io.ReadCloser, limit int64) (bodyBytes []byte, truncated bool, reassembled io.ReadCloser, err error) {
+	var buf bytes.Buffer
+	tee := io.TeeReader(body, &buf)
+	// Read one byte past the limit so a full body can be told apart from one
+	// that was cut short. That extra byte is still captured by the tee, so
+	// reassembled below reproduces the stream in full either way.
+	read, err := io.ReadAll(io.LimitReader(tee, limit+1))
+	reassembled = struct {
+		io.Reader
+		io.Closer
+	}{io.MultiReader(&buf, body), body}
+	if int64(len(read)) > limit {
+		return read[:limit], true, reassembled, err
+	}
+	return read, false, reassembled, err
+}
+
 // OtelMiddleware returns an HTTP middleware that creates spans for OpenAI API
 // calls following GenAI semantic conventions.
 func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, error)) (*http.Response, error) {
@@ -126,15 +148,14 @@ func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, e
 		opName := operationName(op)
 
 		// Read a bounded copy for attribute parsing, but preserve the full body for the SDK.
-		var buf bytes.Buffer
-		tee := io.TeeReader(req.Body, &buf)
-		bodyBytes, err := io.ReadAll(io.LimitReader(tee, maxRequestBodySize))
-		// Reassemble: buffered bytes + remaining unread body.
-		req.Body = struct {
-			io.Reader
-			io.Closer
-		}{io.MultiReader(&buf, req.Body), req.Body}
+		bodyBytes, truncated, reassembledBody, err := readBounded(req.Body, maxRequestBodySize)
+		req.Body = reassembledBody
 		if err != nil {
+			return next(req)
+		}
+		if truncated {
+			logger.Warn("openai request body exceeded size cap, skipping request attributes",
+				"operation", opName, "cap_bytes", maxRequestBodySize)
 			return next(req)
 		}
 
@@ -238,15 +259,14 @@ func handleNonStreamingResponse(
 	defer span.End()
 
 	// Read a bounded preview for parsing, but reassemble the full body for callers.
-	var buf bytes.Buffer
-	tee := io.TeeReader(resp.Body, &buf)
-	bodyBytes, err := io.ReadAll(io.LimitReader(tee, maxResponseBodySize))
-	// Reassemble: preview bytes + remaining unread body.
-	resp.Body = struct {
-		io.Reader
-		io.Closer
-	}{io.MultiReader(&buf, resp.Body), resp.Body}
+	bodyBytes, truncated, reassembledBody, err := readBounded(resp.Body, maxResponseBodySize)
+	resp.Body = reassembledBody
 	if err != nil {
+		return
+	}
+	if truncated {
+		logger.Warn("openai response body exceeded size cap, skipping response attributes",
+			"operation", operationName(op), "cap_bytes", maxResponseBodySize)
 		return
 	}
 

--- a/instrumentation/github.com/openai/openai-go/v2/middleware_integration_test.go
+++ b/instrumentation/github.com/openai/openai-go/v2/middleware_integration_test.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -510,6 +512,110 @@ func TestOtelMiddleware_StreamingResponse(t *testing.T) {
 	assertInt64Attribute(t, attrs, "gen_ai.usage.input_tokens", 5)
 	assertInt64Attribute(t, attrs, "gen_ai.usage.output_tokens", 2)
 	assertInt64Attribute(t, attrs, "gen_ai.usage.total_tokens", 7)
+}
+
+// TestOtelMiddleware_ResponseBodyTruncated covers Issue #1309: a response
+// larger than maxResponseBodySize (e.g. a large batch embeddings call) must
+// not produce a span that silently looks fully successful. The span should
+// still carry request-side attributes, the caller must still see the
+// complete, untruncated body, and the drop should be logged rather than
+// silent.
+func TestOtelMiddleware_ResponseBodyTruncated(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	var logBuf bytes.Buffer
+	origLogger := logger
+	t.Cleanup(func() { logger = origLogger })
+	logger = slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	middleware := OtelMiddleware()
+
+	reqBody := `{"model":"gpt-4"}`
+	req, _ := http.NewRequest(
+		"POST",
+		"http://api.openai.com/v1/chat/completions",
+		io.NopCloser(bytes.NewReader([]byte(reqBody))),
+	)
+
+	// A response whose JSON would otherwise be valid, but padded past
+	// maxResponseBodySize the way a large batch response would be.
+	padding := strings.Repeat("x", maxResponseBodySize)
+	oversized := `{"id":"chatcmpl-big","model":"gpt-4","choices":[{"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2},"padding":"` + padding + `"}`
+	next := func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(oversized)),
+		}, nil
+	}
+
+	resp, err := middleware(req, next)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// The full, untruncated body must still reach the caller - only the
+	// telemetry parse is bounded, not what the SDK receives.
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, oversized, string(body))
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+
+	attrs := spans[0].Attributes()
+	assertAttribute(t, attrs, "gen_ai.request.model", "gpt-4")
+	assertNoAttribute(t, attrs, "gen_ai.response.model")
+	assertNoAttribute(t, attrs, "gen_ai.response.id")
+	assertNoAttribute(t, attrs, "gen_ai.usage.total_tokens")
+
+	assert.Contains(t, logBuf.String(), "response body exceeded size cap",
+		"a truncated response must be logged instead of silently dropped")
+}
+
+// TestOtelMiddleware_RequestBodyTruncated covers Issue #1314: a request
+// larger than maxRequestBodySize must not silently vanish from telemetry
+// without at least a log line, and the SDK must still receive the complete
+// body.
+func TestOtelMiddleware_RequestBodyTruncated(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	var logBuf bytes.Buffer
+	origLogger := logger
+	t.Cleanup(func() { logger = origLogger })
+	logger = slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	middleware := OtelMiddleware()
+
+	padding := strings.Repeat("x", maxRequestBodySize)
+	oversized := `{"model":"gpt-4","padding":"` + padding + `"}`
+	req, _ := http.NewRequest(
+		"POST",
+		"http://api.openai.com/v1/chat/completions",
+		io.NopCloser(strings.NewReader(oversized)),
+	)
+
+	called := false
+	next := func(r *http.Request) (*http.Response, error) {
+		called = true
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, oversized, string(body), "the SDK must still see the full, untruncated request body")
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
+		}, nil
+	}
+
+	resp, err := middleware(req, next)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, called)
+
+	assert.Empty(t, sr.Ended(), "an oversized request should pass through uninstrumented, like any other unparsable body")
+	assert.Contains(t, logBuf.String(), "request body exceeded size cap",
+		"a truncated request must be logged instead of silently dropped")
 }
 
 func TestOtelMiddleware_AzurePath(t *testing.T) {

--- a/instrumentation/github.com/openai/openai-go/v2/testhelpers_test.go
+++ b/instrumentation/github.com/openai/openai-go/v2/testhelpers_test.go
@@ -66,3 +66,13 @@ func assertSliceAttribute(t *testing.T, attrs []attribute.KeyValue, key string, 
 	}
 	t.Errorf("attribute %q not found", key)
 }
+
+func assertNoAttribute(t *testing.T, attrs []attribute.KeyValue, key string) {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			t.Errorf("attribute %q should not be present, got %v", key, attr.Value.Emit())
+			return
+		}
+	}
+}

--- a/instrumentation/github.com/openai/openai-go/v3/middleware.go
+++ b/instrumentation/github.com/openai/openai-go/v3/middleware.go
@@ -108,6 +108,28 @@ func operationName(op operationType) string {
 	}
 }
 
+// readBounded reads up to limit bytes from body for attribute parsing while
+// preserving the full stream for downstream consumers (the SDK or the HTTP
+// caller). truncated reports whether body held more than limit bytes, in
+// which case bodyBytes is a cut-off prefix and must not be treated as
+// complete JSON.
+func readBounded(body io.ReadCloser, limit int64) (bodyBytes []byte, truncated bool, reassembled io.ReadCloser, err error) {
+	var buf bytes.Buffer
+	tee := io.TeeReader(body, &buf)
+	// Read one byte past the limit so a full body can be told apart from one
+	// that was cut short. That extra byte is still captured by the tee, so
+	// reassembled below reproduces the stream in full either way.
+	read, err := io.ReadAll(io.LimitReader(tee, limit+1))
+	reassembled = struct {
+		io.Reader
+		io.Closer
+	}{io.MultiReader(&buf, body), body}
+	if int64(len(read)) > limit {
+		return read[:limit], true, reassembled, err
+	}
+	return read, false, reassembled, err
+}
+
 // OtelMiddleware returns an HTTP middleware that creates spans for OpenAI API
 // calls following GenAI semantic conventions.
 func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, error)) (*http.Response, error) {
@@ -126,15 +148,14 @@ func OtelMiddleware() func(*http.Request, func(*http.Request) (*http.Response, e
 		opName := operationName(op)
 
 		// Read a bounded copy for attribute parsing, but preserve the full body for the SDK.
-		var buf bytes.Buffer
-		tee := io.TeeReader(req.Body, &buf)
-		bodyBytes, err := io.ReadAll(io.LimitReader(tee, maxRequestBodySize))
-		// Reassemble: buffered bytes + remaining unread body.
-		req.Body = struct {
-			io.Reader
-			io.Closer
-		}{io.MultiReader(&buf, req.Body), req.Body}
+		bodyBytes, truncated, reassembledBody, err := readBounded(req.Body, maxRequestBodySize)
+		req.Body = reassembledBody
 		if err != nil {
+			return next(req)
+		}
+		if truncated {
+			logger.Warn("openai request body exceeded size cap, skipping request attributes",
+				"operation", opName, "cap_bytes", maxRequestBodySize)
 			return next(req)
 		}
 
@@ -238,15 +259,14 @@ func handleNonStreamingResponse(
 	defer span.End()
 
 	// Read a bounded preview for parsing, but reassemble the full body for callers.
-	var buf bytes.Buffer
-	tee := io.TeeReader(resp.Body, &buf)
-	bodyBytes, err := io.ReadAll(io.LimitReader(tee, maxResponseBodySize))
-	// Reassemble: preview bytes + remaining unread body.
-	resp.Body = struct {
-		io.Reader
-		io.Closer
-	}{io.MultiReader(&buf, resp.Body), resp.Body}
+	bodyBytes, truncated, reassembledBody, err := readBounded(resp.Body, maxResponseBodySize)
+	resp.Body = reassembledBody
 	if err != nil {
+		return
+	}
+	if truncated {
+		logger.Warn("openai response body exceeded size cap, skipping response attributes",
+			"operation", operationName(op), "cap_bytes", maxResponseBodySize)
 		return
 	}
 

--- a/instrumentation/github.com/openai/openai-go/v3/middleware_integration_test.go
+++ b/instrumentation/github.com/openai/openai-go/v3/middleware_integration_test.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -510,6 +512,110 @@ func TestOtelMiddleware_StreamingResponse(t *testing.T) {
 	assertInt64Attribute(t, attrs, "gen_ai.usage.input_tokens", 5)
 	assertInt64Attribute(t, attrs, "gen_ai.usage.output_tokens", 2)
 	assertInt64Attribute(t, attrs, "gen_ai.usage.total_tokens", 7)
+}
+
+// TestOtelMiddleware_ResponseBodyTruncated covers Issue #1309: a response
+// larger than maxResponseBodySize (e.g. a large batch embeddings call) must
+// not produce a span that silently looks fully successful. The span should
+// still carry request-side attributes, the caller must still see the
+// complete, untruncated body, and the drop should be logged rather than
+// silent.
+func TestOtelMiddleware_ResponseBodyTruncated(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	var logBuf bytes.Buffer
+	origLogger := logger
+	t.Cleanup(func() { logger = origLogger })
+	logger = slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	middleware := OtelMiddleware()
+
+	reqBody := `{"model":"gpt-4"}`
+	req, _ := http.NewRequest(
+		"POST",
+		"http://api.openai.com/v1/chat/completions",
+		io.NopCloser(bytes.NewReader([]byte(reqBody))),
+	)
+
+	// A response whose JSON would otherwise be valid, but padded past
+	// maxResponseBodySize the way a large batch response would be.
+	padding := strings.Repeat("x", maxResponseBodySize)
+	oversized := `{"id":"chatcmpl-big","model":"gpt-4","choices":[{"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2},"padding":"` + padding + `"}`
+	next := func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(oversized)),
+		}, nil
+	}
+
+	resp, err := middleware(req, next)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// The full, untruncated body must still reach the caller - only the
+	// telemetry parse is bounded, not what the SDK receives.
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, oversized, string(body))
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1)
+
+	attrs := spans[0].Attributes()
+	assertAttribute(t, attrs, "gen_ai.request.model", "gpt-4")
+	assertNoAttribute(t, attrs, "gen_ai.response.model")
+	assertNoAttribute(t, attrs, "gen_ai.response.id")
+	assertNoAttribute(t, attrs, "gen_ai.usage.total_tokens")
+
+	assert.Contains(t, logBuf.String(), "response body exceeded size cap",
+		"a truncated response must be logged instead of silently dropped")
+}
+
+// TestOtelMiddleware_RequestBodyTruncated covers Issue #1314: a request
+// larger than maxRequestBodySize must not silently vanish from telemetry
+// without at least a log line, and the SDK must still receive the complete
+// body.
+func TestOtelMiddleware_RequestBodyTruncated(t *testing.T) {
+	sr := setupTestTracer(t)
+
+	var logBuf bytes.Buffer
+	origLogger := logger
+	t.Cleanup(func() { logger = origLogger })
+	logger = slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	middleware := OtelMiddleware()
+
+	padding := strings.Repeat("x", maxRequestBodySize)
+	oversized := `{"model":"gpt-4","padding":"` + padding + `"}`
+	req, _ := http.NewRequest(
+		"POST",
+		"http://api.openai.com/v1/chat/completions",
+		io.NopCloser(strings.NewReader(oversized)),
+	)
+
+	called := false
+	next := func(r *http.Request) (*http.Response, error) {
+		called = true
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, oversized, string(body), "the SDK must still see the full, untruncated request body")
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
+		}, nil
+	}
+
+	resp, err := middleware(req, next)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, called)
+
+	assert.Empty(t, sr.Ended(), "an oversized request should pass through uninstrumented, like any other unparsable body")
+	assert.Contains(t, logBuf.String(), "request body exceeded size cap",
+		"a truncated request must be logged instead of silently dropped")
 }
 
 func TestOtelMiddleware_AzurePath(t *testing.T) {

--- a/instrumentation/github.com/openai/openai-go/v3/testhelpers_test.go
+++ b/instrumentation/github.com/openai/openai-go/v3/testhelpers_test.go
@@ -66,3 +66,13 @@ func assertSliceAttribute(t *testing.T, attrs []attribute.KeyValue, key string, 
 	}
 	t.Errorf("attribute %q not found", key)
 }
+
+func assertNoAttribute(t *testing.T, attrs []attribute.KeyValue, key string) {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			t.Errorf("attribute %q should not be present, got %v", key, attr.Value.Emit())
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1309 and #1314.

Both request and response paths in `instrumentation/github.com/openai/openai-go/middleware.go` (and its `v2`/`v3` copies) read the HTTP body through a bounded `io.LimitReader`. When a body exceeds the cap (e.g. a large-but-normal batch embeddings response, or a large chat request), the read is silently cut off, `json.Unmarshal` fails on the truncated bytes, and the parse functions quietly return nothing.

The result: a span that looks fully successful (correct request-side attributes, status `Unset`) while every response attribute (`gen_ai.response.model`, `gen_ai.usage.*`, etc.) is simply missing, with no error, log, or indication that anything was cut off.

## Changes

- Added a `readBounded` helper that reads one byte past the cap to detect truncation, while still reassembling the complete, untruncated body for the SDK/HTTP caller either way — no data is lost for the actual API call, only the telemetry parse is bounded.
- When a response body is truncated, skip the doomed parse attempt and log a warning (operation + cap size) instead of silently falling through.
- When a request body is truncated, same treatment: pass through un-instrumented (as before) but now with a logged reason instead of silence.
- Applied identically to the `v1`, `v2`, and `v3` copies of the instrumentation to keep them in sync.

No new span attributes were added — this repo governs `gen_ai.*` attributes through a Weaver semconv registry (`schemas/otelc/`), so a new attribute would need a registry change out of scope here. A log line satisfies the issue's own stated minimum bar.

## Test plan

- [x] `go build ./...`, `go vet ./...` pass for all three modules (v1/v2/v3)
- [x] Full existing test suite passes for all three modules
- [x] Added `TestOtelMiddleware_ResponseBodyTruncated` and `TestOtelMiddleware_RequestBodyTruncated` (mirrored across all three modules) asserting: the span still carries request-side attributes but no response attributes, the caller still receives the complete untruncated body, and the warning is logged
- [x] `gofmt -l` reports no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)