### PR TITLE
chore(ci): bump setup-go/paths-filter to Node 24 and silence false-positive test annotations

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"
@@ -63,7 +63,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"

--- a/.github/workflows/check-consistency.yaml
+++ b/.github/workflows/check-consistency.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
         id: filter
         with:
           filters: |
@@ -72,7 +72,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"
@@ -90,7 +90,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"
@@ -108,7 +108,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"
@@ -128,7 +128,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"

--- a/.github/workflows/check-conventional-commit.yml
+++ b/.github/workflows/check-conventional-commit.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           cache-dependency-path: "**/go.mod"
           go-version-file: go.mod

--- a/.github/workflows/check-license-headers.yaml
+++ b/.github/workflows/check-license-headers.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
         id: filter
         with:
           filters: |

--- a/.github/workflows/check-makefile.yaml
+++ b/.github/workflows/check-makefile.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: "1.25"
       - run: mkdir -p .bin && cd .tools && go build -o ../.bin/checkmake github.com/checkmake/checkmake/cmd/checkmake

--- a/.github/workflows/check-yaml-format.yaml
+++ b/.github/workflows/check-yaml-format.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache: false

--- a/.github/workflows/generate-registry-diff.yaml
+++ b/.github/workflows/generate-registry-diff.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           # Latest stable toolchain, not the go.mod version: govulncheck reports
           # stdlib CVEs against the Go release running it, so pinning to go.mod
@@ -58,7 +58,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: stable
           cache-dependency-path: "**/go.mod"

--- a/.github/workflows/lint-actionlint.yaml
+++ b/.github/workflows/lint-actionlint.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache: false

--- a/.github/workflows/lint-golang.yaml
+++ b/.github/workflows/lint-golang.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
         id: filter
         with:
           filters: |
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
       - name: Generate embedded bundle

--- a/.github/workflows/regenerate-bundle.yaml
+++ b/.github/workflows/regenerate-bundle.yaml
@@ -55,7 +55,7 @@ jobs:
           repository: ${{ steps.pr.outputs.head_repo_full }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: 'go.mod'
           cache: false

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
         id: filter
         with:
           filters: |
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
       - run: make test-e2e/coverage
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
         id: filter
         with:
           filters: |
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"
@@ -89,7 +89,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"

--- a/.github/workflows/test-latestlibbuild.yaml
+++ b/.github/workflows/test-latestlibbuild.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
         id: filter
         with:
           filters: |
@@ -62,7 +62,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"

--- a/.github/workflows/test-latestlibrun.yaml
+++ b/.github/workflows/test-latestlibrun.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
         id: filter
         with:
           filters: |
@@ -56,9 +56,19 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
+      # setup-go registers the default "go" problem matcher, whose regexp is
+      # meant for `go build`/`go vet` output. Our tests intentionally log
+      # error strings (e.g. invalid rule files, missing instrumentation) as
+      # part of `go test -json` output, and lines ending in "...go: <text>"
+      # get misdetected as compiler errors, producing false failure
+      # annotations even though the job passes. Remove the matcher before
+      # running tests; it isn't needed here since we don't build with `go
+      # build`/`go vet` in this step.
+      - name: Disable Go problem matcher
+        run: echo "::remove-matcher owner=go::"
       - name: Run unit test coverage
         run: make test-unit/coverage
       # make test-unit/coverage leaves coverage-tool.txt, coverage-pkg.txt and
@@ -105,10 +115,15 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"
+      # See the comment on the "Disable Go problem matcher" step in the
+      # test-unit-coverage job above: `go test -json` output here triggers
+      # false failure annotations from the default "go" problem matcher.
+      - name: Disable Go problem matcher
+        run: echo "::remove-matcher owner=go::"
       - name: Build and test
         env:
           GOARCH: ${{ matrix.platform.arch }}

--- a/.github/workflows/test-versionmatrix.yaml
+++ b/.github/workflows/test-versionmatrix.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
           cache-dependency-path: "**/go.mod"

--- a/.github/workflows/verify-bundle.yaml
+++ b/.github/workflows/verify-bundle.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Summary

Follow-up to a review of [run 34130381628](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/actions/runs/34130381628) (PR #1137). The run **passed** overall, but surfaced two classes of noise worth cleaning up:

1. **Node.js 20 deprecation warnings** on every job:
   > Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `dorny/paths-filter@...`, `actions/setup-go@...`

2. **False-positive "failure" annotations** on the Checks API (confirmed via the GitHub API, not a `gh` CLI artifact) for lines like:
   - `instrumentation package example.com/notinstrumentation contains neither otel.instrumentation.go nor any rule files: not an instrumentation package`
   - `parsing rule file .../invalid.otelc.yaml: yaml: mapping values are not allowed in this context`

   These are expected `go test -json` log lines from negative-path tests (`TestUpdatePinnedProjects_NoInstrumentation`, `TestUpdatePinnedProjects_InvalidRule`, etc.) that assert on specific error messages — every one of them is immediately followed by `PASS` in the JSON stream, and the job conclusion is `success`. The annotations come from the **default `go` problem matcher** that `actions/setup-go` auto-registers; its regexp (meant for `go build`/`go vet` output) misfires on `go test -json` log text containing `otel.instrumentation.go`.

## Changes

- Bump `actions/setup-go` `v6.1.0` → `v7.0.0` and `dorny/paths-filter` `v3.0.2` → `v4.0.3` (pinned by commit SHA) across all workflows that reference them. Both releases run on the Node 24 runtime; `setup-go` v7 is documented as a drop-in replacement for v6 (no input/behavior changes), and `paths-filter` v4 is compatible with our existing filter config.
- In `test-unit.yaml`, add a `::remove-matcher owner=go::` step right after `actions/setup-go` and before the `go test -json` steps (both the coverage job and the per-platform matrix job), so the default Go problem matcher no longer misclassifies expected error-path test log lines as check-run failures.

## Verification

- `actionlint` passes on all modified workflow files.
- Confirmed via the Checks API (`check-runs/<job-id>/annotations`) that the flagged lines were real `annotation_level: failure` entries attributed to path `.github` (no source line), consistent with a problem-matcher misfire rather than an actual test failure.
- No behavior change to test execution; `make test-unit` / `make test-unit/coverage` output is unaffected, only the check-run annotation surface changes.
