### PR TITLE
chore(ci): read the Go version from go.mod in check-makefile

### DIFF
--- a/.github/workflows/check-makefile.yaml
+++ b/.github/workflows/check-makefile.yaml
@@ -30,6 +30,6 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - run: mkdir -p .bin && cd .tools && go build -o ../.bin/checkmake github.com/checkmake/checkmake/cmd/checkmake
       - run: .bin/checkmake --config .tools/checkmake Makefile


### PR DESCRIPTION
The workflow pinned setup-go to a floating "1.25" while every other Go workflow resolves the version from go.mod. Because .github is excluded from Renovate, that copy never moves on its own, so a go.mod bump to a new minor would leave this job silently building checkmake on the old toolchain.
