### PR TITLE
fix(tool/internal/setup): handle test flags and delimiters for go test

### DIFF
--- a/tool/internal/setup/args.go
+++ b/tool/internal/setup/args.go
@@ -1,0 +1,450 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"strings"
+)
+
+// ArgKind represents the semantic category of a command-line argument.
+type ArgKind int
+
+const (
+	// ArgTarget represents a package pattern or file target (e.g., "./...", "main.go").
+	ArgTarget ArgKind = iota
+
+	// ArgBuildFlag represents a recognized Go build/command flag (e.g., "-tags=foo", "-race").
+	ArgBuildFlag
+
+	// ArgBuildFlagValue represents the separated value argument for an ArgBuildFlag.
+	ArgBuildFlagValue
+
+	// ArgTestFlag represents a recognized go test flag (e.g., "-run", "-test.run", "-v").
+	ArgTestFlag
+
+	// ArgTestFlagValue represents the separated value argument for an ArgTestFlag.
+	ArgTestFlagValue
+
+	// ArgTestDelimiter represents "--", "-args", or "--args" in go test.
+	ArgTestDelimiter
+
+	// ArgTestBinary represents test-binary arguments (tokens following a test delimiter,
+	// or unknown/custom test flags and their values/positionals).
+	ArgTestBinary
+
+	// ArgFlagTerminator represents "--" in go build / go install.
+	ArgFlagTerminator
+)
+
+// ClassifiedArg contains the classification metadata for a single command-line argument token.
+type ClassifiedArg struct {
+	Index    int
+	Raw      string
+	Kind     ArgKind
+	FlagName string // normalized single-dash name, e.g. "-tags", "-run", "-test.run"
+	HasValue bool   // whether joined =value was present
+	Value    string // value from joined =value or separate token
+}
+
+// isBuildFlagWithValue reports whether name is a Go build flag that accepts a value.
+func isBuildFlagWithValue(name string) bool {
+	switch name {
+	case "-C", "-o", "-p", "-covermode", "-coverpkg",
+		"-asmflags", "-buildmode", "-buildvcs", "-compiler",
+		"-gccgoflags", "-gcflags", "-installsuffix", "-ldflags",
+		"-mod", "-modfile", "-overlay", "-pgo", "-pkgdir",
+		"-tags", "-toolexec":
+		return true
+	default:
+		return false
+	}
+}
+
+// isBuildBoolFlag reports whether name is a Go build boolean flag.
+func isBuildBoolFlag(name string) bool {
+	switch name {
+	case "-a", "-n", "-v", "-x", "-race", "-msan",
+		"-asan", "-cover", "-trimpath", "-work", "-linkshared", "-json":
+		return true
+	default:
+		return false
+	}
+}
+
+// isTestFlagWithValue reports whether name is a go test flag that accepts a value.
+func isTestFlagWithValue(name string) bool {
+	switch name {
+	case "-bench", "-benchtime", "-blockprofile", "-blockprofilerate",
+		"-count", "-coverprofile", "-cpu", "-cpuprofile", "-exec",
+		"-fuzz", "-fuzzminimizetime", "-fuzztime", "-list",
+		"-memprofile", "-memprofilerate", "-mutexprofile",
+		"-mutexprofilefraction", "-outputdir", "-parallel",
+		"-run", "-shuffle", "-skip", "-timeout", "-trace", "-vet":
+		return true
+	default:
+		return false
+	}
+}
+
+// isTestBoolFlag reports whether name is a go test boolean flag distinct from buildBoolFlags.
+func isTestBoolFlag(name string) bool {
+	switch name {
+	case "-artifacts", "-benchmem", "-c", "-failfast", "-fullpath", "-short":
+		return true
+	default:
+		return false
+	}
+}
+
+// isTestAliasFlagWithValue reports whether name is a supported -test.<name> alias taking a value.
+// Derived from cmd/go/internal/test/flagdefs.go:passFlagToTest.
+func isTestAliasFlagWithValue(name string) bool {
+	switch name {
+	case "-test.bench", "-test.benchtime", "-test.blockprofile", "-test.blockprofilerate",
+		"-test.count", "-test.coverprofile", "-test.cpu", "-test.cpuprofile",
+		"-test.fuzz", "-test.fuzzminimizetime", "-test.fuzztime", "-test.list",
+		"-test.memprofile", "-test.memprofilerate", "-test.mutexprofile",
+		"-test.mutexprofilefraction", "-test.outputdir", "-test.parallel",
+		"-test.run", "-test.shuffle", "-test.skip", "-test.timeout", "-test.trace":
+		return true
+	default:
+		return false
+	}
+}
+
+// isTestAliasBoolFlag reports whether name is a supported -test.<name> boolean alias.
+// Derived from cmd/go/internal/test/flagdefs.go:passFlagToTest.
+func isTestAliasBoolFlag(name string) bool {
+	switch name {
+	case "-test.artifacts", "-test.benchmem", "-test.failfast",
+		"-test.fullpath", "-test.short", "-test.v":
+		return true
+	default:
+		return false
+	}
+}
+
+// isBuildContextFlagWithValue reports whether name affects the build context and takes a value.
+func isBuildContextFlagWithValue(name string) bool {
+	switch name {
+	case "-C", "-overlay", "-tags", "-mod", "-modfile":
+		return true
+	default:
+		return false
+	}
+}
+
+// isBuildContextBoolFlag reports whether name is a boolean flag affecting the build context.
+func isBuildContextBoolFlag(name string) bool {
+	switch name {
+	case "-race", "-msan", "-cover", "-asan", "-trimpath":
+		return true
+	default:
+		return false
+	}
+}
+
+// isPlanIrrelevantFlag reports whether name is stripped from the build plan dry-run command.
+func isPlanIrrelevantFlag(name string) bool {
+	return name == flagJSON
+}
+
+// flagName returns the flag name of arg in single-dash form, without a joined value.
+func flagName(arg string) string {
+	name, _, _ := strings.Cut(arg, "=")
+	if strings.HasPrefix(name, "--") {
+		return name[1:]
+	}
+	return name
+}
+
+// isTestDelimiter reports whether arg is an explicit go test delimiter.
+func isTestDelimiter(arg string) bool {
+	return arg == delimiterDashDash || arg == flagArgs || arg == flagArgsDashDash
+}
+
+// takesValue reports whether a flag name requires an argument value.
+func takesValue(name string) bool {
+	return isBuildFlagWithValue(name) || isTestFlagWithValue(name) || isTestAliasFlagWithValue(name)
+}
+
+type flagToken struct {
+	normName string
+	hasValue bool
+	value    string
+}
+
+func classifyValueFlag(
+	args []string,
+	i int,
+	tok flagToken,
+	isTest bool,
+) (int, []ClassifiedArg) {
+	flagKind := ArgBuildFlag
+	valKind := ArgBuildFlagValue
+	if isTest {
+		flagKind = ArgTestFlag
+		valKind = ArgTestFlagValue
+	}
+	if tok.hasValue {
+		return 1, []ClassifiedArg{{
+			Index:    i,
+			Raw:      args[i],
+			Kind:     flagKind,
+			FlagName: tok.normName,
+			HasValue: true,
+			Value:    tok.value,
+		}}
+	}
+	res := []ClassifiedArg{{
+		Index:    i,
+		Raw:      args[i],
+		Kind:     flagKind,
+		FlagName: tok.normName,
+		HasValue: false,
+	}}
+	if i+1 < len(args) {
+		res = append(res, ClassifiedArg{
+			Index:    i + 1,
+			Raw:      args[i+1],
+			Kind:     valKind,
+			FlagName: tok.normName,
+			Value:    args[i+1],
+		})
+	}
+	return len(res), res
+}
+
+type testArgState struct {
+	inPkgList              bool
+	packageListEstablished bool
+	testArgsFinalized      bool
+}
+
+func classifyBuildFlagToken(args []string, i int) (int, []ClassifiedArg) {
+	arg := args[i]
+	rawName, value, hasValue := strings.Cut(arg, "=")
+	tok := flagToken{
+		normName: flagName(rawName),
+		hasValue: hasValue,
+		value:    value,
+	}
+
+	if isBuildFlagWithValue(tok.normName) {
+		return classifyValueFlag(args, i, tok, false)
+	}
+	return 1, []ClassifiedArg{{
+		Index:    i,
+		Raw:      arg,
+		Kind:     ArgBuildFlag,
+		FlagName: tok.normName,
+		HasValue: tok.hasValue,
+		Value:    tok.value,
+	}}
+}
+
+func classifyTestFlagToken(
+	args []string,
+	i int,
+	state *testArgState,
+) (int, []ClassifiedArg, bool, string) {
+	arg := args[i]
+	rawName, value, hasValue := strings.Cut(arg, "=")
+	tok := flagToken{
+		normName: flagName(rawName),
+		hasValue: hasValue,
+		value:    value,
+	}
+
+	if isBuildFlagWithValue(tok.normName) {
+		c, it := classifyValueFlag(args, i, tok, false)
+		return c, it, false, ""
+	}
+	if isBuildBoolFlag(tok.normName) {
+		return 1, []ClassifiedArg{{
+			Index:    i,
+			Raw:      arg,
+			Kind:     ArgBuildFlag,
+			FlagName: tok.normName,
+			HasValue: tok.hasValue,
+			Value:    tok.value,
+		}}, false, ""
+	}
+	if isTestFlagWithValue(tok.normName) || isTestAliasFlagWithValue(tok.normName) {
+		c, it := classifyValueFlag(args, i, tok, true)
+		return c, it, false, ""
+	}
+	if isTestBoolFlag(tok.normName) || isTestAliasBoolFlag(tok.normName) {
+		return 1, []ClassifiedArg{{
+			Index:    i,
+			Raw:      arg,
+			Kind:     ArgTestFlag,
+			FlagName: tok.normName,
+			HasValue: tok.hasValue,
+			Value:    tok.value,
+		}}, false, ""
+	}
+
+	// Unknown / custom flag: closes the package list region.
+	state.packageListEstablished = true
+	item := ClassifiedArg{
+		Index:    i,
+		Raw:      arg,
+		Kind:     ArgTestBinary,
+		FlagName: tok.normName,
+		HasValue: tok.hasValue,
+		Value:    tok.value,
+	}
+	return 1, []ClassifiedArg{item}, !tok.hasValue, tok.normName
+}
+
+func classifyPositionalTestArg(
+	arg string,
+	i int,
+	state *testArgState,
+	wasAfterUnknown bool,
+	unknownName string,
+) ClassifiedArg {
+	if !state.inPkgList && state.packageListEstablished {
+		if wasAfterUnknown {
+			// Optimistically treated as the separated value for the preceding unknown flag.
+			return ClassifiedArg{
+				Index:    i,
+				Raw:      arg,
+				Kind:     ArgTestBinary,
+				FlagName: unknownName,
+				Value:    arg,
+			}
+		}
+
+		// Definitive positional test argument. All remaining tokens become ArgTestBinary.
+		state.testArgsFinalized = true
+		return ClassifiedArg{
+			Index: i,
+			Raw:   arg,
+			Kind:  ArgTestBinary,
+		}
+	}
+
+	// Establishing or adding to the package list.
+	state.inPkgList = true
+	state.packageListEstablished = true
+	return ClassifiedArg{
+		Index: i,
+		Raw:   arg,
+		Kind:  ArgTarget,
+	}
+}
+
+func classifyBuildArgs(args []string) []ClassifiedArg {
+	classified := make([]ClassifiedArg, 0, len(args))
+	flagParsingClosed := false
+
+	for i := 0; i < len(args); {
+		arg := args[i]
+		if flagParsingClosed {
+			classified = append(classified, ClassifiedArg{
+				Index: i,
+				Raw:   arg,
+				Kind:  ArgTarget,
+			})
+			i++
+			continue
+		}
+
+		if arg == delimiterDashDash {
+			classified = append(classified, ClassifiedArg{
+				Index: i,
+				Raw:   arg,
+				Kind:  ArgFlagTerminator,
+			})
+			flagParsingClosed = true
+			i++
+			continue
+		}
+
+		if strings.HasPrefix(arg, "-") {
+			consumed, items := classifyBuildFlagToken(args, i)
+			classified = append(classified, items...)
+			i += consumed
+			continue
+		}
+
+		classified = append(classified, ClassifiedArg{
+			Index: i,
+			Raw:   arg,
+			Kind:  ArgTarget,
+		})
+		i++
+	}
+
+	return classified
+}
+
+func classifyTestArgs(args []string) []ClassifiedArg {
+	classified := make([]ClassifiedArg, 0, len(args))
+	var testState testArgState
+	afterUnknownFlagWithoutValue := false
+	unknownFlagName := ""
+
+	for i := 0; i < len(args); {
+		arg := args[i]
+		wasAfterUnknown := afterUnknownFlagWithoutValue
+		lastUnknownName := unknownFlagName
+		afterUnknownFlagWithoutValue = false
+		unknownFlagName = ""
+
+		if testState.testArgsFinalized {
+			classified = append(classified, ClassifiedArg{
+				Index: i,
+				Raw:   arg,
+				Kind:  ArgTestBinary,
+			})
+			i++
+			continue
+		}
+
+		if isTestDelimiter(arg) {
+			classified = append(classified, ClassifiedArg{
+				Index: i,
+				Raw:   arg,
+				Kind:  ArgTestDelimiter,
+			})
+			testState.testArgsFinalized = true
+			i++
+			continue
+		}
+
+		if strings.HasPrefix(arg, "-") {
+			if testState.inPkgList {
+				testState.inPkgList = false
+			}
+
+			consumed, items, unjoinedUnknown, name := classifyTestFlagToken(
+				args, i, &testState,
+			)
+			classified = append(classified, items...)
+			afterUnknownFlagWithoutValue = unjoinedUnknown
+			unknownFlagName = name
+			i += consumed
+			continue
+		}
+
+		classified = append(classified, classifyPositionalTestArg(
+			arg, i, &testState, wasAfterUnknown, lastUnknownName,
+		))
+		i++
+	}
+
+	return classified
+}
+
+// classifyArgs scans args and classifies each token according to Go command and subcommand semantics.
+// It is non-validating: it preserves tokens as-is and lets cmd/go produce canonical validation errors.
+func classifyArgs(subcommand string, args []string) []ClassifiedArg {
+	if subcommand == subcmdTest {
+		return classifyTestArgs(args)
+	}
+	return classifyBuildArgs(args)
+}

--- a/tool/internal/setup/args_test.go
+++ b/tool/internal/setup/args_test.go
@@ -1,0 +1,366 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyArgs_Build(t *testing.T) {
+	t.Run("flags, separated values, and targets", func(t *testing.T) {
+		args := []string{"-o", "out", "-tags", "foo", "./pkg"}
+		got := classifyArgs(subcmdBuild, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-o", Kind: ArgBuildFlag, FlagName: "-o", HasValue: false},
+			{Index: 1, Raw: "out", Kind: ArgBuildFlagValue, FlagName: "-o", Value: "out"},
+			{Index: 2, Raw: "-tags", Kind: ArgBuildFlag, FlagName: "-tags", HasValue: false},
+			{Index: 3, Raw: "foo", Kind: ArgBuildFlagValue, FlagName: "-tags", Value: "foo"},
+			{Index: 4, Raw: "./pkg", Kind: ArgTarget},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("joined values and booleans", func(t *testing.T) {
+		args := []string{"--tags=foo", "-race", "--race=false", "main.go"}
+		got := classifyArgs(subcmdBuild, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "--tags=foo", Kind: ArgBuildFlag, FlagName: "-tags", HasValue: true, Value: "foo"},
+			{Index: 1, Raw: "-race", Kind: ArgBuildFlag, FlagName: "-race", HasValue: false},
+			{Index: 2, Raw: "--race=false", Kind: ArgBuildFlag, FlagName: "-race", HasValue: true, Value: "false"},
+			{Index: 3, Raw: "main.go", Kind: ArgTarget},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("terminator closes flag parsing and treats dash-prefixed token as target", func(t *testing.T) {
+		args := []string{"-v", "--", "-weird-target", "./pkg"}
+		got := classifyArgs(subcmdBuild, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-v", Kind: ArgBuildFlag, FlagName: "-v", HasValue: false},
+			{Index: 1, Raw: "--", Kind: ArgFlagTerminator},
+			{Index: 2, Raw: "-weird-target", Kind: ArgTarget},
+			{Index: 3, Raw: "./pkg", Kind: ArgTarget},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("install behaves like build", func(t *testing.T) {
+		args := []string{"-v", "./..."}
+		got := classifyArgs(subcmdInstall, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-v", Kind: ArgBuildFlag, FlagName: "-v", HasValue: false},
+			{Index: 1, Raw: "./...", Kind: ArgTarget},
+		}
+		assert.Equal(t, expected, got)
+	})
+}
+
+func TestClassifyArgs_Test_Delimiters(t *testing.T) {
+	t.Run("dash-dash delimiter terminates into test binary args", func(t *testing.T) {
+		args := []string{"./pkg", "--", "-mod=vendor", "-tags=integration"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+			{Index: 1, Raw: "--", Kind: ArgTestDelimiter},
+			{Index: 2, Raw: "-mod=vendor", Kind: ArgTestBinary},
+			{Index: 3, Raw: "-tags=integration", Kind: ArgTestBinary},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("-args delimiter", func(t *testing.T) {
+		args := []string{"./pkg", "-args", "-custom", "value"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+			{Index: 1, Raw: "-args", Kind: ArgTestDelimiter},
+			{Index: 2, Raw: "-custom", Kind: ArgTestBinary},
+			{Index: 3, Raw: "value", Kind: ArgTestBinary},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("--args delimiter", func(t *testing.T) {
+		args := []string{"./pkg", "--args", "-custom"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+			{Index: 1, Raw: "--args", Kind: ArgTestDelimiter},
+			{Index: 2, Raw: "-custom", Kind: ArgTestBinary},
+		}
+		assert.Equal(t, expected, got)
+	})
+}
+
+func TestClassifyArgs_Test_ValuesResemblingFlagsOrDelimiters(t *testing.T) {
+	t.Run("test flag value is dash-dash delimiter", func(t *testing.T) {
+		args := []string{"-test.run", "--", "./pkg"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-test.run", Kind: ArgTestFlag, FlagName: "-test.run", HasValue: false},
+			{Index: 1, Raw: "--", Kind: ArgTestFlagValue, FlagName: "-test.run", Value: "--"},
+			{Index: 2, Raw: "./pkg", Kind: ArgTarget},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("test flag value is -args delimiter", func(t *testing.T) {
+		args := []string{"-test.run", "-args", "./pkg"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-test.run", Kind: ArgTestFlag, FlagName: "-test.run", HasValue: false},
+			{Index: 1, Raw: "-args", Kind: ArgTestFlagValue, FlagName: "-test.run", Value: "-args"},
+			{Index: 2, Raw: "./pkg", Kind: ArgTarget},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("test flag value is --args delimiter", func(t *testing.T) {
+		args := []string{"-run", "--args", "./pkg"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-run", Kind: ArgTestFlag, FlagName: "-run", HasValue: false},
+			{Index: 1, Raw: "--args", Kind: ArgTestFlagValue, FlagName: "-run", Value: "--args"},
+			{Index: 2, Raw: "./pkg", Kind: ArgTarget},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("test flag value looks like build flag", func(t *testing.T) {
+		args := []string{"-test.run", "-mod=vendor", "./pkg"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-test.run", Kind: ArgTestFlag, FlagName: "-test.run", HasValue: false},
+			{Index: 1, Raw: "-mod=vendor", Kind: ArgTestFlagValue, FlagName: "-test.run", Value: "-mod=vendor"},
+			{Index: 2, Raw: "./pkg", Kind: ArgTarget},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("test flag value looks like tags build flag", func(t *testing.T) {
+		args := []string{"-run", "-tags=integration", "./pkg"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-run", Kind: ArgTestFlag, FlagName: "-run", HasValue: false},
+			{Index: 1, Raw: "-tags=integration", Kind: ArgTestFlagValue, FlagName: "-run", Value: "-tags=integration"},
+			{Index: 2, Raw: "./pkg", Kind: ArgTarget},
+		}
+		assert.Equal(t, expected, got)
+	})
+}
+
+func TestClassifyArgs_Test_UnknownFlags(t *testing.T) {
+	t.Run("unknown flag with separated value terminates package discovery", func(t *testing.T) {
+		args := []string{"./pkg", "-custom", "value"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+			{Index: 1, Raw: "-custom", Kind: ArgTestBinary, FlagName: "-custom", HasValue: false},
+			{Index: 2, Raw: "value", Kind: ArgTestBinary, FlagName: "-custom", Value: "value"},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("unknown flag before package closes package list", func(t *testing.T) {
+		args := []string{"-custom", "value", "./pkg"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-custom", Kind: ArgTestBinary, FlagName: "-custom", HasValue: false},
+			{Index: 1, Raw: "value", Kind: ArgTestBinary, FlagName: "-custom", Value: "value"},
+			{Index: 2, Raw: "./pkg", Kind: ArgTestBinary},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("unknown flag with joined value", func(t *testing.T) {
+		args := []string{"./pkg", "-custom=value"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+			{Index: 1, Raw: "-custom=value", Kind: ArgTestBinary, FlagName: "-custom", HasValue: true, Value: "value"},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("unknown flag followed by delimiter", func(t *testing.T) {
+		args := []string{"./pkg", "-custom", "--", "./other"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+			{Index: 1, Raw: "-custom", Kind: ArgTestBinary, FlagName: "-custom", HasValue: false},
+			{Index: 2, Raw: "--", Kind: ArgTestDelimiter},
+			{Index: 3, Raw: "./other", Kind: ArgTestBinary},
+		}
+		assert.Equal(t, expected, got)
+	})
+}
+
+func TestClassifyArgs_Test_Aliases(t *testing.T) {
+	t.Run("supported -test.run and --test.run", func(t *testing.T) {
+		args := []string{"-test.run", "TestA", "--test.run=TestB", "-test.v", "./pkg"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-test.run", Kind: ArgTestFlag, FlagName: "-test.run", HasValue: false},
+			{Index: 1, Raw: "TestA", Kind: ArgTestFlagValue, FlagName: "-test.run", Value: "TestA"},
+			{
+				Index:    2,
+				Raw:      "--test.run=TestB",
+				Kind:     ArgTestFlag,
+				FlagName: "-test.run",
+				HasValue: true,
+				Value:    "TestB",
+			},
+			{Index: 3, Raw: "-test.v", Kind: ArgTestFlag, FlagName: "-test.v", HasValue: false},
+			{Index: 4, Raw: "./pkg", Kind: ArgTarget},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("unsupported -test.exec and -test.vet treated as unknown flags", func(t *testing.T) {
+		args := []string{"-test.exec", "echo", "./pkg"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-test.exec", Kind: ArgTestBinary, FlagName: "-test.exec", HasValue: false},
+			{Index: 1, Raw: "echo", Kind: ArgTestBinary, FlagName: "-test.exec", Value: "echo"},
+			{Index: 2, Raw: "./pkg", Kind: ArgTestBinary},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("supported plain -exec and -vet", func(t *testing.T) {
+		args := []string{"-exec", "echo", "-vet=off", "./pkg"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-exec", Kind: ArgTestFlag, FlagName: "-exec", HasValue: false},
+			{Index: 1, Raw: "echo", Kind: ArgTestFlagValue, FlagName: "-exec", Value: "echo"},
+			{Index: 2, Raw: "-vet=off", Kind: ArgTestFlag, FlagName: "-vet", HasValue: true, Value: "off"},
+			{Index: 3, Raw: "./pkg", Kind: ArgTarget},
+		}
+		assert.Equal(t, expected, got)
+	})
+}
+
+func TestClassifyArgs_Test_PackageListAndTestArgvTransitions(t *testing.T) {
+	t.Run(
+		"known flag after package list ends package discovery and trailing positional becomes test argv",
+		func(t *testing.T) {
+			args := []string{"./pkg", "-run", "TestX", "./other"}
+			got := classifyArgs(subcmdTest, args)
+
+			expected := []ClassifiedArg{
+				{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+				{Index: 1, Raw: "-run", Kind: ArgTestFlag, FlagName: "-run", HasValue: false},
+				{Index: 2, Raw: "TestX", Kind: ArgTestFlagValue, FlagName: "-run", Value: "TestX"},
+				{Index: 3, Raw: "./other", Kind: ArgTestBinary},
+			}
+			assert.Equal(t, expected, got)
+		},
+	)
+
+	t.Run("known flag followed by positional then build-looking flag", func(t *testing.T) {
+		args := []string{"./pkg", "-run", "TestX", "positional", "-tags=integration"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+			{Index: 1, Raw: "-run", Kind: ArgTestFlag, FlagName: "-run", HasValue: false},
+			{Index: 2, Raw: "TestX", Kind: ArgTestFlagValue, FlagName: "-run", Value: "TestX"},
+			{Index: 3, Raw: "positional", Kind: ArgTestBinary},
+			{Index: 4, Raw: "-tags=integration", Kind: ArgTestBinary},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("vendoring isolation after positional test arg", func(t *testing.T) {
+		args := []string{"./pkg", "-run", "TestX", "positional", "-mod=vendor"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+			{Index: 1, Raw: "-run", Kind: ArgTestFlag, FlagName: "-run", HasValue: false},
+			{Index: 2, Raw: "TestX", Kind: ArgTestFlagValue, FlagName: "-run", Value: "TestX"},
+			{Index: 3, Raw: "positional", Kind: ArgTestBinary},
+			{Index: 4, Raw: "-mod=vendor", Kind: ArgTestBinary},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("joined unknown flag followed by positional", func(t *testing.T) {
+		args := []string{"./pkg", "-custom=x", "positional", "-mod=vendor"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+			{Index: 1, Raw: "-custom=x", Kind: ArgTestBinary, FlagName: "-custom", HasValue: true, Value: "x"},
+			{Index: 2, Raw: "positional", Kind: ArgTestBinary},
+			{Index: 3, Raw: "-mod=vendor", Kind: ArgTestBinary},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("unknown separated flag value optimistic behavior without package target", func(t *testing.T) {
+		args := []string{"-custom", "value", "-run", "TestX"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "-custom", Kind: ArgTestBinary, FlagName: "-custom", HasValue: false},
+			{Index: 1, Raw: "value", Kind: ArgTestBinary, FlagName: "-custom", Value: "value"},
+			{Index: 2, Raw: "-run", Kind: ArgTestFlag, FlagName: "-run", HasValue: false},
+			{Index: 3, Raw: "TestX", Kind: ArgTestFlagValue, FlagName: "-run", Value: "TestX"},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("unknown separated flag value optimistic behavior with package target", func(t *testing.T) {
+		args := []string{"./pkg", "-custom", "value", "-run", "TestX"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+			{Index: 1, Raw: "-custom", Kind: ArgTestBinary, FlagName: "-custom", HasValue: false},
+			{Index: 2, Raw: "value", Kind: ArgTestBinary, FlagName: "-custom", Value: "value"},
+			{Index: 3, Raw: "-run", Kind: ArgTestFlag, FlagName: "-run", HasValue: false},
+			{Index: 4, Raw: "TestX", Kind: ArgTestFlagValue, FlagName: "-run", Value: "TestX"},
+		}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("definitive positional tail classifies all subsequent tokens as test binary", func(t *testing.T) {
+		args := []string{"./pkg", "-run", "TestX", "positional", "-race", "-mod=vendor", "-tags=x", "./other"}
+		got := classifyArgs(subcmdTest, args)
+
+		expected := []ClassifiedArg{
+			{Index: 0, Raw: "./pkg", Kind: ArgTarget},
+			{Index: 1, Raw: "-run", Kind: ArgTestFlag, FlagName: "-run", HasValue: false},
+			{Index: 2, Raw: "TestX", Kind: ArgTestFlagValue, FlagName: "-run", Value: "TestX"},
+			{Index: 3, Raw: "positional", Kind: ArgTestBinary},
+			{Index: 4, Raw: "-race", Kind: ArgTestBinary},
+			{Index: 5, Raw: "-mod=vendor", Kind: ArgTestBinary},
+			{Index: 6, Raw: "-tags=x", Kind: ArgTestBinary},
+			{Index: 7, Raw: "./other", Kind: ArgTestBinary},
+		}
+		assert.Equal(t, expected, got)
+	})
+}

--- a/tool/internal/setup/find.go
+++ b/tool/internal/setup/find.go
@@ -86,28 +86,17 @@ var planIrrelevantFlags = map[string]bool{
 	flagJSON: true,
 }
 
-// flagName returns the flag name of arg in single-dash form, without a joined
-// value. The go command accepts -flag and --flag interchangeably.
-func flagName(arg string) string {
-	name, _, _ := strings.Cut(arg, "=")
-	if strings.HasPrefix(name, "--") {
-		return name[1:]
-	}
-	return name
-}
-
 // dropPlanIrrelevantFlags returns cmdArgs without the flags listed in
-// planIrrelevantFlags. Arguments after -args go to the test binary rather than
+// planIrrelevantFlags. Arguments after test delimiters go to the test binary rather than
 // the go command, so they pass through untouched, and a value that follows a
 // flag in separated form travels with its flag so it is never read as one.
-func dropPlanIrrelevantFlags(cmdArgs []string) []string {
+func dropPlanIrrelevantFlags(subcommand string, cmdArgs []string) []string {
 	kept := make([]string, 0, len(cmdArgs))
+	isTest := subcommand == subcmdTest
 	for i := 0; i < len(cmdArgs); i++ {
 		arg := cmdArgs[i]
 
-		// Everything after -args is passed to the test binary, so it can
-		// contain neither go flags nor packages.
-		if arg == flagArgs {
+		if isTest && isTestDelimiter(arg) {
 			kept = append(kept, cmdArgs[i:]...)
 			break
 		}
@@ -116,13 +105,12 @@ func dropPlanIrrelevantFlags(cmdArgs []string) []string {
 			continue
 		}
 
-		name := flagName(arg)
+		flag := parseFlag(arg, isTest)
 		end := i + 1
-		if !strings.Contains(arg, "=") && (flagsWithPathValues[name] || testFlagsWithValues[name]) &&
-			end < len(cmdArgs) {
+		if !flag.hasValue && flag.takesValue && end < len(cmdArgs) {
 			end++ // the flag's value is the next argument
 		}
-		if !planIrrelevantFlags[name] {
+		if !planIrrelevantFlags[flag.name] {
 			kept = append(kept, cmdArgs[i:end]...)
 		}
 		i = end - 1
@@ -152,7 +140,7 @@ func listBuildPlan(ctx context.Context, subcommand string, cmdArgs []string) ([]
 		planVerb = subcmdTest
 	}
 	// The full command is: "go build/test -a -x -n {...}"
-	planArgs := dropPlanIrrelevantFlags(cmdArgs)
+	planArgs := dropPlanIrrelevantFlags(subcommand, cmdArgs)
 	prefix := []string{planVerb, "-a", "-x", "-n"}
 	args := make([]string, 0, len(prefix)+len(planArgs))
 	args = append(args, prefix...)

--- a/tool/internal/setup/find.go
+++ b/tool/internal/setup/find.go
@@ -80,40 +80,33 @@ func findCommands(buildPlanLog *os.File) ([]string, error) {
 // the go command's stderr, and -json moves it to stdout as a stream of JSON
 // build-output events instead, so the plan parses empty and no dependency is
 // found. The real build keeps the flag; only the dry run drops it.
-//
-//nolint:gochecknoglobals // private lookup table
-var planIrrelevantFlags = map[string]bool{
-	flagJSON: true,
-}
-
 // dropPlanIrrelevantFlags returns cmdArgs without the flags listed in
 // planIrrelevantFlags. Arguments after test delimiters go to the test binary rather than
 // the go command, so they pass through untouched, and a value that follows a
 // flag in separated form travels with its flag so it is never read as one.
 func dropPlanIrrelevantFlags(subcommand string, cmdArgs []string) []string {
+	if subcommand == "" {
+		subcommand = subcmdBuild
+	}
+	classified := classifyArgs(subcommand, cmdArgs)
+	dropIndices := make(map[int]bool)
+
+	for i, a := range classified {
+		if (a.Kind == ArgBuildFlag || a.Kind == ArgTestFlag) && isPlanIrrelevantFlag(a.FlagName) {
+			dropIndices[a.Index] = true
+			if !a.HasValue && i+1 < len(classified) &&
+				(classified[i+1].Kind == ArgBuildFlagValue ||
+					classified[i+1].Kind == ArgTestFlagValue) {
+				dropIndices[classified[i+1].Index] = true
+			}
+		}
+	}
+
 	kept := make([]string, 0, len(cmdArgs))
-	isTest := subcommand == subcmdTest
-	for i := 0; i < len(cmdArgs); i++ {
-		arg := cmdArgs[i]
-
-		if isTest && isTestDelimiter(arg) {
-			kept = append(kept, cmdArgs[i:]...)
-			break
-		}
-		if !strings.HasPrefix(arg, "-") {
+	for i, arg := range cmdArgs {
+		if !dropIndices[i] {
 			kept = append(kept, arg)
-			continue
 		}
-
-		flag := parseFlag(arg, isTest)
-		end := i + 1
-		if !flag.hasValue && flag.takesValue && end < len(cmdArgs) {
-			end++ // the flag's value is the next argument
-		}
-		if !planIrrelevantFlags[flag.name] {
-			kept = append(kept, cmdArgs[i:end]...)
-		}
-		i = end - 1
 	}
 	return kept
 }

--- a/tool/internal/setup/find_test.go
+++ b/tool/internal/setup/find_test.go
@@ -573,80 +573,161 @@ echo nothing useful
 
 func TestDropPlanIrrelevantFlags(t *testing.T) {
 	tests := []struct {
-		name     string
-		args     []string
-		expected []string
+		name       string
+		subcommand string
+		args       []string
+		expected   []string
 	}{
 		{
-			name:     "no flags",
-			args:     []string{"./..."},
-			expected: []string{"./..."},
+			name:       "no flags",
+			subcommand: subcmdBuild,
+			args:       []string{"./..."},
+			expected:   []string{"./..."},
 		},
 		{
-			name:     "nil args",
-			args:     nil,
-			expected: []string{},
+			name:       "nil args",
+			subcommand: subcmdBuild,
+			args:       nil,
+			expected:   []string{},
 		},
 		{
-			name:     "drops -json",
-			args:     []string{"-json", "./..."},
-			expected: []string{"./..."},
+			name:       "drops -json",
+			subcommand: subcmdBuild,
+			args:       []string{"-json", "./..."},
+			expected:   []string{"./..."},
 		},
 		{
-			name:     "drops --json",
-			args:     []string{"--json", "./..."},
-			expected: []string{"./..."},
+			name:       "drops --json",
+			subcommand: subcmdBuild,
+			args:       []string{"--json", "./..."},
+			expected:   []string{"./..."},
 		},
 		{
-			name:     "drops -json=true",
-			args:     []string{"-json=true", "./..."},
-			expected: []string{"./..."},
+			name:       "drops -json=true",
+			subcommand: subcmdBuild,
+			args:       []string{"-json=true", "./..."},
+			expected:   []string{"./..."},
 		},
 		{
 			// -json=false already leaves the plan on stderr, but the dry run
 			// has no use for either form.
-			name:     "drops -json=false",
-			args:     []string{"-json=false", "./..."},
-			expected: []string{"./..."},
+			name:       "drops -json=false",
+			subcommand: subcmdBuild,
+			args:       []string{"-json=false", "./..."},
+			expected:   []string{"./..."},
 		},
 		{
-			name:     "keeps other flags",
-			args:     []string{"-tags=integration", "-json", "-race", "./cmd"},
-			expected: []string{"-tags=integration", "-race", "./cmd"},
+			name:       "keeps other flags",
+			subcommand: subcmdBuild,
+			args:       []string{"-tags=integration", "-json", "-race", "./cmd"},
+			expected:   []string{"-tags=integration", "-race", "./cmd"},
 		},
 		{
-			name:     "keeps a separated flag value that follows -json",
-			args:     []string{"-json", "-run", "TestX", "./..."},
-			expected: []string{"-run", "TestX", "./..."},
+			name:       "keeps a separated flag value that follows -json",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "-run", "TestX", "./..."},
+			expected:   []string{"-run", "TestX", "./..."},
+		},
+		{
+			name:       "keeps a separated -test.run flag value that follows -json",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "-test.run", "TestX", "./..."},
+			expected:   []string{"-test.run", "TestX", "./..."},
+		},
+		{
+			name:       "keeps joined -test.run flag value",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "-test.run=TestX", "./..."},
+			expected:   []string{"-test.run=TestX", "./..."},
+		},
+		{
+			name:       "keeps separated --test.run flag value",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "--test.run", "TestX", "./..."},
+			expected:   []string{"--test.run", "TestX", "./..."},
+		},
+		{
+			name:       "keeps -json when it is the value of -test.run",
+			subcommand: subcmdTest,
+			args:       []string{"-test.run", "-json", "./..."},
+			expected:   []string{"-test.run", "-json", "./..."},
 		},
 		{
 			// `-o -json` names an output file called "-json"; it is a value,
 			// not a flag.
-			name:     "keeps -json as the value of another flag",
-			args:     []string{"-o", "-json", "./cmd"},
-			expected: []string{"-o", "-json", "./cmd"},
+			name:       "keeps -json as the value of another flag",
+			subcommand: subcmdBuild,
+			args:       []string{"-o", "-json", "./cmd"},
+			expected:   []string{"-o", "-json", "./cmd"},
 		},
 		{
 			// Everything after -args belongs to the test binary.
-			name:     "keeps -json after -args",
-			args:     []string{"./...", "-args", "-json", "-v"},
-			expected: []string{"./...", "-args", "-json", "-v"},
+			name:       "keeps -json after -args",
+			subcommand: subcmdTest,
+			args:       []string{"./...", "-args", "-json", "-v"},
+			expected:   []string{"./...", "-args", "-json", "-v"},
 		},
 		{
-			name:     "drops -json before -args and keeps it after",
-			args:     []string{"-json", "./...", "-args", "-json"},
-			expected: []string{"./...", "-args", "-json"},
+			name:       "drops -json before -args and keeps it after",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "./...", "-args", "-json"},
+			expected:   []string{"./...", "-args", "-json"},
 		},
 		{
-			name:     "tolerates a trailing value flag with no value",
-			args:     []string{"-json", "./...", "-run"},
-			expected: []string{"./...", "-run"},
+			name:       "tolerates a trailing value flag with no value",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "./...", "-run"},
+			expected:   []string{"./...", "-run"},
+		},
+		{
+			name:       "tolerates a trailing -test.run flag with no value",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "./...", "-test.run"},
+			expected:   []string{"./...", "-test.run"},
+		},
+		{
+			// go test ./pkg -- -test.run TestName input.go
+			// The output should preserve the delimiter and every trailing argument exactly and in order.
+			name:       "go test exact preservation after delimiter --",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "--", "-test.run", "TestName", "input.go"},
+			expected:   []string{"./pkg", "--", "-test.run", "TestName", "input.go"},
+		},
+		{
+			name:       "go test drops -json before -- and preserves after --",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "./pkg", "--", "-json", "input.go"},
+			expected:   []string{"./pkg", "--", "-json", "input.go"},
+		},
+		{
+			name:       "go test drops -json before --args and preserves after --args",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "./pkg", "--args", "-json", "input.go"},
+			expected:   []string{"./pkg", "--args", "-json", "input.go"},
+		},
+		{
+			name:       "go test preserves empty delimiter --",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "./pkg", "--"},
+			expected:   []string{"./pkg", "--"},
+		},
+		{
+			name:       "go test preserves repeated delimiter -- --",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "./pkg", "--", "--", "-json"},
+			expected:   []string{"./pkg", "--", "--", "-json"},
+		},
+		{
+			name:       "go build -- does not stop filtering -json",
+			subcommand: subcmdBuild,
+			args:       []string{"-json", "./pkg", "--", "-json", "main.go"},
+			expected:   []string{"./pkg", "--", "main.go"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, dropPlanIrrelevantFlags(tt.args))
+			assert.Equal(t, tt.expected, dropPlanIrrelevantFlags(tt.subcommand, tt.args))
 		})
 	}
 }

--- a/tool/internal/setup/find_test.go
+++ b/tool/internal/setup/find_test.go
@@ -718,10 +718,32 @@ func TestDropPlanIrrelevantFlags(t *testing.T) {
 			expected:   []string{"./pkg", "--", "--", "-json"},
 		},
 		{
-			name:       "go build -- does not stop filtering -json",
+			name:       "go build -- closes flag parsing and preserves positional -json",
 			subcommand: subcmdBuild,
 			args:       []string{"-json", "./pkg", "--", "-json", "main.go"},
-			expected:   []string{"./pkg", "--", "main.go"},
+			expected:   []string{"./pkg", "--", "-json", "main.go"},
+		},
+		{
+			name:       "go test preserves -json after positional test-argv boundary",
+			subcommand: subcmdTest,
+			args:       []string{"-json", "./pkg", "-run", "TestX", "positional", "-json"},
+			expected:   []string{"./pkg", "-run", "TestX", "positional", "-json"},
+		},
+		{
+			name:       "go test preserves full tail untouched after positional test-argv boundary",
+			subcommand: subcmdTest,
+			args: []string{
+				"-json",
+				"./pkg",
+				"-run",
+				"TestX",
+				"positional",
+				"-race",
+				"-mod=vendor",
+				"-tags=x",
+				"./other",
+			},
+			expected: []string{"./pkg", "-run", "TestX", "positional", "-race", "-mod=vendor", "-tags=x", "./other"},
 		},
 	}
 

--- a/tool/internal/setup/pin.go
+++ b/tool/internal/setup/pin.go
@@ -670,8 +670,12 @@ func pinLocked(ctx context.Context, opts PinOptions) (*PinResult, error) {
 		}
 		opts.Args = args
 
+		subcommand := opts.Subcommand
+		if subcommand == "" {
+			subcommand = subcmdBuild
+		}
 		// Use opts.Args to find module directories
-		pkgs, getErr := getBuildPackages(ctx, opts.Args)
+		pkgs, getErr := getBuildPackages(ctx, subcommand, opts.Args)
 		if getErr != nil {
 			return nil, getErr
 		}

--- a/tool/internal/setup/pin.go
+++ b/tool/internal/setup/pin.go
@@ -606,7 +606,12 @@ func generatePinnedProjects(ctx context.Context, moduleDirs map[string]bool, opt
 	return &PinResult{}, nil
 }
 
-func prepareVendoredBuild(ctx context.Context, logger *slog.Logger, args []string) ([]string, error) {
+func prepareVendoredBuild(
+	ctx context.Context,
+	logger *slog.Logger,
+	subcommand string,
+	args []string,
+) ([]string, error) {
 	if !vendoringActive(ctx, util.GetOtelcWorkDir()) {
 		return args, nil
 	}
@@ -617,7 +622,7 @@ func prepareVendoredBuild(ctx context.Context, logger *slog.Logger, args []strin
 		return nil, ex.Wrapf(err, "forcing module mode for vendored build")
 	}
 
-	return rewriteModVendor(args), nil
+	return rewriteModVendor(subcommand, args), nil
 }
 
 type PinOptions struct {
@@ -662,18 +667,18 @@ func pinLocked(ctx context.Context, opts PinOptions) (*PinResult, error) {
 	// moduleDirs being empty means Pin was invoked as a standalone command
 	// (not as part of a setup run), so use opts.Args to find module directories.
 	if len(moduleDirs) == 0 {
+		subcommand := opts.Subcommand
+		if subcommand == "" {
+			subcommand = subcmdBuild
+		}
 		// For same reason as Setup, we have to check vendoring state before
 		// forcing module mode and rewriting vendor/ paths to module mode.
-		args, err := prepareVendoredBuild(ctx, util.LoggerFromContext(ctx), opts.Args)
+		args, err := prepareVendoredBuild(ctx, util.LoggerFromContext(ctx), subcommand, opts.Args)
 		if err != nil {
 			return nil, err
 		}
 		opts.Args = args
 
-		subcommand := opts.Subcommand
-		if subcommand == "" {
-			subcommand = subcmdBuild
-		}
 		// Use opts.Args to find module directories
 		pkgs, getErr := getBuildPackages(ctx, subcommand, opts.Args)
 		if getErr != nil {

--- a/tool/internal/setup/pin_test.go
+++ b/tool/internal/setup/pin_test.go
@@ -1143,7 +1143,7 @@ func TestPrepareVendoredBuild_NotVendored(t *testing.T) {
 	t.Setenv("GOFLAGS", "")
 
 	args := []string{"build", "-mod=vendor", "./..."}
-	got, err := prepareVendoredBuild(t.Context(), discardLogger(), args)
+	got, err := prepareVendoredBuild(t.Context(), discardLogger(), subcmdBuild, args)
 	require.NoError(t, err)
 
 	// Unchanged: not a vendored project, so no rewriting happens.
@@ -1174,7 +1174,7 @@ func TestPrepareVendoredBuild_Vendored(t *testing.T) {
 	t.Setenv("GOWORK", "off")
 
 	args := []string{"build", "-mod=vendor", "./..."}
-	got, err := prepareVendoredBuild(t.Context(), discardLogger(), args)
+	got, err := prepareVendoredBuild(t.Context(), discardLogger(), subcmdBuild, args)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"build", "-mod=mod", "./..."}, got)
@@ -1331,7 +1331,12 @@ func TestPrepareVendoredBuild(t *testing.T) {
 	t.Setenv(util.EnvOtelcWorkDir, dir)
 
 	args := []string{"build", "./..."}
-	got, err := prepareVendoredBuild(context.Background(), util.LoggerFromContext(context.Background()), args)
+	got, err := prepareVendoredBuild(
+		context.Background(),
+		util.LoggerFromContext(context.Background()),
+		subcmdBuild,
+		args,
+	)
 	require.NoError(t, err)
 	assert.Equal(t, args, got)
 }

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -66,67 +66,6 @@ func isSetup() bool {
 	return false
 }
 
-// flagsWithPathValues contains flags that accept a value from "go build" command.
-//
-//nolint:gochecknoglobals // private lookup table
-var flagsWithPathValues = map[string]bool{
-	"-C":             true,
-	"-o":             true,
-	"-p":             true,
-	"-covermode":     true,
-	"-coverpkg":      true,
-	"-asmflags":      true,
-	"-buildmode":     true,
-	"-buildvcs":      true,
-	"-compiler":      true,
-	"-gccgoflags":    true,
-	"-gcflags":       true,
-	"-installsuffix": true,
-	"-ldflags":       true,
-	"-mod":           true,
-	"-modfile":       true,
-	"-overlay":       true,
-	"-pgo":           true,
-	"-pkgdir":        true,
-	"-tags":          true,
-	"-toolexec":      true,
-}
-
-// testFlagsWithValues contains `go test` flags that take a separate value
-// argument. Their values are not packages, so splitBuildTargets skips them when
-// scanning for package targets (e.g. `go test -run TestX ./pkg` — TestX is the
-// value of -run, not a package). `-args` is handled separately by
-// splitBuildTargets, which stops scanning at it.
-//
-//nolint:gochecknoglobals // private lookup table
-var testFlagsWithValues = map[string]bool{
-	"-bench":                true,
-	"-benchtime":            true,
-	"-blockprofile":         true,
-	"-blockprofilerate":     true,
-	"-count":                true,
-	"-coverprofile":         true,
-	"-cpu":                  true,
-	"-cpuprofile":           true,
-	"-exec":                 true,
-	"-fuzz":                 true,
-	"-fuzzminimizetime":     true,
-	"-fuzztime":             true,
-	"-list":                 true,
-	"-memprofile":           true,
-	"-memprofilerate":       true,
-	"-mutexprofile":         true,
-	"-mutexprofilefraction": true,
-	"-outputdir":            true,
-	"-parallel":             true,
-	"-run":                  true,
-	"-shuffle":              true,
-	"-skip":                 true,
-	"-timeout":              true,
-	"-trace":                true,
-	"-vet":                  true,
-}
-
 // Go subcommands that otelc wraps with toolexec instrumentation.
 const (
 	subcmdBuild   = "build"
@@ -149,63 +88,17 @@ const (
 	flagJSON = "-json"
 )
 
-func isTestDelimiter(arg string) bool {
-	return arg == delimiterDashDash || arg == flagArgs || arg == flagArgsDashDash
-}
-
 func findTestDelimiter(subcommand string, args []string) int {
 	if subcommand != subcmdTest {
 		return -1
 	}
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if isTestDelimiter(arg) {
-			return i
-		}
-		if strings.HasPrefix(arg, "-") {
-			flag := parseFlag(arg, true)
-			if !flag.hasValue && flag.takesValue {
-				i++ // skip separated value
-			}
+	classified := classifyArgs(subcommand, args)
+	for _, a := range classified {
+		if a.Kind == ArgTestDelimiter {
+			return a.Index
 		}
 	}
 	return -1
-}
-
-// flagName returns the flag name of arg in single-dash form, without a joined
-// value. The go command accepts -flag and --flag interchangeably.
-func flagName(arg string) string {
-	name, _, _ := strings.Cut(arg, "=")
-	if strings.HasPrefix(name, "--") {
-		return name[1:]
-	}
-	return name
-}
-
-type parsedFlag struct {
-	name       string
-	hasValue   bool
-	takesValue bool
-}
-
-func parseFlag(arg string, isTest bool) parsedFlag {
-	rawName, _, hasValue := strings.Cut(arg, "=")
-	name := flagName(rawName)
-	if flagsWithPathValues[name] {
-		return parsedFlag{name: name, hasValue: hasValue, takesValue: true}
-	}
-	if !isTest {
-		return parsedFlag{name: name, hasValue: hasValue, takesValue: false}
-	}
-	if testFlagsWithValues[name] {
-		return parsedFlag{name: name, hasValue: hasValue, takesValue: true}
-	}
-	if suffix, ok := strings.CutPrefix(name, "-test."); ok {
-		if testFlagsWithValues["-"+suffix] {
-			return parsedFlag{name: name, hasValue: hasValue, takesValue: true}
-		}
-	}
-	return parsedFlag{name: name, hasValue: hasValue, takesValue: false}
 }
 
 // getBuildPackages loads all packages from the otelc go build/install or otelc setup command arguments.
@@ -220,7 +113,7 @@ func getBuildPackages(ctx context.Context, subcommand string, args []string) ([]
 	if err != nil {
 		return nil, err
 	}
-	buildFlags := extractBuildFlags(args)
+	buildFlags := extractBuildFlags(subcommand, args)
 
 	var (
 		pkgs    []*packages.Package
@@ -268,31 +161,23 @@ func getBuildPackages(ctx context.Context, subcommand string, args []string) ([]
 
 //nolint:revive // if we add named returns then nonamedreturns will complain
 func splitBuildTargets(subcommand string, args []string) ([]string, []string, error) {
+	classified := classifyArgs(subcommand, args)
 	var pkgs, files []string
-	isTest := subcommand == subcmdTest
 
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-
-		if isTest && isTestDelimiter(arg) {
-			break
-		}
-
-		if strings.HasPrefix(arg, "-") {
-			flag := parseFlag(arg, isTest)
-			if !flag.hasValue && flag.takesValue {
-				if i+1 >= len(args) {
-					return nil, nil, ex.Newf("flag %q requires a value", arg)
-				}
-				i++ // skip this flag's separate value
+	for i, a := range classified {
+		if (a.Kind == ArgBuildFlag || a.Kind == ArgTestFlag) && !a.HasValue && takesValue(a.FlagName) {
+			if i == len(classified)-1 ||
+				(i+1 < len(classified) && classified[i+1].Kind != ArgBuildFlagValue && classified[i+1].Kind != ArgTestFlagValue) {
+				return nil, nil, ex.Newf("flag %q requires a value", a.Raw)
 			}
-			continue
 		}
 
-		if filepath.Ext(arg) == ".go" {
-			files = append(files, arg)
-		} else {
-			pkgs = append(pkgs, arg)
+		if a.Kind == ArgTarget {
+			if filepath.Ext(a.Raw) == ".go" {
+				files = append(files, a.Raw)
+			} else {
+				pkgs = append(pkgs, a.Raw)
+			}
 		}
 	}
 
@@ -412,7 +297,7 @@ func setupLocked(ctx context.Context, cmd *cli.Command) error {
 		// below call it) would still resolve vendor/ paths without an @version;
 		// rewrite it to module mode when vendoring is active so both build phases
 		// agree on where the dependency source lives.
-		args = rewriteModVendor(args)
+		args = rewriteModVendor(subcommand, args)
 	}
 
 	if isSetup() {
@@ -499,28 +384,6 @@ func setupGoCache(ctx context.Context, env []string) ([]string, error) {
 	return env, nil
 }
 
-// buildContextFlagsWithValue are go build flags that take a value and affect the build context.
-//
-//nolint:gochecknoglobals // private lookup table
-var buildContextFlagsWithValue = map[string]bool{
-	"-C":       true, // Change directory before running the command
-	"-overlay": true, // JSON overlay file used by go list/build
-	"-tags":    true, // build tags
-	"-mod":     true, // Module mode (vendor, mod, readonly)
-	"-modfile": true, // Custom go.mod file
-}
-
-// buildContextBoolFlags are go build boolean flags that affect the build context.
-//
-//nolint:gochecknoglobals // private lookup table
-var buildContextBoolFlags = map[string]bool{
-	"-race":     true, // Race detector
-	"-msan":     true, // Memory sanitizer
-	"-cover":    true, // Coverage
-	"-asan":     true, // Address sanitizer
-	"-trimpath": true, // Remove file system paths from compiled archives
-}
-
 // extractBuildFlags extracts flags that affect the build context from the arguments.
 // These flags need to be forwarded to `go list` when resolving import archives.
 // Returns a slice of flag arguments preserving their original form.
@@ -529,7 +392,11 @@ var buildContextBoolFlags = map[string]bool{
 //   - GOFLAGS=-race with -race=false on CLI (result: -race=false)
 //   - -race -race=false (result: -race=false)
 //   - -race=false -race (result: -race)
-func extractBuildFlags(args []string) []string {
+func extractBuildFlags(subcommand string, args []string) []string {
+	if subcommand == "" {
+		subcommand = subcmdBuild
+	}
+	classified := classifyArgs(subcommand, args)
 	var valueFlags []string
 	type boolFlagValue struct {
 		set   bool
@@ -537,50 +404,36 @@ func extractBuildFlags(args []string) []string {
 	}
 	boolFlagState := make(map[string]boolFlagValue) // Track final state of boolean flags
 
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
+	for i, a := range classified {
+		if a.Kind != ArgBuildFlag {
+			continue
+		}
 
-		// Handle -flag=value format
-		if idx := strings.Index(arg, "="); idx > 0 {
-			flagName := arg[:idx]
-			flagValue := arg[idx+1:]
-
-			// Handle value flags (e.g., -tags=foo, -mod=vendor)
-			if buildContextFlagsWithValue[flagName] {
-				valueFlags = append(valueFlags, arg)
-				continue
+		if isBuildContextFlagWithValue(a.FlagName) {
+			if a.HasValue {
+				valueFlags = append(valueFlags, a.Raw)
+			} else if i+1 < len(classified) && classified[i+1].Kind == ArgBuildFlagValue {
+				valueFlags = append(valueFlags, a.Raw, classified[i+1].Raw)
 			}
+			continue
+		}
 
-			// Handle boolean flags in =value format (e.g., -race=true, -race=false)
-			// strconv.ParseBool accepts: 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False
-			if buildContextBoolFlags[flagName] {
-				if enabled, err := strconv.ParseBool(flagValue); err == nil {
-					boolFlagState[flagName] = boolFlagValue{set: true, value: enabled} // Last value wins
+		if isBuildContextBoolFlag(a.FlagName) {
+			if a.HasValue {
+				if enabled, err := strconv.ParseBool(a.Value); err == nil {
+					boolFlagState[a.FlagName] = boolFlagValue{set: true, value: enabled} // Last value wins
 				}
-				// Parse error: ignore invalid value
-				continue
+			} else {
+				boolFlagState[a.FlagName] = boolFlagValue{set: true, value: true}
 			}
-			// Unrecognized -flag=value: skip it
 			continue
-		}
-
-		// Handle boolean flags like -race, -msan, -cover, -asan (implies true)
-		if buildContextBoolFlags[arg] {
-			boolFlagState[arg] = boolFlagValue{set: true, value: true}
-			continue
-		}
-
-		// Handle -flag value format (for flags that take values)
-		if buildContextFlagsWithValue[arg] && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-			valueFlags = append(valueFlags, arg, args[i+1])
-			i++ // Skip the value
 		}
 	}
 
 	// Collect boolean flags that are enabled (in deterministic order)
 	var enabledBoolFlags []string
-	for flag := range buildContextBoolFlags {
-		if state, ok := boolFlagState[flag]; ok && state.set {
+	for flag, state := range boolFlagState {
+		if state.set {
 			if state.value {
 				enabledBoolFlags = append(enabledBoolFlags, flag)
 			} else {
@@ -588,10 +441,8 @@ func extractBuildFlags(args []string) []string {
 			}
 		}
 	}
-	// Sort for deterministic output
 	slices.Sort(enabledBoolFlags)
 
-	// Combine: value flags first, then boolean flags
 	return append(valueFlags, enabledBoolFlags...)
 }
 
@@ -610,7 +461,7 @@ func toolexecBuildArgs(args []string, execPath string, vendored bool) []string {
 	subcommand := args[0]
 	restArgs := args[1:]
 	if vendored {
-		restArgs = rewriteModVendor(restArgs)
+		restArgs = rewriteModVendor(subcommand, restArgs)
 	}
 	if _, fileTargets, err2 := splitBuildTargets(subcommand, restArgs); err2 == nil && len(fileTargets) > 0 {
 		// add otelc.runtime.go manually to command line for file targets
@@ -651,9 +502,11 @@ func buildWithToolexec(ctx context.Context, cmd *cli.Command, vendored bool) err
 
 	// Extract and forward build flags that affect the build context
 	// This ensures `go list` resolves archives matching the current build
-	buildFlags := extractBuildFlags(args)
+	subcommand := args[0]
+	restArgs := args[1:]
+	buildFlags := extractBuildFlags(subcommand, restArgs)
 	if vendored {
-		buildFlags = rewriteModVendor(buildFlags)
+		buildFlags = rewriteModVendor(subcommand, buildFlags)
 	}
 	if len(buildFlags) > 0 {
 		encoded := util.EncodeBuildFlags(buildFlags)

--- a/tool/internal/setup/setup.go
+++ b/tool/internal/setup/setup.go
@@ -142,26 +142,81 @@ const (
 const (
 	// flagArgs separates the go command's own arguments from the ones it
 	// passes through to the test binary.
-	flagArgs = "-args"
+	flagArgs          = "-args"
+	flagArgsDashDash  = "--args"
+	delimiterDashDash = "--"
 	// flagJSON makes the go command report its output as JSON events.
 	flagJSON = "-json"
 )
 
-// GetBuildPackages loads all packages from the otelc go build/install or otelc setup command arguments.
+func isTestDelimiter(arg string) bool {
+	return arg == delimiterDashDash || arg == flagArgs || arg == flagArgsDashDash
+}
+
+func findTestDelimiter(subcommand string, args []string) int {
+	if subcommand != subcmdTest {
+		return -1
+	}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if isTestDelimiter(arg) {
+			return i
+		}
+		if strings.HasPrefix(arg, "-") {
+			flag := parseFlag(arg, true)
+			if !flag.hasValue && flag.takesValue {
+				i++ // skip separated value
+			}
+		}
+	}
+	return -1
+}
+
+// flagName returns the flag name of arg in single-dash form, without a joined
+// value. The go command accepts -flag and --flag interchangeably.
+func flagName(arg string) string {
+	name, _, _ := strings.Cut(arg, "=")
+	if strings.HasPrefix(name, "--") {
+		return name[1:]
+	}
+	return name
+}
+
+type parsedFlag struct {
+	name       string
+	hasValue   bool
+	takesValue bool
+}
+
+func parseFlag(arg string, isTest bool) parsedFlag {
+	rawName, _, hasValue := strings.Cut(arg, "=")
+	name := flagName(rawName)
+	if flagsWithPathValues[name] {
+		return parsedFlag{name: name, hasValue: hasValue, takesValue: true}
+	}
+	if !isTest {
+		return parsedFlag{name: name, hasValue: hasValue, takesValue: false}
+	}
+	if testFlagsWithValues[name] {
+		return parsedFlag{name: name, hasValue: hasValue, takesValue: true}
+	}
+	if suffix, ok := strings.CutPrefix(name, "-test."); ok {
+		if testFlagsWithValues["-"+suffix] {
+			return parsedFlag{name: name, hasValue: hasValue, takesValue: true}
+		}
+	}
+	return parsedFlag{name: name, hasValue: hasValue, takesValue: false}
+}
+
+// getBuildPackages loads all packages from the otelc go build/install or otelc setup command arguments.
 // Returns a list of loaded packages. If no package patterns are found in args,
 // defaults to loading the current directory package.
-// The args parameter should be the go build/install command arguments (e.g., ["-a", "./cmd"]).
 // Returns an error if package loading fails or if invalid patterns are provided.
-// For example:
-//   - args ["-a", "./cmd"] returns packages for "./cmd"
-//   - args ["-a", "cmd"] returns packages for the "cmd" package in the module
-//   - args ["-a", ".", "./cmd"] returns packages for both "." and "./cmd"
-//   - args [] returns packages for "."
-func getBuildPackages(ctx context.Context, args []string) ([]*packages.Package, error) {
+func getBuildPackages(ctx context.Context, subcommand string, args []string) ([]*packages.Package, error) {
 	logger := util.LoggerFromContext(ctx)
 	mode := packages.NeedName | packages.NeedFiles | packages.NeedModule
 
-	pkgTargets, fileTargets, err := splitBuildTargets(args)
+	pkgTargets, fileTargets, err := splitBuildTargets(subcommand, args)
 	if err != nil {
 		return nil, err
 	}
@@ -212,26 +267,20 @@ func getBuildPackages(ctx context.Context, args []string) ([]*packages.Package, 
 }
 
 //nolint:revive // if we add named returns then nonamedreturns will complain
-func splitBuildTargets(args []string) ([]string, []string, error) {
+func splitBuildTargets(subcommand string, args []string) ([]string, []string, error) {
 	var pkgs, files []string
+	isTest := subcommand == subcmdTest
 
-	// Scan forward and classify each argument. Packages and flags may interleave:
-	// `go build` conventionally puts flags first, but `go test` is commonly
-	// invoked as `go test ./pkg -run TestX`, so a position-based scan would miss
-	// the package. A flag in separated form consumes the next argument as its
-	// value (e.g. "-o out", "-run TestX"); skipping it keeps the value from being
-	// mistaken for a package. Joined form ("-tags=x") carries its own value.
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 
-		// Everything after `-args` is passed to the test binary, not the go
-		// command, so it can contain neither packages nor go flags.
-		if arg == flagArgs {
+		if isTest && isTestDelimiter(arg) {
 			break
 		}
 
 		if strings.HasPrefix(arg, "-") {
-			if !strings.Contains(arg, "=") && (flagsWithPathValues[arg] || testFlagsWithValues[arg]) {
+			flag := parseFlag(arg, isTest)
+			if !flag.hasValue && flag.takesValue {
 				if i+1 >= len(args) {
 					return nil, nil, ex.Newf("flag %q requires a value", arg)
 				}
@@ -378,7 +427,7 @@ func setupLocked(ctx context.Context, cmd *cli.Command) error {
 
 	// Introduce additional hook code by generating otelc.runtime.go
 	// Use GetPackage to determine the build target directory
-	pkgs, err := getBuildPackages(ctx, args)
+	pkgs, err := getBuildPackages(ctx, subcommand, args)
 	if err != nil {
 		return err
 	}
@@ -546,6 +595,38 @@ func extractBuildFlags(args []string) []string {
 	return append(valueFlags, enabledBoolFlags...)
 }
 
+func toolexecBuildArgs(args []string, execPath string, vendored bool) []string {
+	insert := "-toolexec=" + execPath + " toolexec"
+	const additionalCount = 2
+	newArgs := make([]string, 0, len(args)+additionalCount) // Avoid in-place modification
+	// Add "go build"
+	newArgs = append(newArgs, "go")
+	newArgs = append(newArgs, args[:1]...)
+	// Add "-work" to give us a chance to debug instrumented code if needed
+	newArgs = append(newArgs, "-work")
+	// Add "-toolexec=..."
+	newArgs = append(newArgs, insert)
+	// Add the rest
+	subcommand := args[0]
+	restArgs := args[1:]
+	if vendored {
+		restArgs = rewriteModVendor(restArgs)
+	}
+	if _, fileTargets, err2 := splitBuildTargets(subcommand, restArgs); err2 == nil && len(fileTargets) > 0 {
+		// add otelc.runtime.go manually to command line for file targets
+		dir := filepath.Dir(fileTargets[0])
+		otelcRuntimePath := filepath.Join(dir, otelcRuntimeFile)
+		if util.PathExists(otelcRuntimePath) {
+			if delimIdx := findTestDelimiter(subcommand, restArgs); delimIdx >= 0 {
+				restArgs = slices.Insert(restArgs, delimIdx, otelcRuntimePath)
+			} else {
+				restArgs = append(restArgs, otelcRuntimePath)
+			}
+		}
+	}
+	return append(newArgs, restArgs...)
+}
+
 // buildWithToolexec builds the project with the toolexec mode. vendored is
 // passed in by GoBuild: Setup already forced GOFLAGS=-mod=mod, but a CLI
 // -mod=vendor beats GOFLAGS, so it still has to be neutralized in the build
@@ -559,30 +640,7 @@ func buildWithToolexec(ctx context.Context, cmd *cli.Command, vendored bool) err
 	if err != nil {
 		return ex.Wrapf(err, "failed to get executable path")
 	}
-	insert := "-toolexec=" + execPath + " toolexec"
-	const additionalCount = 2
-	newArgs := make([]string, 0, len(args)+additionalCount) // Avoid in-place modification
-	// Add "go build"
-	newArgs = append(newArgs, "go")
-	newArgs = append(newArgs, args[:1]...)
-	// Add "-work" to give us a chance to debug instrumented code if needed
-	newArgs = append(newArgs, "-work")
-	// Add "-toolexec=..."
-	newArgs = append(newArgs, insert)
-	// Add the rest
-	restArgs := args[1:]
-	if vendored {
-		restArgs = rewriteModVendor(restArgs)
-	}
-	if _, fileTargets, err2 := splitBuildTargets(restArgs); err2 == nil && len(fileTargets) > 0 {
-		// add otelc.runtime.go manually to command line for file targets
-		dir := filepath.Dir(fileTargets[0])
-		otelcRuntimePath := filepath.Join(dir, otelcRuntimeFile)
-		if util.PathExists(otelcRuntimePath) {
-			restArgs = append(restArgs, otelcRuntimePath)
-		}
-	}
-	newArgs = append(newArgs, restArgs...)
+	newArgs := toolexecBuildArgs(args, execPath, vendored)
 	logger.InfoContext(ctx, "Running go build with toolexec", "args", newArgs)
 
 	// Tell the sub-process the working directory

--- a/tool/internal/setup/setup_test.go
+++ b/tool/internal/setup/setup_test.go
@@ -399,6 +399,20 @@ func TestSplitBuildTargets(t *testing.T) {
 			expectError: true,
 			wantErr:     "cannot mix .go files and packages",
 		},
+		{
+			name:        "go build -- treats dash-prefixed argument as positional target",
+			subcommand:  subcmdBuild,
+			targets:     []string{"--", "-weird-target"},
+			pkgTargets:  []string{"-weird-target"},
+			expectError: false,
+		},
+		{
+			name:        "go install -- treats dash-prefixed argument as positional target",
+			subcommand:  subcmdInstall,
+			targets:     []string{"--", "-weird-target"},
+			pkgTargets:  []string{"-weird-target"},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -456,8 +470,8 @@ func TestSplitBuildTargets(t *testing.T) {
 		}
 	})
 
-	t.Run("boolean and unknown test flags do not consume following argument", func(t *testing.T) {
-		for _, flag := range []string{"-test.v", "--test.v", "-test.short", "-test.unknown"} {
+	t.Run("boolean test flags do not consume following argument", func(t *testing.T) {
+		for _, flag := range []string{"-test.v", "--test.v", "-test.short"} {
 			pkgs, files, err := splitBuildTargets(subcmdTest, []string{flag, "./pkg"})
 			require.NoError(t, err)
 			assert.Equal(t, []string{"./pkg"}, pkgs)
@@ -467,6 +481,46 @@ func TestSplitBuildTargets(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{"./pkg"}, pkgs)
 		assert.Empty(t, files)
+	})
+
+	t.Run("unknown test flags terminate package discovery", func(t *testing.T) {
+		// package before unknown flag is captured; following value is not a package
+		pkgs, files, err := splitBuildTargets(subcmdTest, []string{"./pkg", "-custom", "value"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"./pkg"}, pkgs)
+		assert.Empty(t, files)
+
+		// package before unknown joined flag is captured
+		pkgs, files, err = splitBuildTargets(subcmdTest, []string{"./pkg", "-custom=value"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"./pkg"}, pkgs)
+		assert.Empty(t, files)
+
+		// unknown flag before package closes package discovery: ./pkg is treated as test binary arg
+		pkgs, files, err = splitBuildTargets(subcmdTest, []string{"-custom", "value", "./pkg"})
+		require.NoError(t, err)
+		assert.Empty(t, pkgs)
+		assert.Empty(t, files)
+
+		// unknown joined flag before package closes package discovery
+		pkgs, files, err = splitBuildTargets(subcmdTest, []string{"-custom=value", "./pkg"})
+		require.NoError(t, err)
+		assert.Empty(t, pkgs)
+		assert.Empty(t, files)
+
+		// unknown flag followed by delimiter
+		pkgs, files, err = splitBuildTargets(subcmdTest, []string{"./pkg", "-custom", "--", "./other"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"./pkg"}, pkgs)
+		assert.Empty(t, files)
+
+		// unsupported -test.* aliases are unknown flags and close package discovery
+		for _, flag := range []string{"-test.exec", "-test.vet", "-test.unknown"} {
+			pkgs, files, err = splitBuildTargets(subcmdTest, []string{flag, "val", "./pkg"})
+			require.NoError(t, err)
+			assert.Empty(t, pkgs)
+			assert.Empty(t, files)
+		}
 	})
 
 	t.Run("test delimiters stop target scanning", func(t *testing.T) {
@@ -554,6 +608,23 @@ func TestSplitBuildTargets(t *testing.T) {
 			assert.Empty(t, files)
 		}
 	})
+
+	t.Run(
+		"known flag after package terminates package list and trailing positional becomes test argv",
+		func(t *testing.T) {
+			pkgs, files, err := splitBuildTargets(subcmdTest, []string{"./pkg", "-run", "TestX", "./other"})
+			require.NoError(t, err)
+			assert.Equal(t, []string{"./pkg"}, pkgs)
+			assert.Empty(t, files)
+
+			pkgs, files, err = splitBuildTargets(subcmdTest, []string{
+				"./pkg", "-run", "TestX", "positional", "-race", "-mod=vendor", "-tags=x", "./other",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, []string{"./pkg"}, pkgs)
+			assert.Empty(t, files)
+		},
+	)
 }
 
 func extractPackageIDs(pkgs []*packages.Package) []string {
@@ -680,9 +751,10 @@ func TestSetupGoCache(t *testing.T) {
 
 func TestExtractBuildFlags(t *testing.T) {
 	tests := []struct {
-		name     string
-		args     []string
-		expected []string
+		name       string
+		subcommand string
+		args       []string
+		expected   []string
 	}{
 		{
 			name:     "no build flags",
@@ -845,13 +917,91 @@ func TestExtractBuildFlags(t *testing.T) {
 			args:     []string{"build", "-cover=false", "-tags=foo", "-cover", "./..."},
 			expected: []string{"-tags=foo", "-cover"}, // value flags first, then bool
 		},
+		// go test tail preservation tests
+		{
+			name:       "test delimiter dash-dash ignores tags in tail",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "--", "-tags=integration"},
+			expected:   nil,
+		},
+		{
+			name:       "test delimiter dash-dash ignores race in tail",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "--", "-race"},
+			expected:   nil,
+		},
+		{
+			name:       "test delimiter -args ignores tags in tail",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "-args", "-tags=integration"},
+			expected:   nil,
+		},
+		{
+			name:       "test delimiter --args ignores tags in tail",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "--args", "-tags=integration"},
+			expected:   nil,
+		},
+		// go test flag values resembling build flags
+		{
+			name:       "test flag value -test.run does not extract tags",
+			subcommand: subcmdTest,
+			args:       []string{"-test.run", "-tags=integration", "./pkg"},
+			expected:   nil,
+		},
+		{
+			name:       "test flag value -run does not extract tags",
+			subcommand: subcmdTest,
+			args:       []string{"-run", "-tags=integration", "./pkg"},
+			expected:   nil,
+		},
+		{
+			name:       "genuine build flags in go test are extracted",
+			subcommand: subcmdTest,
+			args:       []string{"-tags=integration", "./pkg"},
+			expected:   []string{"-tags=integration"},
+		},
+		{
+			name:       "genuine separated build flags in go test are extracted",
+			subcommand: subcmdTest,
+			args:       []string{"-tags", "integration", "./pkg"},
+			expected:   []string{"-tags", "integration"},
+		},
+		{
+			name:       "genuine bool build flag in go test is extracted",
+			subcommand: subcmdTest,
+			args:       []string{"-race", "./pkg"},
+			expected:   []string{"-race"},
+		},
+		{
+			name:       "test-binary positional tail ignores subsequent build-looking flags",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "-run", "TestX", "positional", "-tags=integration"},
+			expected:   nil,
+		},
+		{
+			name:       "test-binary positional tail ignores build and boolean flags",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "-run", "TestX", "positional", "-race", "-mod=vendor", "-tags=x", "./other"},
+			expected:   nil,
+		},
+		{
+			name:       "joined unknown flag followed by positional ignores build flags",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "-custom=x", "positional", "-mod=vendor"},
+			expected:   nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := extractBuildFlags(tt.args)
+			subcmd := tt.subcommand
+			if subcmd == "" {
+				subcmd = subcmdBuild
+			}
+			result := extractBuildFlags(subcmd, tt.args)
 			if !slices.Equal(result, tt.expected) {
-				t.Errorf("extractBuildFlags(%v) = %v, expected %v", tt.args, result, tt.expected)
+				t.Errorf("extractBuildFlags(%q, %v) = %v, expected %v", subcmd, tt.args, result, tt.expected)
 			}
 		})
 	}

--- a/tool/internal/setup/setup_test.go
+++ b/tool/internal/setup/setup_test.go
@@ -39,6 +39,175 @@ func TestGoBuild_RejectsUnsupportedSubcommand(t *testing.T) {
 	}
 }
 
+func TestToolexecBuildArgs(t *testing.T) {
+	t.Run("inserts -work and the -toolexec ahead of the caller's args", func(t *testing.T) {
+		got := toolexecBuildArgs([]string{"build", "-o", "app", "./cmd"}, "/opt/my tools/otelc", false)
+		assert.Equal(t, []string{
+			"go", "build", "-work",
+			"-toolexec=/opt/my tools/otelc toolexec",
+			"-o", "app", "./cmd",
+		}, got)
+	})
+
+	t.Run("neutralizes -mod=vendor when vendored", func(t *testing.T) {
+		got := toolexecBuildArgs([]string{"build", "-mod=vendor", "."}, "/usr/bin/otelc", true)
+		assert.NotContains(t, got, "-mod=vendor")
+	})
+
+	t.Run("adds the generated runtime file for file targets", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, otelcRuntimeFile), []byte("package main\n"), 0o644))
+
+		got := toolexecBuildArgs([]string{"build", "main.go"}, "/usr/bin/otelc", false)
+		assert.Contains(t, got, otelcRuntimeFile)
+	})
+
+	t.Run("go test inserts runtime file before -- delimiter", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "main_test.go"), []byte("package main\n"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, otelcRuntimeFile), []byte("package main\n"), 0o644))
+
+		got := toolexecBuildArgs(
+			[]string{"test", "main.go", "main_test.go", "--", "custom.go"},
+			"/usr/bin/otelc",
+			false,
+		)
+		delimIdx := slices.Index(got, "--")
+		require.Positive(t, delimIdx)
+		runtimeIdx := slices.Index(got, otelcRuntimeFile)
+		require.Positive(t, runtimeIdx)
+		assert.Equal(t, delimIdx-1, runtimeIdx, "runtime file must appear immediately before --")
+	})
+
+	t.Run("go test inserts runtime file before -args delimiter", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, otelcRuntimeFile), []byte("package main\n"), 0o644))
+
+		got := toolexecBuildArgs([]string{"test", "main.go", "-args", "custom.go"}, "/usr/bin/otelc", false)
+		delimIdx := slices.Index(got, "-args")
+		require.Positive(t, delimIdx)
+		runtimeIdx := slices.Index(got, otelcRuntimeFile)
+		require.Positive(t, runtimeIdx)
+		assert.Equal(t, delimIdx-1, runtimeIdx, "runtime file must appear immediately before -args")
+	})
+
+	t.Run("go test inserts runtime file before --args delimiter", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, otelcRuntimeFile), []byte("package main\n"), 0o644))
+
+		got := toolexecBuildArgs([]string{"test", "main.go", "--args", "custom.go"}, "/usr/bin/otelc", false)
+		delimIdx := slices.Index(got, "--args")
+		require.Positive(t, delimIdx)
+		runtimeIdx := slices.Index(got, otelcRuntimeFile)
+		require.Positive(t, runtimeIdx)
+		assert.Equal(t, delimIdx-1, runtimeIdx, "runtime file must appear immediately before --args")
+	})
+
+	t.Run("go test does not inject runtime file for .go files after delimiters", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "custom.go"), []byte("package main\n"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, otelcRuntimeFile), []byte("package main\n"), 0o644))
+
+		for _, delim := range []string{"--", "-args", "--args"} {
+			got := toolexecBuildArgs([]string{"test", delim, "custom.go"}, "/usr/bin/otelc", false)
+			assert.NotContains(
+				t,
+				got,
+				otelcRuntimeFile,
+				"no runtime file should be injected when .go file is after %s",
+				delim,
+			)
+		}
+	})
+
+	t.Run("go build preserves existing delimiter and appends runtime file at end", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, otelcRuntimeFile), []byte("package main\n"), 0o644))
+
+		got := toolexecBuildArgs([]string{"build", "--", "main.go"}, "/usr/bin/otelc", false)
+		delimIdx := slices.Index(got, "--")
+		require.Positive(t, delimIdx)
+		runtimeIdx := slices.Index(got, otelcRuntimeFile)
+		require.Positive(t, runtimeIdx)
+		assert.Greater(t, runtimeIdx, delimIdx, "runtime file should be appended at end for go build --")
+	})
+
+	t.Run("go test preserves delimiter-like flag values", func(t *testing.T) {
+		for _, val := range []string{"--", "-args", "--args"} {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			require.NoError(t, os.WriteFile(
+				filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(dir, "main_test.go"), []byte("package main\n"), 0o644))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(dir, otelcRuntimeFile), []byte("package main\n"), 0o644))
+
+			got := toolexecBuildArgs(
+				[]string{"test", "main.go", "main_test.go", "-test.run", val},
+				"/usr/bin/otelc",
+				false,
+			)
+			runIdx := slices.Index(got, "-test.run")
+			require.Positive(t, runIdx)
+			require.Equal(t, val, got[runIdx+1], "flag value must immediately follow flag")
+
+			gotWithDelim := toolexecBuildArgs(
+				[]string{"test", "main.go", "main_test.go", "-test.run", val, "--", "custom.go"},
+				"/usr/bin/otelc",
+				false,
+			)
+			runIdx = slices.Index(gotWithDelim, "-test.run")
+			require.Positive(t, runIdx)
+			require.Equal(t, val, gotWithDelim[runIdx+1], "flag value must immediately follow flag")
+			realDelimIdx := slices.Index(gotWithDelim[runIdx+2:], "--") + runIdx + 2
+			runtimeIdx := slices.Index(gotWithDelim, otelcRuntimeFile)
+			require.Positive(t, runtimeIdx)
+			assert.Equal(t, realDelimIdx-1, runtimeIdx, "runtime file must appear before the real delimiter")
+		}
+	})
+}
+
+func TestFindTestDelimiter(t *testing.T) {
+	assert.Equal(t, -1, findTestDelimiter(subcmdBuild, []string{"--", "main.go"}))
+	assert.Equal(t, 1, findTestDelimiter(subcmdTest, []string{"./pkg", "--", "custom"}))
+	assert.Equal(t, 1, findTestDelimiter(subcmdTest, []string{"./pkg", "-args", "custom"}))
+	assert.Equal(t, 1, findTestDelimiter(subcmdTest, []string{"./pkg", "--args", "custom"}))
+
+	for _, delim := range []string{"--", "-args", "--args"} {
+		assert.Equal(t, -1, findTestDelimiter(subcmdTest, []string{"-test.run", delim, "./pkg"}))
+		assert.Equal(t, -1, findTestDelimiter(subcmdTest, []string{"--test.run", delim, "./pkg"}))
+		assert.Equal(t, -1, findTestDelimiter(subcmdTest, []string{"-run", delim, "./pkg"}))
+		assert.Equal(t, 2, findTestDelimiter(subcmdTest, []string{"-test.run", delim, "--", "./pkg"}))
+		assert.Equal(t, 2, findTestDelimiter(subcmdTest, []string{"-test.run", delim, "-args", "./pkg"}))
+		assert.Equal(t, 2, findTestDelimiter(subcmdTest, []string{"-test.run", delim, "--args", "./pkg"}))
+	}
+}
+
 func TestGetPackages(t *testing.T) {
 	setupTestModule(t, []string{"cmd", "foo/demo"})
 
@@ -109,7 +278,7 @@ func TestGetPackages(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pkgs, err := getBuildPackages(t.Context(), tt.args)
+			pkgs, err := getBuildPackages(t.Context(), subcmdBuild, tt.args)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {
@@ -141,7 +310,7 @@ func TestGetPackagesWithChangeDirectoryFlag(t *testing.T) {
 	))
 	t.Chdir(tmpDir)
 
-	pkgs, err := getBuildPackages(t.Context(), []string{"-C", "app", "."})
+	pkgs, err := getBuildPackages(t.Context(), subcmdBuild, []string{"-C", "app", "."})
 	require.NoError(t, err)
 	require.Len(t, pkgs, 1)
 	require.NotNil(t, pkgs[0].Module)
@@ -150,16 +319,17 @@ func TestGetPackagesWithChangeDirectoryFlag(t *testing.T) {
 
 func TestSplitBuildTargets(t *testing.T) {
 	tests := []struct {
-		name          string
-		targets       []string
-		pkgTargets    []string
-		fileTargets   []string
-		notPkgTargets []string // must NOT be parsed as packages (e.g. flag values)
-		expectError   bool
-		wantErr       string
+		name        string
+		subcommand  string
+		targets     []string
+		pkgTargets  []string
+		fileTargets []string
+		expectError bool
+		wantErr     string
 	}{
 		{
 			name:        "all package targets",
+			subcommand:  subcmdBuild,
 			targets:     []string{"./cmd", "./foo/demo"},
 			pkgTargets:  []string{"./cmd", "./foo/demo"},
 			fileTargets: nil,
@@ -167,110 +337,73 @@ func TestSplitBuildTargets(t *testing.T) {
 		},
 		{
 			name:        "all file targets",
+			subcommand:  subcmdBuild,
 			targets:     []string{"./cmd/main.go", "./cmd/util.go"},
 			pkgTargets:  nil,
 			fileTargets: []string{"./cmd/main.go", "./cmd/util.go"},
 			expectError: false,
 		},
 		{
-			name:        "all file targets from different packages",
+			name:        "all file targets from different directories fails",
+			subcommand:  subcmdBuild,
 			targets:     []string{"./cmd/main.go", "./util/util.go"},
-			pkgTargets:  nil,
-			fileTargets: nil,
 			expectError: true,
+			wantErr:     "named files must all be in one directory",
 		},
 		{
-			name:        "mixed package and file targets with valid package",
+			name:        "mixed package and file targets fails",
+			subcommand:  subcmdBuild,
 			targets:     []string{"./cmd/main.go", "./foo/demo"},
-			pkgTargets:  nil,
-			fileTargets: nil,
 			expectError: true,
+			wantErr:     "cannot mix .go files and packages",
 		},
 		{
-			name:          "go test -run value is not a package",
-			targets:       []string{"-run", "TestX", "./pkg"},
-			pkgTargets:    []string{"./pkg"},
-			notPkgTargets: []string{"TestX"},
-			expectError:   false,
+			name:        "go build -o flag requires a value",
+			subcommand:  subcmdBuild,
+			targets:     []string{"./pkg", "-o"},
+			expectError: true,
+			wantErr:     `flag "-o" requires a value`,
 		},
 		{
-			name:        "go test joined -count=1 leaves package",
-			targets:     []string{"-count=1", "./pkg"},
+			name:        "go build -- does not stop file scanning",
+			subcommand:  subcmdBuild,
+			targets:     []string{"--", "main.go"},
+			fileTargets: []string{"main.go"},
+			expectError: false,
+		},
+		{
+			name:        "go build -- does not stop package scanning",
+			subcommand:  subcmdBuild,
+			targets:     []string{"--", "./pkg"},
 			pkgTargets:  []string{"./pkg"},
 			expectError: false,
 		},
 		{
-			name:          "go test -run value with no package target",
-			targets:       []string{"-run", "TestX"},
-			pkgTargets:    nil,
-			notPkgTargets: []string{"TestX"},
-			expectError:   false,
+			name:        "go build -o out -- ./pkg preserves package",
+			subcommand:  subcmdBuild,
+			targets:     []string{"-o", "out", "--", "./pkg"},
+			pkgTargets:  []string{"./pkg"},
+			expectError: false,
 		},
 		{
-			name:          "go test package before -run flag",
-			targets:       []string{"./pkg", "-run", "TestX"},
-			pkgTargets:    []string{"./pkg"},
-			notPkgTargets: []string{"TestX"},
-			expectError:   false,
+			name:        "go build main.go -- other.go scans both files",
+			subcommand:  subcmdBuild,
+			targets:     []string{"main.go", "--", "other.go"},
+			fileTargets: []string{"main.go", "other.go"},
+			expectError: false,
 		},
 		{
-			name:          "go test package before joined -count",
-			targets:       []string{"./...", "-count=1"},
-			pkgTargets:    []string{"./..."},
-			notPkgTargets: []string{"-count=1"},
-			expectError:   false,
-		},
-		{
-			name:          "go test -args tail is not a package",
-			targets:       []string{"./pkg", "-args", "serverarg"},
-			pkgTargets:    []string{"./pkg"},
-			notPkgTargets: []string{"serverarg"},
-			expectError:   false,
-		},
-		{
-			name:          "go test -vet value is not a package",
-			targets:       []string{"-vet", "off", "./pkg"},
-			pkgTargets:    []string{"./pkg"},
-			notPkgTargets: []string{"off"},
-			expectError:   false,
-		},
-		{
-			name:          "go test -exec value is not a package",
-			targets:       []string{"-exec", "sudo", "./pkg"},
-			pkgTargets:    []string{"./pkg"},
-			notPkgTargets: []string{"sudo"},
-			expectError:   false,
-		},
-		{
-			name:          "go test package before -exec flag",
-			targets:       []string{"./pkg", "-exec", "sudo"},
-			pkgTargets:    []string{"./pkg"},
-			notPkgTargets: []string{"sudo"},
-			expectError:   false,
-		},
-		{
-			name:        "go test -run flag requires a value",
-			targets:     []string{"-run"},
+			name:        "go build -- cannot mix package and file",
+			subcommand:  subcmdBuild,
+			targets:     []string{"./pkg", "--", "main.go"},
 			expectError: true,
-			wantErr:     `flag "-run" requires a value`,
-		},
-		{
-			name:        "go test -exec flag requires a value",
-			targets:     []string{"./pkg", "-exec"},
-			expectError: true,
-			wantErr:     `flag "-exec" requires a value`,
-		},
-		{
-			name:        "go build -o flag requires a value",
-			targets:     []string{"./pkg", "-o"},
-			expectError: true,
-			wantErr:     `flag "-o" requires a value`,
+			wantErr:     "cannot mix .go files and packages",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pkgTargets, fileTargets, err := splitBuildTargets(tt.targets)
+			pkgTargets, fileTargets, err := splitBuildTargets(tt.subcommand, tt.targets)
 			if tt.expectError {
 				require.Error(t, err)
 				if tt.wantErr != "" {
@@ -279,20 +412,148 @@ func TestSplitBuildTargets(t *testing.T) {
 				assert.Nil(t, pkgTargets)
 				assert.Nil(t, fileTargets)
 			} else {
-				assert.NoError(t, err)
-				for _, exp := range tt.pkgTargets {
-					assert.Contains(t, pkgTargets, exp, "Expected package target %q not found in %v", exp, pkgTargets)
-				}
-				for _, exp := range tt.fileTargets {
-					assert.Contains(t, fileTargets, exp, "Expected file target %q not found in %v", exp, fileTargets)
-				}
-				for _, notExp := range tt.notPkgTargets {
-					assert.NotContains(t, pkgTargets, notExp,
-						"Flag value %q must not be parsed as a package (got %v)", notExp, pkgTargets)
-				}
+				require.NoError(t, err)
+				assert.Equal(t, tt.pkgTargets, pkgTargets)
+				assert.Equal(t, tt.fileTargets, fileTargets)
 			}
 		})
 	}
+
+	t.Run("flags requiring values fail when value is missing", func(t *testing.T) {
+		for _, flag := range []string{
+			"-run", "-exec", "-test.run", "--test.run",
+			"-test.timeout", "-test.bench", "-test.count",
+		} {
+			_, _, err := splitBuildTargets(subcmdTest, []string{flag})
+			require.ErrorContains(t, err, "requires a value")
+		}
+	})
+
+	t.Run("supported test flags do not consume packages", func(t *testing.T) {
+		flags := []string{
+			"-run", "--run", "-test.run", "--test.run",
+			"-test.bench", "-test.timeout", "-test.count",
+			"-test.cpu", "-test.benchtime", "-vet", "-exec",
+		}
+		for _, flag := range flags {
+			// separated flag value before package
+			pkgs, files, err := splitBuildTargets(subcmdTest, []string{flag, "val", "./pkg"})
+			require.NoError(t, err)
+			assert.Equal(t, []string{"./pkg"}, pkgs)
+			assert.Empty(t, files)
+
+			// joined flag value before package
+			pkgs, files, err = splitBuildTargets(subcmdTest, []string{flag + "=val", "./pkg"})
+			require.NoError(t, err)
+			assert.Equal(t, []string{"./pkg"}, pkgs)
+			assert.Empty(t, files)
+
+			// package before separated flag
+			pkgs, files, err = splitBuildTargets(subcmdTest, []string{"./pkg", flag, "val"})
+			require.NoError(t, err)
+			assert.Equal(t, []string{"./pkg"}, pkgs)
+			assert.Empty(t, files)
+		}
+	})
+
+	t.Run("boolean and unknown test flags do not consume following argument", func(t *testing.T) {
+		for _, flag := range []string{"-test.v", "--test.v", "-test.short", "-test.unknown"} {
+			pkgs, files, err := splitBuildTargets(subcmdTest, []string{flag, "./pkg"})
+			require.NoError(t, err)
+			assert.Equal(t, []string{"./pkg"}, pkgs)
+			assert.Empty(t, files)
+		}
+		pkgs, files, err := splitBuildTargets(subcmdTest, []string{"-test.v=true", "./pkg"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"./pkg"}, pkgs)
+		assert.Empty(t, files)
+	})
+
+	t.Run("test delimiters stop target scanning", func(t *testing.T) {
+		delims := []string{"--", "-args", "--args"}
+		for _, delim := range delims {
+			// package before delimiter, test-binary args after
+			pkgs, files, err := splitBuildTargets(subcmdTest, []string{
+				"./pkg", delim, "other", "./other/pkg", "foo.go", "-test.run", "val",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, []string{"./pkg"}, pkgs)
+			assert.Empty(t, files)
+
+			// no explicit package before delimiter
+			pkgs, files, err = splitBuildTargets(subcmdTest, []string{delim, "custom", "foo.go"})
+			require.NoError(t, err)
+			assert.Empty(t, pkgs)
+			assert.Empty(t, files)
+
+			// empty delimiter alone
+			pkgs, files, err = splitBuildTargets(subcmdTest, []string{delim})
+			require.NoError(t, err)
+			assert.Empty(t, pkgs)
+			assert.Empty(t, files)
+
+			// files before delimiter, extra after
+			pkgs, files, err = splitBuildTargets(subcmdTest, []string{
+				"./cmd/main.go", "./cmd/util.go", delim, "extra.go",
+			})
+			require.NoError(t, err)
+			assert.Empty(t, pkgs)
+			assert.Equal(t, []string{"./cmd/main.go", "./cmd/util.go"}, files)
+
+			// package before, file after succeeds (not mixed)
+			pkgs, files, err = splitBuildTargets(subcmdTest, []string{"./pkg", delim, "main.go"})
+			require.NoError(t, err)
+			assert.Equal(t, []string{"./pkg"}, pkgs)
+			assert.Empty(t, files)
+
+			// file before, package after succeeds (not mixed)
+			pkgs, files, err = splitBuildTargets(subcmdTest, []string{"./cmd/main.go", delim, "./pkg"})
+			require.NoError(t, err)
+			assert.Empty(t, pkgs)
+			assert.Equal(t, []string{"./cmd/main.go"}, files)
+
+			// file before, file in different directory after succeeds
+			pkgs, files, err = splitBuildTargets(subcmdTest, []string{
+				"./cmd/main.go", delim, "./util/util.go",
+			})
+			require.NoError(t, err)
+			assert.Empty(t, pkgs)
+			assert.Equal(t, []string{"./cmd/main.go"}, files)
+		}
+
+		// mixed package and file before delimiter still fails
+		_, _, err := splitBuildTargets(subcmdTest, []string{
+			"./cmd/main.go", "./pkg", "--", "custom",
+		})
+		require.ErrorContains(t, err, "cannot mix .go files and packages")
+
+		// multiple file targets in different dirs before delimiter still fails
+		_, _, err = splitBuildTargets(subcmdTest, []string{
+			"./cmd/main.go", "./util/util.go", "--", "custom",
+		})
+		require.ErrorContains(t, err, "named files must all be in one directory")
+	})
+
+	t.Run("repeated delimiters and delimiter flag values", func(t *testing.T) {
+		for _, delim1 := range []string{"--", "-args", "--args"} {
+			for _, delim2 := range []string{"--", "-args", "--args"} {
+				pkgs, files, err := splitBuildTargets(subcmdTest, []string{
+					"./pkg", delim1, delim2, "custom",
+				})
+				require.NoError(t, err)
+				assert.Equal(t, []string{"./pkg"}, pkgs)
+				assert.Empty(t, files)
+			}
+		}
+
+		// delimiter used as flag value does not stop scanning
+		for _, val := range []string{"--", "-args", "--args"} {
+			pkgs, files, err := splitBuildTargets(subcmdTest, []string{"-test.run", val, "./pkg"})
+			require.NoError(t, err)
+			assert.Equal(t, []string{"./pkg"}, pkgs)
+			assert.Empty(t, files)
+		}
+	})
 }
 
 func extractPackageIDs(pkgs []*packages.Package) []string {
@@ -628,15 +889,15 @@ func TestGetBuildPackages_LoadErrors(t *testing.T) {
 	nonExistentDir := filepath.Join(t.TempDir(), "nonexistent")
 
 	// File targets with non-existent -C flag
-	_, err := getBuildPackages(ctx, []string{"-C", nonExistentDir, "main.go"})
+	_, err := getBuildPackages(ctx, subcmdBuild, []string{"-C", nonExistentDir, "main.go"})
 	require.Error(t, err)
 
 	// Package targets with non-existent -C flag
-	_, err = getBuildPackages(ctx, []string{"-C", nonExistentDir, "./pkg"})
+	_, err = getBuildPackages(ctx, subcmdBuild, []string{"-C", nonExistentDir, "./pkg"})
 	require.Error(t, err)
 
 	// Default targets with non-existent -C flag
-	_, err = getBuildPackages(ctx, []string{"-C", nonExistentDir})
+	_, err = getBuildPackages(ctx, subcmdBuild, []string{"-C", nonExistentDir})
 	require.Error(t, err)
 }
 

--- a/tool/internal/setup/vendor.go
+++ b/tool/internal/setup/vendor.go
@@ -95,16 +95,23 @@ func forceModMod(goflags string) string {
 // rewritten to module mode, leaving -mod=readonly and -mod=mod untouched. A
 // CLI flag beats GOFLAGS, so this neutralizes a vendor selection that setting
 // GOFLAGS alone cannot override.
-func rewriteModVendor(args []string) []string {
+// Only actual Go build flags are rewritten; test-binary arguments and test flag
+// values are preserved untouched.
+func rewriteModVendor(subcommand string, args []string) []string {
+	if subcommand == "" {
+		subcommand = subcmdBuild
+	}
+	classified := classifyArgs(subcommand, args)
 	out := make([]string, len(args))
 	copy(out, args)
-	for i := 0; i < len(out); i++ {
-		switch {
-		case isModVendorToken(out[i]):
-			out[i] = modMod
-		case isModFlag(out[i]) && i+1 < len(out) && out[i+1] == vendorDirName:
-			out[i+1] = "mod"
-			i++
+
+	for i, a := range classified {
+		if a.Kind == ArgBuildFlag && a.FlagName == flagMod {
+			if a.HasValue && isModVendorToken(a.Raw) {
+				out[a.Index] = modMod
+			} else if !a.HasValue && i+1 < len(classified) && classified[i+1].Kind == ArgBuildFlagValue && classified[i+1].Raw == vendorDirName {
+				out[classified[i+1].Index] = "mod"
+			}
 		}
 	}
 	return out

--- a/tool/internal/setup/vendor_test.go
+++ b/tool/internal/setup/vendor_test.go
@@ -105,48 +105,165 @@ func TestForceModMod(t *testing.T) {
 
 func TestRewriteModVendor(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
-		want []string
+		name       string
+		subcommand string
+		args       []string
+		want       []string
 	}{
-		{"vendor single token", []string{"build", "-mod=vendor", "./..."}, []string{"build", "-mod=mod", "./..."}},
-		{"vendor two token", []string{"build", "-mod", "vendor", "./..."}, []string{"build", "-mod", "mod", "./..."}},
 		{
-			"readonly untouched",
-			[]string{"build", "-mod=readonly", "./..."},
-			[]string{"build", "-mod=readonly", "./..."},
+			name:       "vendor single token",
+			subcommand: subcmdBuild,
+			args:       []string{"build", "-mod=vendor", "./..."},
+			want:       []string{"build", "-mod=mod", "./..."},
 		},
-		{"mod untouched", []string{"build", "-mod=mod", "./..."}, []string{"build", "-mod=mod", "./..."}},
-		{"no mod flag", []string{"build", "-race", "./..."}, []string{"build", "-race", "./..."}},
-		// -mod as the last arg: the two-token branch must not index past the end.
-		{"bare mod as last arg", []string{"build", "-mod"}, []string{"build", "-mod"}},
 		{
-			"multiple occurrences all rewritten",
-			[]string{"build", "-mod=vendor", "-o", "x", "-mod", "vendor"},
-			[]string{"build", "-mod=mod", "-o", "x", "-mod", "mod"},
+			name:       "vendor two token",
+			subcommand: subcmdBuild,
+			args:       []string{"build", "-mod", "vendor", "./..."},
+			want:       []string{"build", "-mod", "mod", "./..."},
+		},
+		{
+			name:       "readonly untouched",
+			subcommand: subcmdBuild,
+			args:       []string{"build", "-mod=readonly", "./..."},
+			want:       []string{"build", "-mod=readonly", "./..."},
+		},
+		{
+			name:       "mod untouched",
+			subcommand: subcmdBuild,
+			args:       []string{"build", "-mod=mod", "./..."},
+			want:       []string{"build", "-mod=mod", "./..."},
+		},
+		{
+			name:       "no mod flag",
+			subcommand: subcmdBuild,
+			args:       []string{"build", "-race", "./..."},
+			want:       []string{"build", "-race", "./..."},
+		},
+		// -mod as the last arg: the two-token branch must not index past the end.
+		{
+			name:       "bare mod as last arg",
+			subcommand: subcmdBuild,
+			args:       []string{"build", "-mod"},
+			want:       []string{"build", "-mod"},
+		},
+		{
+			name:       "multiple occurrences all rewritten",
+			subcommand: subcmdBuild,
+			args:       []string{"build", "-mod=vendor", "-o", "x", "-mod", "vendor"},
+			want:       []string{"build", "-mod=mod", "-o", "x", "-mod", "mod"},
 		},
 		// A positional "vendor" not preceded by -mod is a build target, not a flag.
-		{"positional vendor left alone", []string{"build", "vendor"}, []string{"build", "vendor"}},
+		{
+			name:       "positional vendor left alone",
+			subcommand: subcmdBuild,
+			args:       []string{"build", "vendor"},
+			want:       []string{"build", "vendor"},
+		},
 		// Go's flag parser treats the double-dash form the same as single-dash.
 		{
-			"double-dash vendor single token",
-			[]string{"build", "--mod=vendor", "./..."},
-			[]string{"build", "-mod=mod", "./..."},
+			name:       "double-dash vendor single token",
+			subcommand: subcmdBuild,
+			args:       []string{"build", "--mod=vendor", "./..."},
+			want:       []string{"build", "-mod=mod", "./..."},
 		},
 		{
-			"double-dash vendor two token",
-			[]string{"build", "--mod", "vendor", "./..."},
-			[]string{"build", "--mod", "mod", "./..."},
+			name:       "double-dash vendor two token",
+			subcommand: subcmdBuild,
+			args:       []string{"build", "--mod", "vendor", "./..."},
+			want:       []string{"build", "--mod", "mod", "./..."},
 		},
 		{
-			"double-dash readonly untouched",
-			[]string{"build", "--mod=readonly", "./..."},
-			[]string{"build", "--mod=readonly", "./..."},
+			name:       "double-dash readonly untouched",
+			subcommand: subcmdBuild,
+			args:       []string{"build", "--mod=readonly", "./..."},
+			want:       []string{"build", "--mod=readonly", "./..."},
+		},
+		// Test-binary arguments after delimiters must never be mutated
+		{
+			name:       "test delimiter dash-dash preserves -mod=vendor tail",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "--", "-mod=vendor"},
+			want:       []string{"./pkg", "--", "-mod=vendor"},
+		},
+		{
+			name:       "test delimiter -args preserves -mod=vendor tail",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "-args", "-mod=vendor"},
+			want:       []string{"./pkg", "-args", "-mod=vendor"},
+		},
+		{
+			name:       "test delimiter --args preserves -mod=vendor tail",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "--args", "-mod=vendor"},
+			want:       []string{"./pkg", "--args", "-mod=vendor"},
+		},
+		{
+			name:       "test delimiter dash-dash preserves -mod vendor two-token tail",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "--", "-mod", "vendor"},
+			want:       []string{"./pkg", "--", "-mod", "vendor"},
+		},
+		// Test flag values that resemble build flags must never be mutated
+		{
+			name:       "test flag value -test.run preserves -mod=vendor",
+			subcommand: subcmdTest,
+			args:       []string{"-test.run", "-mod=vendor", "./pkg"},
+			want:       []string{"-test.run", "-mod=vendor", "./pkg"},
+		},
+		{
+			name:       "test flag value -run preserves -mod=vendor",
+			subcommand: subcmdTest,
+			args:       []string{"-run", "-mod=vendor", "./pkg"},
+			want:       []string{"-run", "-mod=vendor", "./pkg"},
+		},
+		// Real build flags in go test must be rewritten
+		{
+			name:       "genuine build flag in go test is rewritten",
+			subcommand: subcmdTest,
+			args:       []string{"-mod=vendor", "./pkg"},
+			want:       []string{"-mod=mod", "./pkg"},
+		},
+		{
+			name:       "genuine two-token build flag in go test is rewritten",
+			subcommand: subcmdTest,
+			args:       []string{"-mod", "vendor", "./pkg"},
+			want:       []string{"-mod", "mod", "./pkg"},
+		},
+		// Unknown test flag value is preserved
+		{
+			name:       "unknown test flag value preserves -mod=vendor",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "-custom=-mod=vendor"},
+			want:       []string{"./pkg", "-custom=-mod=vendor"},
+		},
+		// Positional test-argv boundary preserves -mod=vendor
+		{
+			name:       "positional test arg preserves -mod=vendor",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "-run", "TestX", "positional", "-mod=vendor"},
+			want:       []string{"./pkg", "-run", "TestX", "positional", "-mod=vendor"},
+		},
+		{
+			name:       "joined unknown flag followed by positional preserves -mod=vendor",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "-custom=x", "positional", "-mod=vendor"},
+			want:       []string{"./pkg", "-custom=x", "positional", "-mod=vendor"},
+		},
+		{
+			name:       "definitive positional tail preserves -mod=vendor",
+			subcommand: subcmdTest,
+			args:       []string{"./pkg", "-run", "TestX", "positional", "-race", "-mod=vendor", "-tags=x", "./other"},
+			want:       []string{"./pkg", "-run", "TestX", "positional", "-race", "-mod=vendor", "-tags=x", "./other"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, rewriteModVendor(tt.args))
+			subcmd := tt.subcommand
+			if subcmd == "" {
+				subcmd = subcmdBuild
+			}
+			assert.Equal(t, tt.want, rewriteModVendor(subcmd, tt.args))
 		})
 	}
 }


### PR DESCRIPTION
## Description

* Unify command-line argument parsing into a shared classifier (`classifyArgs`) across target discovery, build-flag extraction, build-plan handling, and vendoring rewrites.
* Align `go test` argument handling with `cmd/go`:

  * Keep package discovery open across recognized Go/test flags, so package targets can appear on both sides of flags like `-run`.
  * Unknown/custom flags close package discovery, while unjoined unknown flags still associate their following value correctly.
  * Recognize supported `-test.*` flags and their values without mistaking them for package targets or delimiters.
  * Handle `--`, `-args`, and `--args` as test-binary boundaries without treating delimiter-like flag values as actual delimiters.
* Keep test-binary arguments isolated so flags such as `-tags` or `-mod=vendor` after the test boundary do not leak into build-context extraction or vendoring rewrites.
* Preserve `go build` / `go install` `--` behavior, where `--` stops flag parsing and the remaining arguments are treated as targets.
* Ensure generated `otelc.runtime.go` is inserted before the test-argument delimiter for file-based `go test` invocations.
* Pass the active subcommand through setup/pinning paths so argument handling stays consistent across build, install, and test flows.

## Motivation

When running `go test`, package arguments, Go/test flags, and arguments intended for the test binary can be interspersed in ways that the previous parsing logic did not handle consistently.

This could cause flag values to be treated as package targets, `--` to be missed as a test delimiter, package targets after recognized flags to be skipped, or test-binary arguments such as `-tags` / `-mod=vendor` to leak into setup and build handling.

The parsing logic was also spread across target discovery, build-flag extraction, build-plan generation, and vendoring rewrites. Using a shared classifier keeps these paths consistent and avoids fixing the same argument-boundary cases independently in multiple places.

Fixes #1346
