### PR TITLE
fix(tool/internal/setup): drop -json from the build plan dry run

### DIFF
--- a/tool/internal/setup/find.go
+++ b/tool/internal/setup/find.go
@@ -75,6 +75,61 @@ func findCommands(buildPlanLog *os.File) ([]string, error) {
 	return commands, nil
 }
 
+// planIrrelevantFlags names flags that change how the go command formats its
+// own output without changing the build plan. listBuildPlan reads the plan from
+// the go command's stderr, and -json moves it to stdout as a stream of JSON
+// build-output events instead, so the plan parses empty and no dependency is
+// found. The real build keeps the flag; only the dry run drops it.
+//
+//nolint:gochecknoglobals // private lookup table
+var planIrrelevantFlags = map[string]bool{
+	flagJSON: true,
+}
+
+// flagName returns the flag name of arg in single-dash form, without a joined
+// value. The go command accepts -flag and --flag interchangeably.
+func flagName(arg string) string {
+	name, _, _ := strings.Cut(arg, "=")
+	if strings.HasPrefix(name, "--") {
+		return name[1:]
+	}
+	return name
+}
+
+// dropPlanIrrelevantFlags returns cmdArgs without the flags listed in
+// planIrrelevantFlags. Arguments after -args go to the test binary rather than
+// the go command, so they pass through untouched, and a value that follows a
+// flag in separated form travels with its flag so it is never read as one.
+func dropPlanIrrelevantFlags(cmdArgs []string) []string {
+	kept := make([]string, 0, len(cmdArgs))
+	for i := 0; i < len(cmdArgs); i++ {
+		arg := cmdArgs[i]
+
+		// Everything after -args is passed to the test binary, so it can
+		// contain neither go flags nor packages.
+		if arg == flagArgs {
+			kept = append(kept, cmdArgs[i:]...)
+			break
+		}
+		if !strings.HasPrefix(arg, "-") {
+			kept = append(kept, arg)
+			continue
+		}
+
+		name := flagName(arg)
+		end := i + 1
+		if !strings.Contains(arg, "=") && (flagsWithPathValues[name] || testFlagsWithValues[name]) &&
+			end < len(cmdArgs) {
+			end++ // the flag's value is the next argument
+		}
+		if !planIrrelevantFlags[name] {
+			kept = append(kept, cmdArgs[i:end]...)
+		}
+		i = end - 1
+	}
+	return kept
+}
+
 // listBuildPlan lists the build plan by running `go build -a -x -n`
 // and then filtering the commands (cd, cgo, compile) from the build plan log.
 func listBuildPlan(ctx context.Context, subcommand string, cmdArgs []string) ([]string, error) {
@@ -97,10 +152,11 @@ func listBuildPlan(ctx context.Context, subcommand string, cmdArgs []string) ([]
 		planVerb = subcmdTest
 	}
 	// The full command is: "go build/test -a -x -n {...}"
+	planArgs := dropPlanIrrelevantFlags(cmdArgs)
 	prefix := []string{planVerb, "-a", "-x", "-n"}
-	args := make([]string, 0, len(prefix)+len(cmdArgs))
+	args := make([]string, 0, len(prefix)+len(planArgs))
 	args = append(args, prefix...)
-	args = append(args, cmdArgs...) // args from original build/install or setup command
+	args = append(args, planArgs...) // args from original build/install or setup command
 	logger.InfoContext(ctx, "go build command", "args", args)
 
 	cmd := execCommandContext(ctx, "go", args...)

--- a/tool/internal/setup/find_test.go
+++ b/tool/internal/setup/find_test.go
@@ -480,6 +480,33 @@ echo nothing useful
 			expectedGoCmd: []string{"build", "-a", "-x", "-n", "./..."},
 		},
 		{
+			// -json makes `go test` write the plan to stdout as JSON events
+			// instead of to stderr as shell commands, which leaves the plan
+			// empty. The dry run must drop it.
+			name:       "drops -json from a go test plan",
+			subcommand: "test",
+			buildPlan: `
+.../compile -o /tmp/out.a -buildid abc -p main main.go
+`,
+			args: []string{"-json", "-count=1", "./..."},
+			expected: []string{
+				".../compile -o /tmp/out.a -buildid abc -p main main.go",
+			},
+			expectedGoCmd: []string{"test", "-a", "-x", "-n", "-count=1", "./..."},
+		},
+		{
+			// `go build -json` reports build output as JSON events too.
+			name: "drops -json from a go build plan",
+			buildPlan: `
+.../compile -o /tmp/out.a -buildid abc -p main main.go
+`,
+			args: []string{"-json", "./cmd"},
+			expected: []string{
+				".../compile -o /tmp/out.a -buildid abc -p main main.go",
+			},
+			expectedGoCmd: []string{"build", "-a", "-x", "-n", "./cmd"},
+		},
+		{
 			// The test subcommand must list a `go test` plan, which surfaces the
 			// test-augmented, external test, and test-main compiles that is_test
 			// gates on. A `go build` plan would never contain them.
@@ -540,6 +567,107 @@ echo nothing useful
 				require.NoError(t, err)
 				assert.Equal(t, tt.expected, buildPlan)
 			}
+		})
+	}
+}
+
+func TestDropPlanIrrelevantFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{
+			name:     "no flags",
+			args:     []string{"./..."},
+			expected: []string{"./..."},
+		},
+		{
+			name:     "nil args",
+			args:     nil,
+			expected: []string{},
+		},
+		{
+			name:     "drops -json",
+			args:     []string{"-json", "./..."},
+			expected: []string{"./..."},
+		},
+		{
+			name:     "drops --json",
+			args:     []string{"--json", "./..."},
+			expected: []string{"./..."},
+		},
+		{
+			name:     "drops -json=true",
+			args:     []string{"-json=true", "./..."},
+			expected: []string{"./..."},
+		},
+		{
+			// -json=false already leaves the plan on stderr, but the dry run
+			// has no use for either form.
+			name:     "drops -json=false",
+			args:     []string{"-json=false", "./..."},
+			expected: []string{"./..."},
+		},
+		{
+			name:     "keeps other flags",
+			args:     []string{"-tags=integration", "-json", "-race", "./cmd"},
+			expected: []string{"-tags=integration", "-race", "./cmd"},
+		},
+		{
+			name:     "keeps a separated flag value that follows -json",
+			args:     []string{"-json", "-run", "TestX", "./..."},
+			expected: []string{"-run", "TestX", "./..."},
+		},
+		{
+			// `-o -json` names an output file called "-json"; it is a value,
+			// not a flag.
+			name:     "keeps -json as the value of another flag",
+			args:     []string{"-o", "-json", "./cmd"},
+			expected: []string{"-o", "-json", "./cmd"},
+		},
+		{
+			// Everything after -args belongs to the test binary.
+			name:     "keeps -json after -args",
+			args:     []string{"./...", "-args", "-json", "-v"},
+			expected: []string{"./...", "-args", "-json", "-v"},
+		},
+		{
+			name:     "drops -json before -args and keeps it after",
+			args:     []string{"-json", "./...", "-args", "-json"},
+			expected: []string{"./...", "-args", "-json"},
+		},
+		{
+			name:     "tolerates a trailing value flag with no value",
+			args:     []string{"-json", "./...", "-run"},
+			expected: []string{"./...", "-run"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, dropPlanIrrelevantFlags(tt.args))
+		})
+	}
+}
+
+func TestFlagName(t *testing.T) {
+	tests := []struct {
+		arg      string
+		expected string
+	}{
+		{arg: "-json", expected: "-json"},
+		{arg: "--json", expected: "-json"},
+		{arg: "-json=false", expected: "-json"},
+		{arg: "--tags=integration", expected: "-tags"},
+		{arg: "./...", expected: "./..."},
+		{arg: "-", expected: "-"},
+		{arg: "--", expected: "-"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arg, func(t *testing.T) {
+			assert.Equal(t, tt.expected, flagName(tt.arg))
 		})
 	}
 }

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -134,6 +134,15 @@ const (
 	subcmdTest    = "test"
 )
 
+// Go command flags that the argument scanners treat specially.
+const (
+	// flagArgs separates the go command's own arguments from the ones it
+	// passes through to the test binary.
+	flagArgs = "-args"
+	// flagJSON makes the go command report its output as JSON events.
+	flagJSON = "-json"
+)
+
 // GetBuildPackages loads all packages from the otelc go build/install or otelc setup command arguments.
 // Returns a list of loaded packages. If no package patterns are found in args,
 // defaults to loading the current directory package.
@@ -213,7 +222,7 @@ func splitBuildTargets(args []string) ([]string, []string, error) {
 
 		// Everything after `-args` is passed to the test binary, not the go
 		// command, so it can contain neither packages nor go flags.
-		if arg == "-args" {
+		if arg == flagArgs {
 			break
 		}
 


### PR DESCRIPTION
## Description

Setup derives its build plan from a dry run of the go command. That dry run now drops `-json`. The real build still receives it, so `-json` output is unchanged.

## Motivation

`otelc go test -json ./pkg` built and ran the tests, but produced an uninstrumented binary. No rule was applied and nothing failed loudly.

**Why it happens.** Setup finds the packages to instrument by running the build as a dry run:

```
go test -a -x -n <user args>
```

`-x -n` makes the go command print the compile commands it would run to stderr, which otelc parses. `-json` sends that output to stdout as JSON events instead. stderr is left empty, so the plan parses to nothing, no dependency matches, and `matched.json` is written as `[]`. The instrument phase then has nothing to apply.

**How to reproduce.** In any module with an instrumentation rule:

```
otelc go test -json ./pkg    # .otelc-build/matched.json is []
otelc go test ./pkg          # .otelc-build/matched.json is populated
```

`go build -json` and `go install -json` fail the same way, as do `--json` and `-json=true`. Only `-json=false` was unaffected.

**Second effect.** The dry run's JSON also reached stdout alongside the real run's, so the stream carried a duplicate `start` and `pass` for each package, with the extra `pass` arriving before the tests ran. Consumers of the stream saw every package twice.
