### PR TITLE
fix(ast): stripGenericTypes fatals on qualified pointer receivers

### DIFF
--- a/tool/internal/ast/shared.go
+++ b/tool/internal/ast/shared.go
@@ -50,6 +50,7 @@ func FindFuncDeclWithoutRecv(root *dst.File, funcName string) *dst.FuncDecl {
 // - MyStruct -> MyStruct
 // - *GenStruct[T] -> *GenStruct
 // - GenStruct[T] -> GenStruct
+// - *pkg.Type -> *Type
 func stripGenericTypes(recvTypeExpr dst.Expr) string {
 	switch expr := recvTypeExpr.(type) {
 	case *dst.StarExpr: // func (*Recv)T or func (*Recv[T])T
@@ -68,6 +69,9 @@ func stripGenericTypes(recvTypeExpr dst.Expr) string {
 			if baseIdent, ok := x.X.(*dst.Ident); ok {
 				return "*" + baseIdent.Name
 			}
+		case *dst.SelectorExpr:
+			// Qualified pointer receiver: *pkg.Type
+			return "*" + x.Sel.Name
 		}
 	case *dst.Ident: // func (Recv)T
 		return expr.Name

--- a/tool/internal/ast/shared_test.go
+++ b/tool/internal/ast/shared_test.go
@@ -233,6 +233,34 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {}
 	assert.Equal(t, "handleRoot", fn.Name.Name)
 }
 
+// TestFindFuncDeclForRule_QualifiedPointerReceiver is an end-to-end regression
+// test for the bug where a recv filter (e.g. "*Writer") crashed instead of
+// matching or returning no match against a qualified pointer receiver like
+// *bufio.Writer. stripGenericTypes only handled *dst.Ident and generic
+// index expressions under a StarExpr, not *dst.SelectorExpr, so it fell
+// through to util.Unimplemented/ex.Fatalf.
+func TestFindFuncDeclForRule_QualifiedPointerReceiver(t *testing.T) {
+	p := NewAstParser()
+	file, err := p.ParseSource(`package main
+
+import "bufio"
+
+func (*bufio.Writer) Write(p []byte) (n int, err error) { return }
+`)
+	require.NoError(t, err)
+
+	r := &rule.InstFuncRule{
+		Func: "Write",
+		Recv: "*Writer",
+	}
+
+	fn, ok, err := FindFuncDecl(file, r)
+	require.NoError(t, err)
+	require.True(t, ok, `recv: "*Writer" should match a *bufio.Writer receiver`)
+	require.NotNil(t, fn)
+	assert.Equal(t, "Write", fn.Name.Name)
+}
+
 func TestFindVarDecl(t *testing.T) {
 	file := parseSharedFixture(t)
 
@@ -790,6 +818,11 @@ func TestStripGenericTypes(t *testing.T) {
 				X: &dst.IndexListExpr{X: Ident("GenStruct"), Indices: []dst.Expr{Ident("T"), Ident("U")}},
 			},
 			want: "*GenStruct",
+		},
+		{
+			name: "qualified pointer receiver",
+			expr: &dst.StarExpr{X: &dst.SelectorExpr{X: Ident("bufio"), Sel: Ident("Writer")}},
+			want: "*Writer",
 		},
 		{
 			name: "unrecognized expression yields empty",


### PR DESCRIPTION
## Description

`stripGenericTypes` extracts the base type name from a method receiver so rules with a `recv` filter (like `recv: "*Writer"`) can match against it. Under the `*dst.StarExpr` case it only handled `*dst.Ident` (`*MyStruct`) and the generic index forms (`*GenStruct[T]`). It never handled `*dst.SelectorExpr`, which is what a qualified pointer receiver like `*bufio.Writer` or `*http.ResponseWriter` parses as.

So any rule targeting a method with a qualified pointer receiver hit the fallthrough at the bottom of the function, got an empty string back, and `findFuncDecl` called `util.Unimplemented` on it, which fatals:

```
Unimplemented: unexpected receiver type: *dst.StarExpr
```

This crashes `otelc setup` at load time, not just the one rule.

## Fix

Added a `*dst.SelectorExpr` case next to the existing `*dst.Ident` one, same shape, pulls `Sel.Name` off it so `*pkg.Type` resolves to `*Type`. Left the bare (non-pointer) `*dst.SelectorExpr` case alone, that one's a value receiver on a foreign type, which isn't valid Go, so it stays as returning empty like before.

## Tests

- Added a case to the existing `TestStripGenericTypes` table for `*bufio.Writer` -> `*Writer`.
- Added `TestFindFuncDeclForRule_QualifiedPointerReceiver`, an end to end test parsing `func (*bufio.Writer) Write(...)` and matching it with `recv: "*Writer"`, same pattern as `TestFindFuncDeclForRule_QualifiedParamType` right above it.

Checked both new tests fatal on main without the fix (stashed the change and reran).

No `instrumentation/` files touched, so the bundle doesn't need regenerating.

Fixes #766

---

- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/blob/main/docs/AI_POLICY.md).