### PR TITLE
refactor(tool): replace duplicate writeCloser interfaces with io.WriteCloser

### DIFF
--- a/tool/internal/ast/parser.go
+++ b/tool/internal/ast/parser.go
@@ -93,11 +93,6 @@ func (ap *AstParser) FindPosition(node dst.Node) token.Position {
 	return ap.fset.Position(astNode.Pos())
 }
 
-type writeCloser interface {
-	io.Writer
-	io.Closer
-}
-
 // WriteFile writes the AST to a file.
 func WriteFile(filePath string, root *dst.File) error {
 	file, err := os.Create(filePath)
@@ -107,7 +102,7 @@ func WriteFile(filePath string, root *dst.File) error {
 	return writeFile(file, filePath, root)
 }
 
-func writeFile(w writeCloser, filePath string, root *dst.File) error {
+func writeFile(w io.WriteCloser, filePath string, root *dst.File) error {
 	r := decorator.NewRestorer()
 	if err := r.Fprint(w, root); err != nil {
 		_ = w.Close()

--- a/tool/internal/imports/importcfg.go
+++ b/tool/internal/imports/importcfg.go
@@ -102,11 +102,6 @@ func parse(r io.Reader) (ImportConfig, error) {
 	return reg, nil
 }
 
-type writeCloser interface {
-	io.Writer
-	io.Closer
-}
-
 // WriteFile writes the content of the ImportConfig to the provided file,
 // in the format expected by the Go toolchain commands.
 func (r *ImportConfig) WriteFile(filename string) error {
@@ -117,7 +112,7 @@ func (r *ImportConfig) WriteFile(filename string) error {
 	return r.writeFile(file, filename)
 }
 
-func (r *ImportConfig) writeFile(w writeCloser, filename string) error {
+func (r *ImportConfig) writeFile(w io.WriteCloser, filename string) error {
 	if err := r.write(w); err != nil {
 		_ = w.Close()
 		return ex.Wrapf(err, "failed to write to file %s", filename)


### PR DESCRIPTION
## Summary
- `tool/internal/ast` and `tool/internal/imports` each independently declared a private `writeCloser` interface (`io.Writer` + `io.Closer`) that is identical to the standard library's `io.WriteCloser`
- Replace both with `io.WriteCloser` and drop the duplicate type definitions

Addresses the "writeCloser is defined twice" item from #1299.

## Test plan
- [x] `go test ./internal/imports/... ./internal/ast/...`
- [x] `go vet ./internal/imports/... ./internal/ast/...`

