### PR TITLE
test(e2e): increase whole-suite timeout to 30m in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -745,14 +745,17 @@ test-e2e: ## Run e2e tests
 test-e2e: build build-demo
 	@echo "Running e2e tests..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags e2e ./e2e/... 2>&1 | tee ./gotest-e2e.log
+	# 30m: multi-process e2e tests build demo binaries and spin up Kafka, database, and Docker
+	# containers; aggregate wall time regularly exceeds 10m on slower CI runners.
+	go -C "test" test -json -v -shuffle=on -timeout=30m -count=1 -tags e2e ./e2e/... 2>&1 | tee ./gotest-e2e.log
 
 .ONESHELL:
 test-e2e/coverage: ## Run e2e tests with coverage report
 test-e2e/coverage: build build-demo
 	@echo "Running e2e tests with coverage report..."
 	set -euo pipefail
-	go -C "test" test -json -v -shuffle=on -timeout=10m -count=1 -tags e2e ./e2e/... -coverprofile=../coverage-e2e.txt -covermode=atomic 2>&1 | tee ./gotest-e2e.log
+	# See test-e2e: same container and binary-build overhead applies under coverage.
+	go -C "test" test -json -v -shuffle=on -timeout=30m -count=1 -tags e2e ./e2e/... -coverprofile=../coverage-e2e.txt -covermode=atomic 2>&1 | tee ./gotest-e2e.log
 
 .PHONY: crosslink
 crosslink: $(CROSSLINK) ## Update intra-repository dependencies in all go modules


### PR DESCRIPTION
## Description

Increases the `-timeout` flag for `test-e2e` and `test-e2e/coverage` in `Makefile` from `10m` to `30m`.

## Motivation

As reported in #1352, `go test -timeout` enforces an aggregate budget across the entire package rather than per test. The e2e suite comprises multi-process integration tests that build demo binaries, pull images, and spin up Kafka and database containers. On slower CI virtualized runners, this aggregate workload frequently exceeds 10 minutes and panics with `panic: test timed out after 10m0s`, misattributing the failure to whichever test the random shuffle happened to schedule last.

Because `-timeout` enforces a hard runtime deadline for the entire test binary, individual per-test timeouts cannot prevent this package-level panic when the aggregate duration exceeds the budget. Raising the timeout to `30m` gives adequate headroom for container initialization and image pulls (matching the pattern used for `test-integration` with its 40m budget) and resolves intermittent CI failures across open PRs.

Fixes #1352
