### PR TITLE
refactor(tool): use []string instead of map for module directories

### DIFF
--- a/tool/internal/pkgload/pkgload.go
+++ b/tool/internal/pkgload/pkgload.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"golang.org/x/tools/go/packages"
@@ -216,10 +217,11 @@ func resolveModuleDir(ctx context.Context, pkgDir string) (string, error) {
 	return mod.Dir, nil
 }
 
-func FindModuleDirs(ctx context.Context, pkgs []*packages.Package) (map[string]bool, error) {
+func FindModuleDirs(ctx context.Context, pkgs []*packages.Package) ([]string, error) {
 	logger := util.LoggerFromContext(ctx)
 
-	moduleDirs := make(map[string]bool)
+	seen := make(map[string]struct{})
+	moduleDirs := make([]string, 0)
 	for _, pkg := range pkgs {
 		// file-based builds use synthetic "command-line-arguments" packages
 		if pkg.Module == nil && pkg.PkgPath != CommandLineArgumentsPackage {
@@ -245,8 +247,12 @@ func FindModuleDirs(ctx context.Context, pkgs []*packages.Package) (map[string]b
 			moduleDir = modDir
 		}
 
-		moduleDirs[moduleDir] = true
+		if _, ok := seen[moduleDir]; !ok {
+			seen[moduleDir] = struct{}{}
+			moduleDirs = append(moduleDirs, moduleDir)
+		}
 	}
 
+	slices.Sort(moduleDirs)
 	return moduleDirs, nil
 }

--- a/tool/internal/pkgload/pkgload_test.go
+++ b/tool/internal/pkgload/pkgload_test.go
@@ -6,6 +6,7 @@ package pkgload
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -391,19 +392,12 @@ func TestFindModuleDirs(t *testing.T) {
 	tests := []struct {
 		name    string
 		pkgs    []*packages.Package
-		want    map[string]bool
+		want    []string
 		wantErr bool
 	}{
 		{
-			name: "collects module dirs",
+			name: "collects module dirs in sorted order",
 			pkgs: []*packages.Package{
-				{
-					PkgPath: "example.com/a",
-					GoFiles: []string{"/tmp/moda/a.go"},
-					Module: &packages.Module{
-						Dir: "/tmp/moda",
-					},
-				},
 				{
 					PkgPath: "example.com/b",
 					GoFiles: []string{"/tmp/modb/b.go"},
@@ -411,14 +405,21 @@ func TestFindModuleDirs(t *testing.T) {
 						Dir: "/tmp/modb",
 					},
 				},
+				{
+					PkgPath: "example.com/a",
+					GoFiles: []string{"/tmp/moda/a.go"},
+					Module: &packages.Module{
+						Dir: "/tmp/moda",
+					},
+				},
 			},
-			want: map[string]bool{
-				"/tmp/moda": true,
-				"/tmp/modb": true,
+			want: []string{
+				"/tmp/moda",
+				"/tmp/modb",
 			},
 		},
 		{
-			name: "deduplicates module dirs",
+			name: "deduplicates module dirs across multiple packages",
 			pkgs: []*packages.Package{
 				{
 					PkgPath: "example.com/a",
@@ -434,9 +435,16 @@ func TestFindModuleDirs(t *testing.T) {
 						Dir: "/tmp/mod",
 					},
 				},
+				{
+					PkgPath: "example.com/c",
+					GoFiles: []string{"/tmp/mod/c.go"},
+					Module: &packages.Module{
+						Dir: "/tmp/mod",
+					},
+				},
 			},
-			want: map[string]bool{
-				"/tmp/mod": true,
+			want: []string{
+				"/tmp/mod",
 			},
 		},
 		{
@@ -447,7 +455,7 @@ func TestFindModuleDirs(t *testing.T) {
 					GoFiles: []string{"/tmp/a.go"},
 				},
 			},
-			want: map[string]bool{},
+			want: []string{},
 		},
 		{
 			name: "skips package with module but no go files",
@@ -459,7 +467,7 @@ func TestFindModuleDirs(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]bool{},
+			want: []string{},
 		},
 		{
 			name: "skips command line package without go files",
@@ -468,7 +476,7 @@ func TestFindModuleDirs(t *testing.T) {
 					PkgPath: CommandLineArgumentsPackage,
 				},
 			},
-			want: map[string]bool{},
+			want: []string{},
 		},
 		{
 			name: "resolves module dir for command line package",
@@ -478,8 +486,8 @@ func TestFindModuleDirs(t *testing.T) {
 					GoFiles: []string{mainFile},
 				},
 			},
-			want: map[string]bool{
-				tmp: true,
+			want: []string{
+				tmp,
 			},
 		},
 		{
@@ -500,11 +508,14 @@ func TestFindModuleDirs(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
+				assert.Nil(t, got, "must return no partial result on error")
 				return
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
+			assert.NotNil(t, got, "empty result must be non-nil")
+			assert.Equal(t, tt.want, got)
+			assert.True(t, slices.IsSorted(got), "output must be sorted")
 		})
 	}
 }

--- a/tool/internal/setup/config.go
+++ b/tool/internal/setup/config.go
@@ -61,9 +61,9 @@ func findToolFile(moduleDir string) (string, error) {
 	}
 }
 
-func findToolFiles(moduleDirs map[string]bool) ([]string, error) {
+func findToolFiles(moduleDirs []string) ([]string, error) {
 	toolFiles := make([]string, 0, len(moduleDirs))
-	for dir := range moduleDirs {
+	for _, dir := range moduleDirs {
 		toolFile, err := findToolFile(dir)
 		if err != nil {
 			return nil, err
@@ -72,9 +72,9 @@ func findToolFiles(moduleDirs map[string]bool) ([]string, error) {
 			toolFiles = append(toolFiles, toolFile)
 		}
 	}
-	// Sort for deterministic rule loading.
+	// Sort and compact for deterministic, deduplicated rule loading.
 	slices.Sort(toolFiles)
-	return toolFiles, nil
+	return slices.Compact(toolFiles), nil
 }
 
 const packagesLoadTimeout = 30 * time.Second

--- a/tool/internal/setup/config_test.go
+++ b/tool/internal/setup/config_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/dave/dst"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -86,6 +87,46 @@ func TestFindToolFile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFindToolFiles(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	dirC := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dirA, toolFileCanonical), nil, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dirB, toolFileAlias), nil, 0o644))
+	// dirC has no tool file
+
+	expectedA := filepath.Join(dirA, toolFileCanonical)
+	expectedB := filepath.Join(dirB, toolFileAlias)
+	wantSorted := []string{expectedA, expectedB}
+	slices.Sort(wantSorted)
+
+	t.Run("empty moduleDirs returns empty slice", func(t *testing.T) {
+		got, err := findToolFiles([]string{})
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("collects, deduplicates, and sorts tool files", func(t *testing.T) {
+		input := []string{dirC, dirB, dirA, dirB, dirA}
+		inputOrig := append([]string(nil), input...)
+
+		got, err := findToolFiles(input)
+		require.NoError(t, err)
+		assert.Equal(t, wantSorted, got)
+		assert.Equal(t, inputOrig, input, "input slice must not be mutated")
+	})
+
+	t.Run("propagates error on conflicting tool files", func(t *testing.T) {
+		errDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(errDir, toolFileCanonical), nil, 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(errDir, toolFileAlias), nil, 0o644))
+
+		_, err := findToolFiles([]string{dirA, errDir})
+		require.Error(t, err)
+	})
 }
 
 func TestResolveInstrumentationConfig(t *testing.T) {
@@ -816,7 +857,7 @@ func TestFindToolFilesBothExist(t *testing.T) {
 	err = os.WriteFile(filepath.Join(dir, toolFileAlias), []byte("package main"), 0o644)
 	require.NoError(t, err)
 
-	_, err = findToolFiles(map[string]bool{dir: true})
+	_, err = findToolFiles([]string{dir})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "only one instrumentation config file")
 }

--- a/tool/internal/setup/match.go
+++ b/tool/internal/setup/match.go
@@ -474,7 +474,7 @@ func loadRulesFromToolFiles(
 	return ruleSet, nil
 }
 
-func (sp *setupPhase) loadRules(ctx context.Context, moduleDirs map[string]bool) ([]rule.InstRule, error) {
+func (sp *setupPhase) loadRules(ctx context.Context, moduleDirs []string) ([]rule.InstRule, error) {
 	// Load rules from environment variable OTELC_RULES if specified. It has the
 	// highest priority.
 	rulePath := os.Getenv(util.EnvOtelcRules)
@@ -507,7 +507,7 @@ func (sp *setupPhase) loadRules(ctx context.Context, moduleDirs map[string]bool)
 func (sp *setupPhase) matchDeps(
 	ctx context.Context,
 	deps []*Dependency,
-	moduleDirs map[string]bool,
+	moduleDirs []string,
 ) ([]*rule.InstRuleSet, error) {
 	// Construct the set of default allRules by parsing embedded data
 	allRules, err := sp.loadRules(ctx, moduleDirs)

--- a/tool/internal/setup/match_test.go
+++ b/tool/internal/setup/match_test.go
@@ -689,7 +689,7 @@ func TestLoadDefaultRules(t *testing.T) {
 		"example.com/foo": filepath.Join(tmp, "foo"),
 	})
 	writeInstrumentationModule(t, filepath.Join(tmp, "foo"), "example.com/foo", true, nil)
-	moduleDirs := map[string]bool{tmp: true}
+	moduleDirs := []string{tmp}
 
 	// Prepare setup phase and set custom rules via environment variable and flag
 	sp := newTestSetupPhase()
@@ -1980,6 +1980,14 @@ func TestLoadRules_FindToolFilesError(t *testing.T) {
 	require.NoError(t, err)
 
 	sp := newTestSetupPhase()
-	_, err = sp.loadRules(context.Background(), map[string]bool{dir: true})
+	_, err = sp.loadRules(context.Background(), []string{dir})
 	require.Error(t, err)
+}
+
+func TestLoadRules_EmptyModuleDirs(t *testing.T) {
+	t.Setenv(util.EnvOtelcRules, "")
+	sp := newTestSetupPhase()
+	rules, err := sp.loadRules(t.Context(), []string{})
+	require.NoError(t, err)
+	assert.Nil(t, rules)
 }

--- a/tool/internal/setup/pin.go
+++ b/tool/internal/setup/pin.go
@@ -11,7 +11,6 @@ import (
 	"go/token"
 	"io/fs"
 	"log/slog"
-	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -534,7 +533,7 @@ func updatePinnedProjects(
 	return &PinResult{}, nil
 }
 
-func generatePinnedProjects(ctx context.Context, moduleDirs map[string]bool, opts PinOptions) (*PinResult, error) {
+func generatePinnedProjects(ctx context.Context, moduleDirs []string, opts PinOptions) (*PinResult, error) {
 	logger := util.LoggerFromContext(ctx)
 	subcommand := opts.Subcommand
 	if subcommand == "" {
@@ -582,8 +581,7 @@ func generatePinnedProjects(ctx context.Context, moduleDirs map[string]bool, opt
 
 	// Generate otel.instrumentation.go file with imports for all matched rules.
 	f := generateOtelInstrumentationGo(imports, opts)
-	dirs := slices.Sorted(maps.Keys(moduleDirs))
-	for _, moduleDir := range dirs {
+	for _, moduleDir := range moduleDirs {
 		path := filepath.Join(moduleDir, toolFileCanonical)
 		if writeErr := ast.WriteFileAtomic(path, f); writeErr != nil {
 			return nil, ex.Wrapf(writeErr, "writing %s", path)
@@ -620,6 +618,17 @@ func prepareVendoredBuild(ctx context.Context, logger *slog.Logger, args []strin
 	return rewriteModVendor(args), nil
 }
 
+// normalizeModuleDirs returns a cloned, sorted, and deduplicated copy of dirs.
+// If dirs is empty, it returns an empty non-nil slice. The caller's slice is never mutated.
+func normalizeModuleDirs(dirs []string) []string {
+	if len(dirs) == 0 {
+		return []string{}
+	}
+	res := slices.Clone(dirs)
+	slices.Sort(res)
+	return slices.Compact(res)
+}
+
 type PinOptions struct {
 	// Whether to prune invalid imports within otel.instrumentation.go
 	Prune bool
@@ -633,7 +642,7 @@ type PinOptions struct {
 	Subcommand string
 	// ModuleDirs is the set of module directories to search for tool files
 	// If empty, module directories will be found using opts.Args
-	ModuleDirs map[string]bool
+	ModuleDirs []string
 }
 
 type PinResult struct {
@@ -658,7 +667,7 @@ func Pin(ctx context.Context, opts PinOptions) (*PinResult, error) {
 }
 
 func pinLocked(ctx context.Context, opts PinOptions) (*PinResult, error) {
-	moduleDirs := opts.ModuleDirs
+	moduleDirs := normalizeModuleDirs(opts.ModuleDirs)
 	// moduleDirs being empty means Pin was invoked as a standalone command
 	// (not as part of a setup run), so use opts.Args to find module directories.
 	if len(moduleDirs) == 0 {
@@ -700,7 +709,7 @@ func pinLocked(ctx context.Context, opts PinOptions) (*PinResult, error) {
 
 // autoPin is a convenience function that automatically tracks generated/modified files before calling Pin
 // in order to restore them after the build completes.
-func autoPin(ctx context.Context, moduleDirs map[string]bool, subcommand string, args []string) (*PinResult, error) {
+func autoPin(ctx context.Context, moduleDirs []string, subcommand string, args []string) (*PinResult, error) {
 	stateManager, found := stateManagerFromContext(ctx)
 	if !found {
 		return nil, ex.New("state manager not found in context")

--- a/tool/internal/setup/pin_test.go
+++ b/tool/internal/setup/pin_test.go
@@ -1100,7 +1100,7 @@ func main() {
 
 	result, err := generatePinnedProjects(
 		t.Context(),
-		map[string]bool{dir: true},
+		[]string{dir},
 		PinOptions{},
 	)
 	require.NoError(t, err)
@@ -1200,13 +1200,77 @@ func TestPinLocked_UpdatesExistingToolFile(t *testing.T) {
 
 	_, err := pinLocked(t.Context(), PinOptions{
 		Prune:      true,
-		ModuleDirs: map[string]bool{tmp: true},
+		ModuleDirs: []string{tmp},
 	})
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(toolFile)
 	require.NoError(t, err)
 	assert.NotContains(t, string(data), "example.com/notinstrumentation")
+}
+
+func TestPinLocked_UnsortedDuplicateModuleDirs(t *testing.T) {
+	// Assert that unsorted, duplicate PinOptions.ModuleDirs are normalized
+	// so each module is processed exactly once, and the caller's slice is not mutated.
+	tmp := t.TempDir()
+
+	notInstDirA := filepath.Join(tmp, "notiA")
+	writeInstrumentationModule(
+		t,
+		notInstDirA,
+		"example.com/notiA",
+		false,
+		nil,
+	)
+
+	notInstDirB := filepath.Join(tmp, "notiB")
+	writeInstrumentationModule(
+		t,
+		notInstDirB,
+		"example.com/notiB",
+		false,
+		nil,
+	)
+
+	modA := filepath.Join(tmp, "modA")
+	modB := filepath.Join(tmp, "modB")
+
+	toolFileA := writeInstrumentationModule(t, modA, "example.com/modA", false, map[string]string{
+		"example.com/notiA": notInstDirA,
+	})
+	toolFileB := writeInstrumentationModule(t, modB, "example.com/modB", false, map[string]string{
+		"example.com/notiB": notInstDirB,
+	})
+
+	var logOutput strings.Builder
+	logger := slog.New(slog.NewTextHandler(&logOutput, nil))
+	ctx := util.ContextWithLogger(t.Context(), logger)
+
+	callerDirs := []string{modB, modA, modB, modA}
+	callerOrig := append([]string(nil), callerDirs...)
+
+	result, err := pinLocked(ctx, PinOptions{
+		Prune:      true,
+		ModuleDirs: callerDirs,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Caller slice must remain unchanged
+	assert.Equal(t, callerOrig, callerDirs, "caller slice must not be mutated")
+
+	// Both tool files must be updated and uninstrumented imports pruned
+	dataA, err := os.ReadFile(toolFileA)
+	require.NoError(t, err)
+	assert.NotContains(t, string(dataA), "example.com/notiA")
+
+	dataB, err := os.ReadFile(toolFileB)
+	require.NoError(t, err)
+	assert.NotContains(t, string(dataB), "example.com/notiB")
+
+	// Each module should have been processed exactly once
+	assert.Equal(t, 1, strings.Count(logOutput.String(), toolFileA), "modA should be processed exactly once")
+	assert.Equal(t, 1, strings.Count(logOutput.String(), toolFileB), "modB should be processed exactly once")
 }
 
 func TestPinLocked_DiscoversModuleDirs(t *testing.T) {
@@ -1255,7 +1319,7 @@ func TestPin_UpdatesExistingToolFile(t *testing.T) {
 
 	result, err := Pin(t.Context(), PinOptions{
 		Prune:      true,
-		ModuleDirs: map[string]bool{tmp: true},
+		ModuleDirs: []string{tmp},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -1267,7 +1331,7 @@ func TestPin_UpdatesExistingToolFile(t *testing.T) {
 
 func TestAutoPin_NoStateManager(t *testing.T) {
 	// autoPin cannot track files to restore without a stateManager in context.
-	_, err := autoPin(t.Context(), map[string]bool{t.TempDir(): true}, subcmdBuild, nil)
+	_, err := autoPin(t.Context(), []string{t.TempDir()}, subcmdBuild, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "state manager not found")
 }
@@ -1293,7 +1357,7 @@ func TestAutoPin_TracksAndPins(t *testing.T) {
 	sm := newStateManager()
 	ctx := contextWithStateManager(t.Context(), sm)
 
-	_, err := autoPin(ctx, map[string]bool{tmp: true}, subcmdBuild, nil)
+	_, err := autoPin(ctx, []string{tmp}, subcmdBuild, nil)
 	require.NoError(t, err)
 
 	// getBackupFiles tracks go.mod, go.sum, and the tool file together for
@@ -1359,7 +1423,7 @@ func TestAutoPin_TrackAllError(t *testing.T) {
 	sm := newStateManager()
 	ctx := contextWithStateManager(t.Context(), sm)
 
-	_, err := autoPin(ctx, map[string]bool{modDir: true}, "build", []string{"."})
+	_, err := autoPin(ctx, []string{modDir}, "build", []string{"."})
 	require.Error(t, err)
 }
 
@@ -1390,7 +1454,7 @@ func TestAutoPin_GetBackupFilesError(t *testing.T) {
 	sm := newStateManager()
 	ctx = contextWithStateManager(ctx, sm)
 
-	_, err := autoPin(ctx, map[string]bool{"/some/dir": true}, "build", []string{"."})
+	_, err := autoPin(ctx, []string{"/some/dir"}, "build", []string{"."})
 	require.Error(t, err)
 }
 
@@ -1398,7 +1462,7 @@ func TestGeneratePinnedProjects_FindDepsError(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // canceled context causes findDeps to fail
 
-	_, err := generatePinnedProjects(ctx, map[string]bool{"/some/dir": true}, PinOptions{})
+	_, err := generatePinnedProjects(ctx, []string{"/some/dir"}, PinOptions{})
 	require.Error(t, err)
 }
 
@@ -1424,7 +1488,7 @@ func TestGeneratePinnedProjects_LoadMinimalRulesError(t *testing.T) {
 	require.NoError(t, os.MkdirAll(instDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(instDir, "go.mod"), []byte("invalid go.mod"), 0o644))
 
-	_, err := generatePinnedProjects(t.Context(), map[string]bool{tempDir: true}, PinOptions{})
+	_, err := generatePinnedProjects(t.Context(), []string{tempDir}, PinOptions{})
 	require.Error(t, err)
 }
 
@@ -1450,7 +1514,7 @@ require (
 	ruleFile := filepath.Join(util.GetBuildTempDir(), unzippedInstDir, "net", "http", "client", "rules.yaml")
 	require.NoError(t, os.WriteFile(ruleFile, []byte("rule1:\n  target: net/http\n  func: Get\n"), 0o644))
 
-	_, err := generatePinnedProjects(t.Context(), map[string]bool{tempDir: true}, PinOptions{
+	_, err := generatePinnedProjects(t.Context(), []string{tempDir}, PinOptions{
 		Args: []string{"."},
 	})
 	require.Error(t, err)
@@ -1476,7 +1540,7 @@ go 1.21
 	// Corrupt go.mod so ensureOtelcRequire fails in generatePinnedProjects (line 563)
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte("invalid go.mod {"), 0o644))
 
-	_, err := generatePinnedProjects(t.Context(), map[string]bool{tempDir: true}, PinOptions{})
+	_, err := generatePinnedProjects(t.Context(), []string{tempDir}, PinOptions{})
 	require.Error(t, err)
 }
 
@@ -1494,7 +1558,7 @@ func TestGeneratePinnedProjects_ExtractBundleError(t *testing.T) {
 	pkgPath := filepath.Join(buildTemp, unzippedPkgDir)
 	require.NoError(t, os.WriteFile(pkgPath, []byte("file"), 0o644))
 
-	_, err := generatePinnedProjects(t.Context(), map[string]bool{tempDir: true}, PinOptions{
+	_, err := generatePinnedProjects(t.Context(), []string{tempDir}, PinOptions{
 		Args: []string{"."},
 	})
 	require.Error(t, err)
@@ -1508,4 +1572,25 @@ func TestUpdateToolFile_RemoveImportsError(t *testing.T) {
 
 	err := updateToolFile(t.Context(), toolFile, map[string]bool{"foo": true}, PinOptions{})
 	require.Error(t, err)
+}
+
+func TestNormalizeModuleDirs(t *testing.T) {
+	t.Run("empty slice returns empty non-nil slice", func(t *testing.T) {
+		got := normalizeModuleDirs(nil)
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+
+		got = normalizeModuleDirs([]string{})
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("sorts and compacts without mutating caller slice", func(t *testing.T) {
+		dirs := []string{"/dir/c", "/dir/a", "/dir/b", "/dir/a", "/dir/c"}
+		dirsOrig := append([]string(nil), dirs...)
+
+		got := normalizeModuleDirs(dirs)
+		assert.Equal(t, []string{"/dir/a", "/dir/b", "/dir/c"}, got)
+		assert.Equal(t, dirsOrig, dirs, "caller slice must not be mutated")
+	})
 }

--- a/tool/internal/setup/state.go
+++ b/tool/internal/setup/state.go
@@ -8,11 +8,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 
@@ -97,10 +95,10 @@ func stateManagerFromContext(ctx context.Context) (*stateManager, bool) {
 	return s, true
 }
 
-func getBackupFiles(ctx context.Context, moduleDirs map[string]bool) ([]string, error) {
+func getBackupFiles(ctx context.Context, moduleDirs []string) ([]string, error) {
 	var files []string
 
-	dirs := slices.Sorted(maps.Keys(moduleDirs))
+	dirs := normalizeModuleDirs(moduleDirs)
 	// Find all go.mod, go.sum, and tool files
 	for _, moduleDir := range dirs {
 		goModFile := filepath.Join(moduleDir, goModFileName)

--- a/tool/internal/setup/state_test.go
+++ b/tool/internal/setup/state_test.go
@@ -218,8 +218,8 @@ func TestGetBackupFiles(t *testing.T) {
 
 			moduleDir := tt.setup(t, tmp)
 
-			files, err := getBackupFiles(t.Context(), map[string]bool{
-				moduleDir: true,
+			files, err := getBackupFiles(t.Context(), []string{
+				moduleDir,
 			})
 
 			require.NoError(t, err)
@@ -472,11 +472,13 @@ func TestGetBackupFiles_DeterministicOrder(t *testing.T) {
 	mustWriteFile(t, filepath.Join(modB, "go.mod"), "module dirB")
 	mustWriteFile(t, filepath.Join(modC, "go.mod"), "module dirC")
 
-	moduleDirs := map[string]bool{
-		modC: true,
-		modA: true,
-		modB: true,
+	moduleDirs := []string{
+		modC,
+		modA,
+		modB,
+		modA, // duplicate to verify deduplication
 	}
+	callerOrig := append([]string(nil), moduleDirs...)
 
 	var firstResult []string
 	for range 20 {
@@ -485,10 +487,17 @@ func TestGetBackupFiles_DeterministicOrder(t *testing.T) {
 
 		if firstResult == nil {
 			firstResult = files
+			// Assert that files contains no duplicates
+			seenFiles := make(map[string]bool)
+			for _, f := range files {
+				assert.False(t, seenFiles[f], "duplicate backup file: %s", f)
+				seenFiles[f] = true
+			}
 		} else {
 			assert.Equal(t, firstResult, files, "getBackupFiles output must be deterministic across multiple calls")
 		}
 	}
+	assert.Equal(t, callerOrig, moduleDirs, "caller slice must not be mutated")
 }
 
 func TestStateManagerDiscard(t *testing.T) {

--- a/tool/internal/setup/store.go
+++ b/tool/internal/setup/store.go
@@ -6,7 +6,6 @@ package setup
 import (
 	"context"
 	"encoding/json"
-	"maps"
 	"slices"
 
 	"go.opentelemetry.io/otelc/tool/ex"
@@ -17,8 +16,8 @@ import (
 
 // resolveRulePaths resolves the import paths referenced by function and file rules
 // to absolute filesystem paths.
-func resolveRulePaths(ctx context.Context, matched []*rule.InstRuleSet, moduleDirs map[string]bool) error {
-	dirs := slices.Sorted(maps.Keys(moduleDirs))
+func resolveRulePaths(ctx context.Context, matched []*rule.InstRuleSet, moduleDirs []string) error {
+	dirs := normalizeModuleDirs(moduleDirs)
 
 	var pending []string
 	for _, ruleset := range matched {
@@ -100,7 +99,7 @@ func resolveRulePaths(ctx context.Context, matched []*rule.InstRuleSet, moduleDi
 
 // store stores the matched rules to the file
 // It's the pair of the InstrumentPhase.load
-func (sp *setupPhase) store(ctx context.Context, matched []*rule.InstRuleSet, moduleDirs map[string]bool) error {
+func (sp *setupPhase) store(ctx context.Context, matched []*rule.InstRuleSet, moduleDirs []string) error {
 	if err := resolveRulePaths(ctx, matched, moduleDirs); err != nil {
 		return ex.Wrapf(err, "resolving rule paths")
 	}

--- a/tool/internal/setup/store_test.go
+++ b/tool/internal/setup/store_test.go
@@ -25,7 +25,7 @@ func TestSetupPhaseStore(t *testing.T) {
 
 	// An empty rule set resolves no paths and writes an empty JSON array to the
 	// matched-rule file.
-	err := sp.store(context.Background(), []*rule.InstRuleSet{}, map[string]bool{})
+	err := sp.store(context.Background(), []*rule.InstRuleSet{}, []string{})
 	require.NoError(t, err)
 
 	matchedFile := util.GetMatchedRuleFile()
@@ -43,7 +43,7 @@ func TestSetupPhaseStoreCreateError(t *testing.T) {
 	t.Setenv(util.EnvOtelcWorkDir, workDir)
 
 	sp := newTestSetupPhase()
-	err := sp.store(context.Background(), []*rule.InstRuleSet{}, map[string]bool{})
+	err := sp.store(context.Background(), []*rule.InstRuleSet{}, []string{})
 	require.Error(t, err)
 }
 
@@ -78,7 +78,7 @@ func TestResolveRulePaths(t *testing.T) {
 	err := resolveRulePaths(
 		t.Context(),
 		[]*rule.InstRuleSet{rs},
-		map[string]bool{dir: true},
+		[]string{dir},
 	)
 	require.NoError(t, err)
 
@@ -115,7 +115,7 @@ func TestResolveRulePaths_MultipleDistinctPaths(t *testing.T) {
 	err := resolveRulePaths(
 		t.Context(),
 		[]*rule.InstRuleSet{rs},
-		map[string]bool{dir: true},
+		[]string{dir},
 	)
 	require.NoError(t, err)
 
@@ -143,7 +143,7 @@ func TestResolveRulePaths_LoadError(t *testing.T) {
 	err := resolveRulePaths(
 		t.Context(),
 		[]*rule.InstRuleSet{rs},
-		map[string]bool{missingDir: true},
+		[]string{missingDir},
 	)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to resolve import path")
@@ -169,9 +169,47 @@ func TestResolveRulePaths_NotFound(t *testing.T) {
 	err := resolveRulePaths(
 		t.Context(),
 		[]*rule.InstRuleSet{rs},
-		map[string]bool{dir: true},
+		[]string{dir},
 	)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to resolve import path")
+}
+
+func TestResolveRulePaths_DuplicateAndUnsortedModuleDirs(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/test\n\ngo 1.25\n"),
+		0o644,
+	))
+
+	hooksDir := filepath.Join(dir, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(hooksDir, "hook.go"),
+		[]byte("package hooks\n"),
+		0o644,
+	))
+
+	rs := &rule.InstRuleSet{
+		FuncRules: map[string][]*rule.InstFuncRule{
+			"foo": {{
+				Path: "example.com/test/hooks",
+			}},
+		},
+	}
+
+	callerDirs := []string{dir, dir}
+	callerOrig := append([]string(nil), callerDirs...)
+
+	err := resolveRulePaths(
+		t.Context(),
+		[]*rule.InstRuleSet{rs},
+		callerDirs,
+	)
+	require.NoError(t, err)
+	require.Equal(t, hooksDir, rs.AllFuncRules()[0].ResolvedPath)
+	assert.Equal(t, callerOrig, callerDirs, "caller slice must not be mutated")
 }


### PR DESCRIPTION
## Description

Switches module directory handling from `map[string]bool` to `[]string` across `pkgload` and `setup`. `FindModuleDirs` now returns sorted, deduplicated slices, and setup functions take `[]string` directly to eliminate redundant map-to-slice conversions.

## Motivation

Follow-up from PR #1262 review discussion:
https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pull/1262#discussion_r3900479846


