### PR TITLE
chore(ci): read Go version from go.mod in check-makefile workflow

### DIFF
--- a/.github/workflows/check-makefile.yaml
+++ b/.github/workflows/check-makefile.yaml
@@ -30,6 +30,6 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - run: mkdir -p .bin && cd .tools && go build -o ../.bin/checkmake github.com/checkmake/checkmake/cmd/checkmake
       - run: .bin/checkmake --config .tools/checkmake Makefile


### PR DESCRIPTION
## Description

Switch `check-makefile.yaml` from a hardcoded `go-version: "1.25"` to `go-version-file: go.mod`, matching every other Go workflow in the repo (`lint-golang.yaml`, `lint-actionlint.yaml`, `check-yaml-format.yaml`, etc.).

## Motivation

`go.mod` is the source of truth for the toolchain version, but this one job duplicated it as a floating minor. When `go.mod` moves to `1.26.x`, this job would silently keep building `checkmake` with Go 1.25 while every other job follows `go.mod`. Renovate does not touch `.github/**` here (actions are ratchet-pinned), so the value never moves on its own.

`.tools/go.mod` also declares `go 1.25.0`, so the root `go.mod` toolchain is sufficient to build `checkmake`, same as `lint-actionlint` and `check-yaml-format` building their tools from `.tools`.

Verified locally: `make lint/action`, `make lint/yaml`, and the workflow's two `run:` steps (build + `checkmake --config .tools/checkmake Makefile`) all pass on a `go.mod`-derived toolchain.

Fixes #1327

---

AI disclosure: this change was made with Claude Code assistance; I reviewed the diff and the local verification myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
